### PR TITLE
Add CMake build script + few fixes of incorrect printf() usage in two files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,17 @@
 *.exe
 *.o
 dro2vgm
+raw2vgm
+imf2vgm
 optdac
+opl_23
 optvgm32
 optvgmrf
 vgm2txt
 vgm_cmp
 vgm_cnt
 vgm_dbc
+vgm_dso
 vgm_facc
 vgm_mono
 vgm_ndlz
@@ -17,6 +21,7 @@ vgm_sptd
 vgm_spts
 vgm_sro
 vgm_tag
+vgm_tt
 vgm_trim
 vgm_vol
 vgmlpfnd
@@ -28,3 +33,5 @@ vc6/Release
 vc6/*.plg
 vc6/*.opt
 vc6/*.ncb
+build/
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,196 @@
+#############################
+#
+# VGM Tools CMake build file
+#
+#############################
+
+cmake_minimum_required (VERSION 3.2)
+project (VGMTools LANGUAGES C CXX)
+
+find_package(ZLIB REQUIRED)
+
+
+add_executable(dro2vgm
+    dro2vgm.c
+)
+
+
+add_executable(imf2vgm
+    imf2vgm.c
+)
+
+
+add_executable(opl_23
+    opl_23.c
+)
+target_link_libraries(opl_23 ${ZLIB_LIBRARIES})
+
+
+add_executable(optvgmrf
+    optvgmrf.c
+)
+target_link_libraries(optvgmrf ${ZLIB_LIBRARIES})
+
+
+add_executable(raw2vgm
+    raw2vgm.c
+)
+
+
+add_executable(vgm2txt
+    vgm2txt.c
+    chiptext.c
+)
+target_link_libraries(vgm2txt ${ZLIB_LIBRARIES})
+if(NOT MSVC)
+    target_link_libraries(vgm2txt -lm)
+endif()
+
+
+add_executable(vgm_cmp
+    vgm_cmp.c
+    chip_cmp.c
+)
+target_link_libraries(vgm_cmp ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_cnt
+    vgm_cnt.c
+)
+target_link_libraries(vgm_cnt ${ZLIB_LIBRARIES})
+if(NOT MSVC)
+    target_link_libraries(vgm_cnt -lm)
+endif()
+
+
+add_executable(vgm_dbc
+    vgm_dbc.c
+)
+target_link_libraries(vgm_dbc ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_dso
+    vgm_dso.c
+)
+target_link_libraries(vgm_dso ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_facc
+    vgm_facc.c
+)
+target_link_libraries(vgm_facc ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_mono
+    vgm_mono.c
+)
+target_link_libraries(vgm_mono ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_ndlz
+    vgm_ndlz.c
+)
+target_link_libraries(vgm_ndlz ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_ptch
+    vgm_ptch.c
+    chip_strp.c
+)
+target_link_libraries(vgm_ptch ${ZLIB_LIBRARIES})
+if(NOT MSVC)
+    target_link_libraries(vgm_ptch -lm)
+endif()
+
+
+add_executable(vgm_smp1
+    vgm_smp1.c
+)
+target_link_libraries(vgm_smp1 ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_sptd
+    vgm_sptd.c
+    vgm_trml.c
+)
+target_link_libraries(vgm_sptd ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_spts
+    vgm_spts.c
+    vgm_trml.c
+)
+target_link_libraries(vgm_spts ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_sro
+    vgm_sro.c
+    chip_srom.c
+)
+target_link_libraries(vgm_sro ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_stat
+    vgm_stat.c
+)
+target_link_libraries(vgm_stat ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_tag
+    vgm_tag.c
+)
+target_link_libraries(vgm_tag ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_trim
+    vgm_trim.c
+    vgm_trml.c
+)
+target_link_libraries(vgm_trim ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_tt
+    vgm_tt.cpp
+)
+target_link_libraries(vgm_tt ${ZLIB_LIBRARIES})
+
+
+add_executable(vgm_vol
+    vgm_vol.c
+)
+if(NOT MSVC)
+    target_link_libraries(vgm_vol -lm)
+endif()
+
+
+add_executable(vgmlpfnd
+    vgmlpfnd.c
+)
+target_link_libraries(vgmlpfnd ${ZLIB_LIBRARIES})
+
+
+add_executable(vgmmerge
+    vgmmerge.c
+)
+target_link_libraries(vgmmerge ${ZLIB_LIBRARIES})
+
+
+# extra tools not compiled by default, because they are
+# either in beta state or not of use/shouldn't be used without special knowledge
+add_executable(opt_oki EXCLUDE_FROM_ALL
+    opt_oki.c
+)
+target_link_libraries(opt_oki ${ZLIB_LIBRARIES})
+
+
+add_executable(optdac EXCLUDE_FROM_ALL
+    optdac.c
+)
+target_link_libraries(optdac ${ZLIB_LIBRARIES})
+
+
+add_executable(optvgm32 EXCLUDE_FROM_ALL
+    optvgm32.c
+)
+target_link_libraries(optvgm32 ${ZLIB_LIBRARIES})
+

--- a/chiptext.c
+++ b/chiptext.c
@@ -1014,7 +1014,7 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 			sprintf(WriteStr, "%s, Enable Timer: %c%c, Timer IRQ Enable: %c%c, Reset Timer Status: %c%c",
 					WriteStr,
 					(Data & 0x01) ? 'A' : '-', (Data & 0x02) ? 'B' : '-',
-					(Data & 0x04) ? 'A' : '-', (Data & 0x08) ? 'B' : '-', 
+					(Data & 0x04) ? 'A' : '-', (Data & 0x08) ? 'B' : '-',
 					(Data & 0x10) ? 'A' : '-', (Data & 0x20) ? 'B' : '-');
 			break;
 		case 0x18:	// LFO frequency
@@ -1857,7 +1857,7 @@ void ymf278b_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 				break;
 			case 0xF8:	// FM Mix Control
 			case 0xF9:	// PCM Mix Control
-				sprintf(WriteStr, "%S Mix L: 0x%01X = %u%%, 0x%01X = %u%%",
+				sprintf(WriteStr, "%s Mix L: 0x%01X = %u%%, 0x%01X = %u%%",
 						(Register == 0xF9) ? "PCM" : "FM",
 						(Data & 0x38) >> 3, GetLogVolPercent((Data & 0x38) >> 3, 0x02, 0xFF),
 						(Data & 0x07) >> 0, GetLogVolPercent((Data & 0x07) >> 0, 0x02, 0xFF));

--- a/opl_23.c
+++ b/opl_23.c
@@ -440,14 +440,14 @@ static void CompressVGMData(void)
 						break;
 					case 0xC0:
 						if (TempByt == OPL2ChipMap[0x00] && (VGMPnt[0x02] & OPL3_RIGHT))
-							printf("Warning! Stereo mismatch at 0x%06!\n", VGMPos);
+							printf("Warning! Stereo mismatch at 0x%06X!\n", VGMPos);
 						else if (TempByt == OPL2ChipMap[0x01] && (VGMPnt[0x02] & OPL3_LEFT))
-							printf("Warning! Stereo mismatch at 0x%06!\n", VGMPos);
+							printf("Warning! Stereo mismatch at 0x%06X!\n", VGMPos);
 						break;
 					case 0xE0:
 					case 0xF0:
 						if (VGMPnt[0x02] & 0x04)
-							printf("Warning! Waveform %02 used at 0x%06!\n", VGMPnt[0x02], VGMPos);
+							printf("Warning! Waveform %02d used at 0x%06X!\n", VGMPnt[0x02], VGMPos);
 						break;
 					}
 					if (VGMPnt[0x01] < 0x20)


### PR DESCRIPTION
I have added CMake script as an alternative way to compile the project: CMake can be easily used to generate builds for a wide set of toolchains include various versions of MSVC, Xcode, Code::Blocks. CodeLite, Ninja, NMake, GNU/BSD Make, etc. Original makefile and other builds were kept.

The way to build by CMake is:
```
mkdir build
cd build
cmake ..
make -j 4
```
