### PR TITLE
Remove all junk line-end spaces

### DIFF
--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -117,7 +117,7 @@ typedef struct ymf271_slot
 {
 	UINT8 RegData[0x10];
 	UINT8 RegFirst[0x10];
-	
+
 	UINT8 PCMRegFirst[0x10];
 	UINT8 PCMRegData[0x10];
 	/*UINT8 startaddr[3];
@@ -136,7 +136,7 @@ typedef struct ymf271_chip
 {
 	YMF271_SLOT slots[48];
 	YMF271_GROUP groups[12];
-	
+
 	UINT8 ext_address[3];
 	UINT8 ext_read;
 } YMF271_DATA;
@@ -214,7 +214,7 @@ typedef struct k054539_data
 {
 	UINT8 RegData[0x230];
 	UINT8 RegFirst[0x230];
-	
+
 //	UINT8 k054539_flags;
 } K054539_DATA;
 typedef struct k051649_data
@@ -368,14 +368,14 @@ void InitAllChips(void)
 {
 	UINT8 CurChip;
 	ALL_CHIPS* TempChp;
-	
+
 	if (ChipData == NULL)
 		ChipData = (ALL_CHIPS*)malloc(ChipCount * sizeof(ALL_CHIPS));
 	for (CurChip = 0x00; CurChip < ChipCount; CurChip ++)
 	{
 		TempChp = &ChipData[CurChip];
 		memset(TempChp, 0xFF, sizeof(ALL_CHIPS));
-		
+
 		TempChp->GGSt = 0x00;
 		memset(TempChp->SegaPCM.ChnPrg, 0x00, sizeof(UINT8) * 0x10);
 		// FM ADPCM restarts notes always, so leaving them at FF works fine.
@@ -384,14 +384,14 @@ void InitAllChips(void)
 		memset(TempChp->YMZ280B.KeyOn, 0x00, sizeof(UINT8) * 0x08);
 		TempChp->C140.banking_type = 0x00;
 		memset(TempChp->QSound.KeyOn, 0x00, sizeof(UINT8) * 0x10);
-		
+
 		memset(&TempChp->OKIM6258.RegFirst[0x08], 0x00, 0x0D-0x08);
 	}
 	memset(StreamFreqs, 0xFF, sizeof(UINT32) * 0x100);
 	VGM_Loops = false;
-	
+
 	SetChipSet(0x00);
-	
+
 	return;
 }
 
@@ -402,7 +402,7 @@ void ResetAllChips(void)
 	UINT8 RegBak[0x05];
 	UINT8 ClkBak[0x05];
 	UINT8 VSUBak[0x60];
-	
+
 	for (CurChip = 0x00; CurChip < ChipCount; CurChip ++)
 	{
 		TempChp = &ChipData[CurChip];
@@ -414,16 +414,16 @@ void ResetAllChips(void)
 		//RegBak[0x04] = TempChp->YM2610.RegData[0x100];
 		memcpy(ClkBak, &TempChp->OKIM6258.RegData[0x08], 0x05);
 		memcpy(VSUBak, &TempChp->VSU.RegData[0x100], 0x60);
-		
+
 		// TODO: reset RegFist for each chip separately
 		memset(TempChp, 0xFF, sizeof(ALL_CHIPS));
-		
+
 		TempChp->GGSt = 0x00;
 		memset(TempChp->SegaPCM.ChnPrg, 0x00, sizeof(UINT8) * 0x10);
 		memset(TempChp->YMZ280B.KeyOn, 0x00, sizeof(UINT8) * 0x08);
 		TempChp->C140.banking_type = RegBak[0x03];
 		memset(TempChp->QSound.KeyOn, 0x00, sizeof(UINT8) * 0x10);
-		
+
 		TempChp->RF5C68.RegData[RF_CBANK] = RegBak[0x00];
 		TempChp->RF5C68.RegData[RF_CHN_LOOP] = RegBak[0x00];
 		TempChp->RF5C164.RegData[RF_CBANK] = RegBak[0x01];
@@ -436,9 +436,9 @@ void ResetAllChips(void)
 		memcpy(&TempChp->VSU.RegData[0x100], VSUBak, 0x60);
 	}
 	memset(StreamFreqs, 0xFF, sizeof(UINT32) * 0x100);
-	
+
 	VGM_Loops = true;
-	
+
 	return;
 }
 
@@ -446,17 +446,17 @@ void FreeAllChips(void)
 {
 	if (ChipData == NULL)
 		return;
-	
+
 	free(ChipData);
 	ChipData = NULL;
-	
+
 	return;
 }
 
 void SetChipSet(UINT8 ChipID)
 {
 	ChDat = ChipData + ChipID;
-	
+
 	return;
 }
 
@@ -464,10 +464,10 @@ bool dac_stream_control_freq(UINT8 strmID, UINT32 freq)
 {
 	if (JustTimerCmds)
 		return true;
-	
+
 	if (freq == StreamFreqs[strmID])
 		return false;
-	
+
 	StreamFreqs[strmID] = freq;
 	return true;
 }
@@ -476,7 +476,7 @@ bool GGStereo(UINT8 Data)
 {
 	if (Data == ChDat->GGSt && ! JustTimerCmds)
 		return false;
-	
+
 	ChDat->GGSt = Data;
 	return true;
 }
@@ -489,15 +489,15 @@ bool sn76496_write(UINT8 Command/*, UINT8 NextCmd*/)
 	UINT8 Data;
 	bool RetVal;
 	UINT8 NextCmd;
-	
+
 	if (JustTimerCmds)
 		return true;
-	
+
 	chip = &ChDat->SN76496;
-	
+
 	RetVal = GetNextChipCommand();
 	NextCmd = RetVal ? NxtCmdVal : 0x80;
-	
+
 	RetVal = true;
 	if (Command & 0x80)
 	{
@@ -505,7 +505,7 @@ bool sn76496_write(UINT8 Command/*, UINT8 NextCmd*/)
 		Channel = Reg >> 1;
 		Data = Command & 0x0F;
 		chip->LastReg = Reg;
-		
+
 		switch(Reg)
 		{
 		case 0:	// Tone 0: Frequency
@@ -563,7 +563,7 @@ bool sn76496_write(UINT8 Command/*, UINT8 NextCmd*/)
 		Reg = chip->LastReg;
 		Channel = Reg >> 1;
 		Data = Command & 0x7F;	// Command & 0x3F
-		
+
 		if (! (Reg & 0x10))
 		{
 			if (Data == chip->FreqLSB[Channel])
@@ -586,19 +586,19 @@ bool sn76496_write(UINT8 Command/*, UINT8 NextCmd*/)
 	//if (Channel != 0x02 || (ChDat != ChipData && !(Reg & 0x01)))
 	//if (! (Channel == 0x03 || (ChDat != ChipData && Channel == 0x02 && !(Reg & 0x01))))
 	//	RetVal = false;
-	
+
 	return RetVal;
 }
 
 bool ym2413_write(UINT8 Register, UINT8 Data)
 {
 	YM2413_DATA* chip = &ChDat->YM2413;
-	
+
 	Register &= 0x3F;
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
 	return true;
@@ -609,7 +609,7 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	YM2612_DATA* chip = &ChDat->YM2612;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	RegVal = (Port << 8) | Register;
 	switch(RegVal)
 	{
@@ -620,19 +620,19 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	// no OPN Prescaler Registers for YM2612
 	case 0x027:
 		Data &= 0xC0;	// mask out all timer-relevant bits
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
 	case 0x028:
 		Channel = Data & 0x07;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = JustTimerCmds;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -657,17 +657,17 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		case 0xA0:	// A0-A3 and A8-AB
 			if ((RegVal & 0x03) == 0x03)
 				break;
-			
+
 			if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 				return false;
-			
+
 			chip->RegFirst[RegVal] = JustTimerCmds;
 			chip->RegData[RegVal] = Data;
 			return true;
 		case 0xA4:	// A4-A7 and AC-AF - Frequence Latch
 			if ((RegVal & 0x03) == 0x03)
 				break;
-			
+
 			// FINALLY, I got it to work properly
 			// The vgm I tested (Dyna Brothers 2 - 28 - Get Crazy - More Rave.vgz) was
 			// successfully tested against the Gens and MAME cores.
@@ -706,15 +706,15 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			chip->RegData[RegVal] = Data;
 			return true;
 		}
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = JustTimerCmds;
 		chip->RegData[RegVal] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -722,7 +722,7 @@ bool ym2151_write(UINT8 Register, UINT8 Data)
 {
 	YM2151_DATA* chip = &ChDat->YM2151;
 	UINT8 Channel;
-	
+
 	switch(Register)
 	{
 	case 0x08:
@@ -730,7 +730,7 @@ bool ym2151_write(UINT8 Register, UINT8 Data)
 		Data &= 0xF8;
 		if (! chip->MCFirst[Channel] && Data == chip->MCMask[Channel])
 			return false;
-		
+
 		chip->MCFirst[Channel] = JustTimerCmds;
 		chip->MCMask[Channel] = Data;
 		break;
@@ -742,7 +742,7 @@ bool ym2151_write(UINT8 Register, UINT8 Data)
 		Data &= 0x80;
 		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 			return false;
-		
+
 		chip->RegFirst[Register] = 0x00;
 		chip->RegData[Register] = Data;
 		break;
@@ -751,19 +751,19 @@ bool ym2151_write(UINT8 Register, UINT8 Data)
 		Data &= 0x7F;
 		if (! chip->MDFirst[Channel] && Data == chip->MDMask[Channel])
 			return false;
-		
+
 		chip->MDFirst[Channel] = JustTimerCmds;
 		chip->MDMask[Channel] = Data;
 		break;
 	default:
 		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 			return false;
-		
+
 		chip->RegFirst[Register] = JustTimerCmds;
 		chip->RegData[Register] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -772,11 +772,11 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 	SEGAPCM_DATA* chip = &ChDat->SegaPCM;
 	UINT8 Channel;
 	UINT16 RelOffset;
-	
+
 	Offset &= 0x07FF;	// it has 2 KB of RAM, but only 256 Byte are used
 	Channel = (Offset >> 3) & 0xF;
 	RelOffset = Offset & ~0x78;
-	
+
 	if (RelOffset == 0x04 || RelOffset == 0x05)
 		RelOffset |= 0x80;	// patch for the old SegaPCM core
 	switch(RelOffset)
@@ -784,7 +784,7 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 	case 0x07:	// Sample Delta Time
 		if (! chip->RAMFirst[Offset] && Data == chip->RAMData[Offset])
 			return false;
-		
+
 		// if Sample Delta Time is 0x00, it's like a KeyOff
 		chip->ChnPrg[Channel] &= ~0x02;
 		chip->ChnPrg[Channel] |= Data ? 0x02 : 0x00;
@@ -796,7 +796,7 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 			chip->RAMFirst[(Channel << 3) | 0x04] |= 0x01;
 			chip->RAMFirst[(Channel << 3) | 0x05] |= 0x01;
 		}
-		
+
 		chip->RAMFirst[Offset] = JustTimerCmds;
 		chip->RAMData[Offset] = Data;
 		break;
@@ -804,7 +804,7 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 	case 0x85:	// Current Address H
 		if (! chip->RAMFirst[Offset] && Data == chip->RAMData[Offset])
 			return false;
-		
+
 		// the chip modifies the Current Address while playing,
 		// so they must be rewritten of a channel is active
 		chip->RAMFirst[Offset] = JustTimerCmds | (chip->ChnPrg[Channel] == 0x03);
@@ -813,7 +813,7 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 	case 0x86:	// Channel Disable (Bit 0), Loop Disable (Bit 1), Bank
 		if (! chip->RAMFirst[Offset] && Data == chip->RAMData[Offset])
 			return false;
-		
+
 		chip->ChnPrg[Channel] &= ~0x01;
 		chip->ChnPrg[Channel] |= (~Data & 0x01);
 		if (chip->ChnPrg[Channel] == 0x03)
@@ -824,7 +824,7 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 			chip->RAMFirst[(Channel << 3) | 0x04] |= 0x01;
 			chip->RAMFirst[(Channel << 3) | 0x05] |= 0x01;
 		}
-		
+
 		// like above, the Channel register gets modified by the chip,
 		// so the same rules apply
 		chip->RAMFirst[Offset] = JustTimerCmds | (chip->ChnPrg[Channel] == 0x03);
@@ -833,12 +833,12 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 	default:
 		if (! chip->RAMFirst[Offset] && Data == chip->RAMData[Offset])
 			return false;
-		
+
 		chip->RAMFirst[Offset] = JustTimerCmds;
 		chip->RAMData[Offset] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -846,7 +846,7 @@ static bool rf_pcm_reg_write(RF5C68_DATA* chip, UINT8 Register, UINT8 Data)
 {
 	RF5C68_CHANNEL* chan;
 	UINT8 OldVal;
-	
+
 	switch(Register)
 	{
 	case 0x00:	// Envelope
@@ -857,20 +857,20 @@ static bool rf_pcm_reg_write(RF5C68_DATA* chip, UINT8 Register, UINT8 Data)
 	case 0x05:	// Loop Start High
 	case 0x06:	// Start
 		chan = &chip->chan[chip->RegData[RF_CBANK] & 0x07];
-		
+
 		if (chip->RegFirst[RF_CHN_LOOP])
 			chip->RegFirst[RF_CHN_LOOP] = 0x00;
-		
+
 		if (Register == 0x06)
 		{
 			OldVal = chip->RegData[RF_CHN_MASK] & (0x01 << (chip->RegData[RF_CBANK] & 0x07));
 			if (! OldVal)
 				chan->RegFirst[Register] = 0x01;
 		}
-		
+
 		if (! chan->RegFirst[Register] && Data == chan->ChnReg[Register])
 			return false;
-		
+
 		chan->RegFirst[Register] = JustTimerCmds;
 		chan->ChnReg[Register] = Data;
 		break;
@@ -882,7 +882,7 @@ static bool rf_pcm_reg_write(RF5C68_DATA* chip, UINT8 Register, UINT8 Data)
 			OldVal |= chip->RegData[RF_WBANK];
 		if (! chip->RegFirst[RF_ENABLE] && Data == OldVal)
 			return false;
-		
+
 		if (/*! chip->RegFirst[RF_ENABLE] &&*/ (Data & 0x40))
 		{
 			// additional test for 2 Channel Select-Commands after each other
@@ -911,7 +911,7 @@ static bool rf_pcm_reg_write(RF5C68_DATA* chip, UINT8 Register, UINT8 Data)
 				}
 			}
 		}
-		
+
 		chip->RegFirst[RF_ENABLE] = JustTimerCmds;
 		chip->RegData[RF_ENABLE] = Data & 0x80;
 		if (Data & 0x40)
@@ -924,7 +924,7 @@ static bool rf_pcm_reg_write(RF5C68_DATA* chip, UINT8 Register, UINT8 Data)
 				chip->RegData[RF_CHN_LOOP] = 0x80;	// set to 'ignore'
 			}
 		}
-		else	
+		else
 		{
 			chip->RegData[RF_WBANK] = Data;
 		}
@@ -932,19 +932,19 @@ static bool rf_pcm_reg_write(RF5C68_DATA* chip, UINT8 Register, UINT8 Data)
 	case 0x08:	// Channel On/Off Register
 		if (! chip->RegFirst[RF_CHN_MASK] && Data == chip->RegData[RF_CHN_MASK])
 			return false;
-		
+
 		chip->RegFirst[RF_CHN_MASK] = JustTimerCmds;
 		chip->RegData[RF_CHN_MASK] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
 bool rf5c68_reg_write(UINT8 Register, UINT8 Data)
 {
 	RF5C68_DATA* chip = &ChDat->RF5C68;
-	
+
 	return rf_pcm_reg_write(chip, Register, Data);
 }
 
@@ -952,7 +952,7 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 {
 	YM2203_DATA* chip = &ChDat->YM2203;
 	UINT8 Channel;
-	
+
 	/*if ((Register & 0x1F0) == 0x000)
 		return ! (Register >= 0x0E && Register <= 0x0F);
 	else
@@ -965,10 +965,10 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 		return false;
 	case 0x27:
 		Data &= 0xC0;	// mask out all timer-relevant bits
-		
+
 		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 			return false;
-		
+
 		chip->RegFirst[Register] = 0x00;
 		chip->RegData[Register] = Data;
 		break;
@@ -981,10 +981,10 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 		break;
 	case 0x28:
 		Channel = Data & 0x03;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = JustTimerCmds;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -994,23 +994,23 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 			// SSG emulator (AY8910)
 			return ay8910_part_write(chip->RegData, chip->RegFirst, Register & 0x0F, Data);
 		}
-		
+
 		switch(Register & 0xF4)
 		{
 		case 0xA0:	// A0-A3 and A8-AB
 			if ((Register & 0x03) == 0x03)
 				break;
-			
+
 			if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 				return false;
-			
+
 			chip->RegFirst[Register] = JustTimerCmds;
 			chip->RegData[Register] = Data;
 			return true;
 		case 0xA4:	// A4-A7 and AC-AF - Frequence Latch
 			if ((Register & 0x03) == 0x03)
 				break;
-			
+
 			while(GetNextChipCommand())
 			{
 				if ((NxtCmdReg & 0xFC) == (Register & 0xFC))
@@ -1046,15 +1046,15 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 			chip->RegData[Register] = Data;
 			return true;
 		}
-		
+
 		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 			return false;
-		
+
 		chip->RegFirst[Register] = JustTimerCmds;
 		chip->RegData[Register] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1063,7 +1063,7 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	YM2608_DATA* chip = &ChDat->YM2608;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	RegVal = (Port << 8) | Register;
 	switch(RegVal)
 	{
@@ -1073,10 +1073,10 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		return false;
 	case 0x027:
 		Data &= 0xC0;	// mask out all timer-relevant bits
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
@@ -1088,19 +1088,19 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		break;
 	case 0x028:
 		Channel = Data & 0x07;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = JustTimerCmds;
 		chip->KeyOn[Channel] = Data;
 		break;
 	case 0x029:	// IRQ Mask and 3/6 ch mode
 		Data &= 0x80;	// mask out all IRQ-relevant bits
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
@@ -1125,23 +1125,23 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			else
 				return true;
 		}
-		
+
 		switch(RegVal & 0xF4)
 		{
 		case 0xA0:	// A0-A3 and A8-AB
 			if ((RegVal & 0x03) == 0x03)
 				break;
-			
+
 			if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 				return false;
-			
+
 			chip->RegFirst[RegVal] = JustTimerCmds;
 			chip->RegData[RegVal] = Data;
 			return true;
 		case 0xA4:	// A4-A7 and AC-AF - Frequence Latch
 			if ((RegVal & 0x03) == 0x03)
 				break;
-			
+
 			while(GetNextChipCommand())
 			{
 				if ((NxtCmdReg & 0x1FC) == (RegVal & 0x1FC))
@@ -1177,15 +1177,15 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			chip->RegData[RegVal] = Data;
 			return true;
 		}
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = JustTimerCmds;
 		chip->RegData[RegVal] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1194,7 +1194,7 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	YM2610_DATA* chip = &ChDat->YM2610;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	RegVal = (Port << 8) | Register;
 	switch(RegVal)
 	{
@@ -1205,19 +1205,19 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	// no OPN Prescaler Registers for YM2610
 	case 0x27:
 		Data &= 0xC0;	// mask out all timer-relevant bits
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
 	case 0x28:
 		Channel = Data & 0x07;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = JustTimerCmds;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -1244,23 +1244,23 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			return fmadpcm_write(RegVal & 0x3F, Data, &chip->RegData[0x100],
 								&chip->RegFirst[0x100]);
 		}
-		
+
 		switch(RegVal & 0xF4)
 		{
 		case 0xA0:	// A0-A3 and A8-AB
 			if ((RegVal & 0x03) == 0x03)
 				break;
-			
+
 			if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 				return false;
-			
+
 			chip->RegFirst[RegVal] = JustTimerCmds;
 			chip->RegData[RegVal] = Data;
 			return true;
 		case 0xA4:	// A4-A7 and AC-AF - Frequence Latch
 			if ((RegVal & 0x03) == 0x03)
 				break;
-			
+
 			while(GetNextChipCommand())
 			{
 				if ((NxtCmdReg & 0x1FC) == (RegVal & 0x1FC))
@@ -1296,15 +1296,15 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			chip->RegData[RegVal] = Data;
 			return true;
 		}
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = JustTimerCmds;
 		chip->RegData[RegVal] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1319,18 +1319,18 @@ bool ym3812_write(UINT8 Register, UINT8 Data)
 		return false;
 		/*if (Data & 0x80)
 			Data &= 0x80;
-		
+
 		if (! ChDat->YM3812.RegFirst[Register] && Data == ChDat->YM3812.RegData[Register])
 			return false;
-		
+
 		ChDat->YM3812.RegFirst[Register] = 0x00;
 		ChDat->YM3812.RegData[Register] = Data;
 		break;*/
 	default:
 		if (! ChDat->YM3812.RegFirst[Register] && Data == ChDat->YM3812.RegData[Register])
 			return false;
-		
-		
+
+
 		if (Register == 0x01)
 		{
 			if ((ChDat->YM3812.RegData[Register] ^ Data) & 0x20)
@@ -1340,12 +1340,12 @@ bool ym3812_write(UINT8 Register, UINT8 Data)
 					ChDat->YM3812.RegFirst[Register] = 0x01;
 			}
 		}
-		
+
 		ChDat->YM3812.RegFirst[Register] = JustTimerCmds;
 		ChDat->YM3812.RegData[Register] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1360,22 +1360,22 @@ bool ym3526_write(UINT8 Register, UINT8 Data)
 		return false;
 		/*if (Data & 0x80)
 			Data &= 0x80;
-		
+
 		if (! ChDat->YM3526.RegFirst[Register] && Data == ChDat->YM3526.RegData[Register])
 			return false;
-		
+
 		ChDat->YM3526.RegFirst[Register] = 0x00;
 		ChDat->YM3526.RegData[Register] = Data;
 		break;*/
 	default:
 		if (! ChDat->YM3526.RegFirst[Register] && Data == ChDat->YM3526.RegData[Register])
 			return false;
-		
+
 		ChDat->YM3526.RegFirst[Register] = JustTimerCmds;
 		ChDat->YM3526.RegData[Register] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1390,10 +1390,10 @@ bool y8950_write(UINT8 Register, UINT8 Data)
 		return false;
 		/*if (Data & 0x80)
 			Data &= 0x80;
-		
+
 		if (! ChDat->Y8950.RegFirst[Register] && Data == ChDat->Y8950.RegData[Register])
 			return false;
-		
+
 		ChDat->Y8950.RegFirst[Register] = 0x00;
 		ChDat->Y8950.RegData[Register] = Data;
 		break;*/
@@ -1403,12 +1403,12 @@ bool y8950_write(UINT8 Register, UINT8 Data)
 									&ChDat->Y8950.RegFirst[0x07]);
 		if (! ChDat->Y8950.RegFirst[Register] && Data == ChDat->Y8950.RegData[Register])
 			return false;
-		
+
 		ChDat->Y8950.RegFirst[Register] = JustTimerCmds;
 		ChDat->Y8950.RegData[Register] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1416,7 +1416,7 @@ bool ymf262_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	YMF262_DATA* chip = &ChDat->YMF262;
 	UINT16 RegVal;
-	
+
 	RegVal = (Port << 8) | Register;
 	switch(RegVal)
 	{
@@ -1427,22 +1427,22 @@ bool ymf262_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		return false;
 		/*if (Data & 0x80)
 			Data &= 0x80;
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;*/
 	default:
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = JustTimerCmds;
 		chip->RegData[RegVal] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1450,7 +1450,7 @@ bool ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	YMF278B_DATA* chip = &ChDat->YMF278B;
 	UINT16 RegVal;
-	
+
 	if (Port < 0x02)
 	{
 		RegVal = (Port << 8) | Register;
@@ -1463,17 +1463,17 @@ bool ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			return false;
 			/*if (Data & 0x80)
 				Data &= 0x80;
-			
+
 			if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 				return false;
-			
+
 			chip->RegFirst[RegVal] = 0x00;
 			chip->RegData[RegVal] = Data;
 			break;*/
 		default:
 			if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 				return false;
-			
+
 			chip->RegFirst[RegVal] = JustTimerCmds;
 			chip->RegData[RegVal] = Data;
 			break;
@@ -1483,38 +1483,38 @@ bool ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	{
 		return true;
 	}
-	
+
 	return true;
 }
 
 bool ymz280b_write(UINT8 Register, UINT8 Data)
 {
 	YMZ280B_DATA* chip = &ChDat->YMZ280B;
-	
+
 //	// the KeyOn-Register can be sent 2x to stop a sound instantly
 //	if ((Register & 0xE3) == 0x01)
 //		return true;
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
-	
+
 	return true;
 }
 
 bool rf5c164_reg_write(UINT8 Register, UINT8 Data)
 {
 	RF5C68_DATA* chip = &ChDat->RF5C164;
-	
+
 	return rf_pcm_reg_write(chip, Register, Data);
 }
 
 static bool ay8910_part_write(UINT8* RegData, UINT8* RegFirst, UINT8 Register, UINT8 Data)
 {
 	Register &= 0x0F;
-	
+
 	switch(Register)
 	{
 	case 0x07:
@@ -1526,10 +1526,10 @@ static bool ay8910_part_write(UINT8* RegData, UINT8* RegFirst, UINT8 Register, U
 	case 0x0F:	// Port B write
 		return false;
 	}
-	
+
 	if (! RegFirst[Register] && Data == RegData[Register])
 		return false;
-	
+
 	RegFirst[Register] = JustTimerCmds;
 	RegData[Register] = Data;
 	return true;
@@ -1543,12 +1543,12 @@ bool ay8910_write_reg(UINT8 Register, UINT8 Data)
 static bool ymf271_write_fm_reg(YMF271_DATA* chip, UINT8 SlotNum, UINT8 Register, UINT8 Data)
 {
 	YMF271_SLOT* slot = &chip->slots[SlotNum];
-	
+
 	if (Register == 0x0A)	// Frequency MSB Latch (confirmed/flushed by Register 09)
 	{
 		// Note: Based on the code for A0/A4 on OPN chips.
 		UINT16 RegBase;
-		
+
 		RegBase =   (SlotNum % 3) << 0;
 		RegBase |= ((SlotNum / 3) & 0x03) << 2;
 		RegBase |=  (SlotNum / 12) << 8;
@@ -1556,7 +1556,7 @@ static bool ymf271_write_fm_reg(YMF271_DATA* chip, UINT8 SlotNum, UINT8 Register
 		{
 			if ((NxtCmdReg & 0xF0F) != RegBase)
 				continue;	// ignore other channels
-			
+
 			if ((NxtCmdReg & 0x0F0) == 0x0A0)
 			{
 				return false;	// this will be ignored, because the 09 (flushing Freq LSB) write is missing
@@ -1590,13 +1590,13 @@ static bool ymf271_write_fm_reg(YMF271_DATA* chip, UINT8 SlotNum, UINT8 Register
 		slot->RegData[0x0A] = Data;
 		return true;
 	}
-	
+
 	if (Register == 0x00 && (Data & 0x01))
 		slot->RegFirst[Register] = 0x01;	// a Key On triggers always
-	
+
 	if (! slot->RegFirst[Register] && slot->RegData[Register] == Data)
 		return false;
-	
+
 	slot->RegFirst[Register] = JustTimerCmds;
 	slot->RegData[Register] = Data;
 	return true;
@@ -1610,16 +1610,16 @@ static bool ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 	UINT8 SyncMode;
 	UINT8 SyncReg;
 	UINT8 RetVal;
-	
+
 	if ((Register & 0x03) == 0x03)
 		return true;
-	
+
 	SlotNum = ((Register & 0x0F) / 0x04 * 0x03) + (Register & 0x03);
 	slot = &chip->slots[12 * Port + SlotNum];
 	SlotReg = (Register >> 4) & 0x0F;
 	if (SlotNum >= 12 || 12 * Port > 48)
 		printf("Error");
-	
+
 	// check if the register is a synchronized register
 	switch(SlotReg)
 	{
@@ -1635,7 +1635,7 @@ static bool ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 		SyncReg = 0;
 		break;
 	}
-	
+
 	// check if the slot is key on slot for synchronizing
 	SyncMode = 0;
 	switch (chip->groups[SlotNum].sync)
@@ -1655,7 +1655,7 @@ static bool ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 	default:
 		break;
 	}
-	
+
 	if (SyncMode && SyncReg)		// key-on slot & synced register
 	{
 		//RetVal = false;
@@ -1700,7 +1700,7 @@ static bool ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 	{
 		RetVal = ymf271_write_fm_reg(chip, 12 * Port + SlotNum, SlotReg, Data);
 	}
-	
+
 	return RetVal;
 }
 
@@ -1712,7 +1712,7 @@ bool ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	UINT8 GrpNum;
 	UINT8 SlotNum;
 	UINT8 Addr;
-	
+
 	switch(Port)
 	{
 	case 0x00:
@@ -1723,18 +1723,18 @@ bool ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	case 0x04:
 		if ((Register & 0x03) == 0x03)
 			return true;
-		
+
 		SlotNum = ((Register & 0x0F) / 0x04 * 0x03) + (Register & 0x03);
 		Addr = (Register >> 4) % 3;
 		slot = &chip->slots[SlotNum * 4];
-		
+
 		Register = (Register >> 4) & 0x0F;
 		if (! slot->PCMRegFirst[Register] && slot->PCMRegData[Register] == Data)
 			return false;
-		
+
 		slot->PCMRegFirst[Register] = JustTimerCmds;
 		slot->PCMRegData[Register] = Data;
-		
+
 		/*switch((Register >> 4) & 0x0F)
 		{
 		case 0:
@@ -1765,10 +1765,10 @@ bool ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		{
 			if ((Register & 0x03) == 0x03)
 				return true;
-			
+
 			GrpNum = ((Register & 0x0F) / 0x04 * 0x03) + (Register & 0x03);
 			group = &chip->groups[GrpNum];
-			
+
 			if (! group->First && group->Data == Data)
 				return false;
 			group->First = JustTimerCmds;
@@ -1812,26 +1812,26 @@ bool ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		}
 		break;
 	}
-	
+
 	return true;
 }
 
 bool gameboy_write_reg(UINT8 Register, UINT8 Data)
 {
 	GBDMG_DATA* chip = &ChDat->GBDMG;
-	
+
 	if (Register >= 0x30)
 		return true;	// invalid registers
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	if (Register == 0x16)
 	{
 		if (! (Data & 0x80))
 		{
 			UINT8 CurReg;
-			
+
 			for (CurReg = 0x00; CurReg < 0x16; CurReg ++)
 				chip->RegFirst[CurReg] = 0x01;
 		}
@@ -1840,7 +1840,7 @@ bool gameboy_write_reg(UINT8 Register, UINT8 Data)
 	if (Register < 0x20 && ! (chip->RegData[0x16] & 0x80))
 		return false;	// when the chip is off, writes have no effect (except Wave RAM)
 	return true;	// disable further optimization until I figure out what doesn't break actual GB hardware
-	
+
 	// uncomment these lines for sample-accurateness
 	// (otherwise the squares may change one sample too late)
 	// the less accurate way has the advantage of slightly cleaner squares
@@ -1853,7 +1853,7 @@ bool gameboy_write_reg(UINT8 Register, UINT8 Data)
 	else
 		chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
-	
+
 	return true;
 }
 
@@ -1864,13 +1864,13 @@ static bool ymdeltat_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Re
 	case 0x00:	// start, rec, memory mode, repeat flag copy, reset(bit0)
 		if (! RegFirst[Register] && Data == RegData[Register])
 			return false;
-		
+
 		RegData[Register] = Data & (0x80|0x40|0x20|0x10|0x01);
 		if (RegData[Register] & 0x80)
 			RegFirst[Register] = 0x01;
 		else
 			RegFirst[Register] = JustTimerCmds;
-		
+
 		break;
 	case 0x01:	// L,R,-,-,SAMPLE,DA/AD,RAMTYPE,ROM
 	case 0x02:	// Start Address L
@@ -1881,7 +1881,7 @@ static bool ymdeltat_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Re
 	case 0x07:	// Prescale H
 		if (! RegFirst[Register] && Data == RegData[Register])
 			return false;
-		
+
 		RegData[Register] = Data;
 		RegFirst[Register] = JustTimerCmds;
 		break;
@@ -1897,12 +1897,12 @@ static bool ymdeltat_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Re
 	case 0x0D:	// Limit Address H
 		if (! RegFirst[Register] && Data == RegData[Register])
 			return false;
-		
+
 		RegData[Register] = Data;
 		RegFirst[Register] = JustTimerCmds;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -1911,12 +1911,12 @@ bool nes_psg_write(UINT8 Register, UINT8 Data)
 	NESAPU_DATA* chip = &ChDat->NES;
 	UINT8 CurChn;
 	bool ChnIsOn;
-	
+
 	if (Register >= 0x40)
 		return true;	// invalid registers
 	//if (Register >= 0x10 && Register <= 0x13)
 	//	return false;	// remove all DPCM writes
-	
+
 	ChnIsOn = false;
 	if (Register < 0x14)
 	{
@@ -1945,7 +1945,7 @@ bool nes_psg_write(UINT8 Register, UINT8 Data)
 				return true;	// direct DPCM write
 			}
 		}
-		
+
 		if (ChnIsOn)
 		{
 			//ChnIsOn = (chip->RegData[0x15] >> CurChn) & 0x01;
@@ -1977,16 +1977,16 @@ bool nes_psg_write(UINT8 Register, UINT8 Data)
 			return true;
 		}
 	}
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	//if (ChnIsOn)
 	//	chip->RegFirst[Register] = 0x01;	// Channel Initialize
 	//else
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
-	
+
 	return true;
 }
 
@@ -1994,36 +1994,36 @@ bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	C140_DATA* chip = &ChDat->C140;
 	UINT16 RegVal;
-	
+
 	if (Port == 0xFF)
 	{
 		chip->banking_type = Data;
 		return true;
 	}
-	
+
 	RegVal = (Port << 8) | Register;
 	RegVal &= 0x1FF;
 
 	// mirror the bank registers on the 219, fixes bkrtmaq
 	if ((RegVal >= 0x1F8) && (chip->banking_type == C140_TYPE_ASIC219))
 		RegVal -= 0x008;
-	
+
 	if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 		return false;
-	
+
 	if (RegVal < 0x180 && (RegVal & 0x0F) == 0x05 && (Data & 0x80))
 		chip->RegFirst[RegVal] = 0x01;
 	else
 		chip->RegFirst[RegVal] = JustTimerCmds;
 	chip->RegData[RegVal] = Data;
-	
+
 	return true;
 }
 
 bool qsound_write(UINT8 Offset, UINT16 Value)
 {
 	QSOUND_DATA* chip = &ChDat->QSound;
-	
+
 	if (Offset < 0x80)	// PCM channels
 	{
 		switch(Offset & 0x07)
@@ -2059,20 +2059,20 @@ bool qsound_write(UINT8 Offset, UINT16 Value)
 		// so I'll just reset the state.
 		memset(chip->RegFirst, 0xFF, 0x100);
 	}
-	
+
 	if (! chip->RegFirst[Offset] && Value == chip->RegData[Offset])
 		return false;
-	
+
 	chip->RegFirst[Offset] = JustTimerCmds;
 	chip->RegData[Offset] = Value;
-	
+
 	return true;
 }
 
 bool pokey_write(UINT8 Register, UINT8 Data)
 {
 	POKEY_DATA* chip = &ChDat->Pokey;
-	
+
 	Register &= 0x0F;
 	switch(Register)
 	{
@@ -2084,13 +2084,13 @@ bool pokey_write(UINT8 Register, UINT8 Data)
 	case 0x0F:	// SKCTL_C
 		return false;	// not sure - maybe a break is needed for SKCTL_C
 	}
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
-	
+
 	return true;
 }
 
@@ -2099,14 +2099,14 @@ bool c6280_write(UINT8 Register, UINT8 Data)
 	C6280_DATA* chip = &ChDat->C6280;
 	C6280_CHANNEL* chan;
 	UINT8 ChnReg;
-	
+
 	Register &= 0x0F;
 	switch(Register)
 	{
 	case 0x00:	// Channel Select
 		if (! chip->RegFirst[C6280_CHN_SEL] && Data == chip->RegData[C6280_CHN_SEL])
 			return false;
-		
+
 		//if (! chip->RegFirst[C6280_CHN_SEL])
 		{
 			// additional test for 2 Channel Select-Commands after each other
@@ -2138,7 +2138,7 @@ bool c6280_write(UINT8 Register, UINT8 Data)
 				}
 			}
 		}
-		
+
 		chip->RegFirst[C6280_CHN_SEL] = JustTimerCmds;
 		chip->RegData[C6280_CHN_SEL] = Data;
 		if (chip->RegFirst[C6280_CHN_LOOP])
@@ -2147,7 +2147,7 @@ bool c6280_write(UINT8 Register, UINT8 Data)
 			chip->RegFirst[C6280_CHN_LOOP] = 0x00;
 			chip->RegData[C6280_CHN_LOOP] = 0x80;	// set to 'ignore'
 		}
-		
+
 		break;
 	case 0x01:	// Global Balance
 	case 0x08:	// LFO Frequency
@@ -2166,7 +2166,7 @@ bool c6280_write(UINT8 Register, UINT8 Data)
 		}
 		if (! chip->RegFirst[ChnReg] && Data == chip->RegData[ChnReg])
 			return false;
-		
+
 		chip->RegFirst[ChnReg] = JustTimerCmds;
 		chip->RegData[ChnReg] = Data;
 		break;
@@ -2178,19 +2178,19 @@ bool c6280_write(UINT8 Register, UINT8 Data)
 	case 0x07:	// Noise Control (Enable, Frequency)
 		chan = &chip->chan[chip->RegData[C6280_CHN_SEL] & 0x07];
 		ChnReg = Register - 0x02;
-		
+
 		if (chip->RegFirst[C6280_CHN_LOOP])
 			chip->RegFirst[C6280_CHN_LOOP] = 0x00;
-		
+
 		if (Register == 0x06)
 		{
 			// increment Wave Index
 			return true;
 		}
-		
+
 		if (! chan->RegFirst[ChnReg] && Data == chan->ChnReg[ChnReg])
 			return false;
-		
+
 		if (Register == 0x04)
 		{
 			if ((chan->ChnReg[ChnReg] & 0x40) && ! (Data & 0x40))
@@ -2198,12 +2198,12 @@ bool c6280_write(UINT8 Register, UINT8 Data)
 				// reset Wave Index
 			}
 		}
-		
+
 		chan->RegFirst[ChnReg] = JustTimerCmds;
 		chan->ChnReg[ChnReg] = Data;
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -2211,13 +2211,13 @@ static bool fmadpcm_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Reg
 {
 	UINT8 CurChn;
 	UINT8 TempByt;
-	
+
 	switch(Register)
 	{
 	case 0x00:	// DM,--,C5,C4,C3,C2,C1,C0
 		if (! (Data & 0x3F))	// none of the channel bits set
 			return JustTimerCmds;
-		
+
 		if (! (Data & 0x80))
 		{
 			// Key On
@@ -2230,7 +2230,7 @@ static bool fmadpcm_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Reg
 					RegFirst[Register] |= (1 << CurChn);
 				}
 			}
-			
+
 			return true;
 		}
 		else
@@ -2250,10 +2250,10 @@ static bool fmadpcm_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Reg
 					}
 				}
 			}
-			
+
 			if (TempByt == RegData[Register])
 				return false;
-			
+
 			TempByt &= 0x3F;
 			RegData[Register] = TempByt;
 			/*RegFirst[Register] &= 0x3F;
@@ -2262,10 +2262,10 @@ static bool fmadpcm_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Reg
 		break;
 	case 0x01:	// B0-5 = Total Level
 		Data &= 0x3F;
-		
+
 		if (! RegFirst[Register] && Data == RegData[Register])
 			return false;
-		
+
 		RegData[Register] = Data;
 		RegFirst[Register] = JustTimerCmds;
 		break;
@@ -2281,14 +2281,14 @@ static bool fmadpcm_write(UINT8 Register, UINT8 Data, UINT8* RegData, UINT8* Reg
 		default:	// unused*/
 			if (! RegFirst[Register] && Data == RegData[Register])
 				return false;
-			
+
 			RegData[Register] = Data;
 			RegFirst[Register] = JustTimerCmds;
 		/*	break;
 		}*/
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -2298,13 +2298,13 @@ bool k054539_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	UINT16 RegVal;
 	UINT8 TempByt;
 	//UINT8 latch;
-	
+
 	RegVal = (Port << 8) | Register;
 	if (RegVal >= 0x230)
 		return true;
-	
+
 	//latch = (chip->k054539_flags & K054539_UPDATE_AT_KEYON) && (chip->RegData[0x22F] & 0x01);
-	
+
 	switch(RegVal)
 	{
 	case 0x214:
@@ -2314,13 +2314,13 @@ bool k054539_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	/*case 0x214:	// Key On
 		if (chip->RegData[0x22F] & 0x80)
 			return true;
-		
+
 		if (! chip->RegFirst[RegVal])
 			return false;
 		TempByt = chip->RegData[0x22C] | Data;
 		if (TempByt == chip->RegData[0x022C])
 			return false;
-		
+
 		chip->RegData[0x22C] = TempByt;
 		//chip->RegFirst[RegVal] = JustTimerCmds;
 		//chip->RegData[RegVal] = Data;
@@ -2328,13 +2328,13 @@ bool k054539_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	case 0x215:	// Key Off
 		if (chip->RegData[0x22F] & 0x80)
 			return true;
-		
+
 		if (! chip->RegFirst[RegVal])
 			return false;
 		TempByt = chip->RegData[0x22C] & ~Data;
 		if (TempByt == chip->RegData[0x022C])
 			return false;
-		
+
 		chip->RegData[0x22C] = TempByt;
 		//chip->RegFirst[RegVal] = JustTimerCmds;
 		//chip->RegData[RegVal] = Data;
@@ -2360,14 +2360,14 @@ bool k054539_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		}
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		//chip->RegFirst[RegVal] = JustTimerCmds;
 		//chip->RegData[RegVal] = Data;
 		break;
 	}
 	chip->RegFirst[RegVal] = JustTimerCmds;
 	chip->RegData[RegVal] = Data;
-	
+
 	return true;
 }
 
@@ -2376,7 +2376,7 @@ bool k051649_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	K051649_DATA* chip = &ChDat->K051649;
 	UINT8* DataFirst;
 	UINT8* DataPtr;
-	
+
 	switch(Port)
 	{
 	case 0x00:	// k051649_waveform_w
@@ -2420,13 +2420,13 @@ bool k051649_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	default:
 		return true;
 	}
-	
+
 	if (! *DataFirst && Data == *DataPtr)
 		return false;
-	
+
 	*DataFirst = JustTimerCmds;
 	*DataPtr = Data;
-	
+
 	return true;
 }
 
@@ -2434,14 +2434,14 @@ bool okim6295_write(UINT8 Port, UINT8 Data)
 {
 	OKIM6295_DATA* chip = &ChDat->OKIM6295;
 	//UINT8 CurChn;
-	
+
 	if (Port & 0x80)
 	{
 		chip->RegData[Port & 0x7F] = Data;
 		chip->RegFirst[Port & 0x7F] = 0x00;
 		return true;
 	}
-	
+
 	switch(Port)
 	{
 	case 0x00:	// okim6295_write_command
@@ -2455,7 +2455,7 @@ bool okim6295_write(UINT8 Port, UINT8 Data)
 				if (Data & (0x10 << CurChn))
 					ChnEnable[CurChn] = 0x01;
 			}
-			
+
 			CacheOKI6295[ChpCur].Command = 0xFF;
 		}
 		else if (Data & 0x80)
@@ -2478,7 +2478,7 @@ bool okim6295_write(UINT8 Port, UINT8 Data)
 	case 0x0A:	// Master Clock 00dd0000
 		if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
 			return false;
-		
+
 		chip->RegData[Port] = Data;
 		chip->RegFirst[Port] = JustTimerCmds;
 		chip->RegFirst[0x0B] = 0x01;	// force Clock rewrite
@@ -2494,43 +2494,43 @@ bool okim6295_write(UINT8 Port, UINT8 Data)
 	case 0x13:	// Set NMK Bank 3
 		break;
 	}
-	
+
 	//if (Port >= 0x14)
 	//	return true;
-	
+
 	if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
 		return false;
-	
+
 	chip->RegData[Port] = Data;
 	chip->RegFirst[Port] = JustTimerCmds;
-	
+
 	return true;
 }
 
 bool scsp_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	//SCSP_DATA* chip = &ChDat->SCSP;
-	
+
 	if (Port == 0x04 && (Register >= 0x1A && Register <= 0x29))
 		return false;
 	if (Port == 0x04 && Register == 0x08)
 		return false;	// TODO: mainly used for reading?
-	
+
 	return true;
 }
 
 bool upd7759_write(UINT8 Port, UINT8 Data)
 {
 	UPD7759_DATA* chip = &ChDat->UPD7759;
-	
+
 	if (Port == 0x02)
 		return true;	// write FIFO
 	else if (Port >= 0x04)
 		return true;	// unknown write
-	
+
 	if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
 		return false;
-	
+
 	chip->RegData[Port] = Data;
 	chip->RegFirst[Port] = JustTimerCmds;
 	return true;
@@ -2540,14 +2540,14 @@ bool okim6258_write(UINT8 Port, UINT8 Data)
 {
 	OKIM6258_DATA* chip = &ChDat->OKIM6258;
 	bool RetVal;
-	
+
 	if (Port & 0x80)
 	{
 		chip->RegData[Port & 0x0F] = Data;
 		chip->RegFirst[Port & 0x0F] = 0x00;
 		return true;
 	}
-	
+
 	switch(Port)
 	{
 	case 0x00:	// Start/Stop
@@ -2558,7 +2558,7 @@ bool okim6258_write(UINT8 Port, UINT8 Data)
 			return true;
 		if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
 			return false;
-		
+
 		chip->RegData[Port] = Data;
 		chip->RegFirst[Port] = JustTimerCmds;
 		break;
@@ -2567,7 +2567,7 @@ bool okim6258_write(UINT8 Port, UINT8 Data)
 	case 0x0A:	// Master Clock 00dd0000
 		if (/*! chip->RegFirst[Port] &&*/ Data == chip->RegData[Port])
 			return false;
-		
+
 		chip->RegData[Port] = Data;
 		chip->RegFirst[Port] = 0x00;
 		chip->RegFirst[0x0B] = 0x01;	// force Clock rewrite
@@ -2575,7 +2575,7 @@ bool okim6258_write(UINT8 Port, UINT8 Data)
 	case 0x0B:	// Master Clock dd000000
 		if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
 			return false;
-		
+
 		chip->RegData[Port] = Data;
 		chip->RegFirst[Port] = 0x00;
 		printf("Master Clock Change!\n");
@@ -2584,7 +2584,7 @@ bool okim6258_write(UINT8 Port, UINT8 Data)
 	case 0x0C:	// Clock Divider
 		if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
 			return false;
-		
+
 		if (Port == 0x0C && Data == chip->RegData[Port])
 		{
 			do
@@ -2600,7 +2600,7 @@ bool okim6258_write(UINT8 Port, UINT8 Data)
 		//getchar();
 		break;
 	}
-	
+
 	return true;
 }
 
@@ -2611,7 +2611,7 @@ bool c352_write(UINT16 offset, UINT16 val)
 
 	if (offset >= 0x208)
 		return true;
-	
+
 	ChnBase = offset & 0x0F8;
 	if (offset < 0x100 && (chip->RegData[ChnBase | 3] & C352_FLG_LINKLOOP) == C352_FLG_LINKLOOP)
 	{
@@ -2636,10 +2636,10 @@ bool c352_write(UINT16 offset, UINT16 val)
 			break;
 		}
 	}
-	
+
 	if (! chip->RegFirst[offset] && val == chip->RegData[offset])
 		return false;
-	
+
 	chip->RegData[offset] = val;
 	chip->RegFirst[offset] = JustTimerCmds;
 	if (offset < 0x100)
@@ -2652,15 +2652,15 @@ bool x1_010_write(UINT16 offset, UINT8 val)
 	X1_010_DATA *chip = &ChDat->X1_010;
 
 	// Key on without loop flag set: chip will clear the key on flag once playback is finished
-	if(offset < 0x80 && (offset&0x07) == 0x00 && val&0x01 && !(val&0x04)) 
+	if(offset < 0x80 && (offset&0x07) == 0x00 && val&0x01 && !(val&0x04))
 		chip->RegFirst[offset] = 1;
-	
+
 	if(offset >= 0x2000)
 		return false;
 
 	if (! chip->RegFirst[offset] && val == chip->RegData[offset])
 		return false;
-	
+
 	chip->RegData[offset] = val;
 	chip->RegFirst[offset] = JustTimerCmds;
 	return true;
@@ -2669,15 +2669,15 @@ bool x1_010_write(UINT16 offset, UINT8 val)
 bool es5503_write(UINT8 Register, UINT8 Data)
 {
 	ES5503_DATA* chip = &ChDat->ES5503;
-	
+
 	if (Register >= 0xE2)
 		return true;
 	if ((Register & 0xE0) == 0xA0)
 		return true;	// don't strip Control register (can be changed by sound chip itself)
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
 	return true;
@@ -2688,7 +2688,7 @@ bool vsu_write(UINT16 Register, UINT8 Data)
 	VSU_DATA* chip = &ChDat->VSU;
 	UINT8 CurChn;
 	UINT16 ChnBaseReg;
-	
+
 	if (Register == 0x160)
 	{
 		// All Channels Off register
@@ -2736,10 +2736,10 @@ bool vsu_write(UINT16 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 		return false;
-	
+
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
 	return true;

--- a/chip_srom.c
+++ b/chip_srom.c
@@ -33,7 +33,7 @@ typedef struct deltat_adpcm_state	// AT: rearranged and tigntened structure
 	UINT32 start;		// start address
 	//UINT32 limit;		// limit address
 	UINT32 end;			// end address
-	UINT8 portstate;		// port status 
+	UINT8 portstate;		// port status
 	UINT8 control2;			// control reg: SAMPLE, DA/AD, RAM TYPE (x8bit / x1bit), ROM/RAM
 	UINT8 portshift;		// address bits shift-left:
 							//		** 8 for YM2610,
@@ -112,11 +112,11 @@ typedef struct ymz280b_data
 typedef struct ymf271_slot
 {
 	UINT8 waveform;
-	
+
 	UINT32 startaddr;
 	UINT32 loopaddr;
 	UINT32 endaddr;
-	
+
 	UINT8 active;
 	UINT8 bits;
 	UINT8 IsPCM;
@@ -129,7 +129,7 @@ typedef struct ymz271_data
 {
 	YMF271_SLOT slots[48];
 	YMF271_GROUP groups[12];
-	
+
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
@@ -166,7 +166,7 @@ typedef struct okim6295_data
 	UINT8		nmk_mode;
 	UINT32		bank_offs;
 	UINT8		nmk_bank[4];
-	
+
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
@@ -188,7 +188,7 @@ typedef struct
 	UINT8 start_lsb;
 	UINT8 end_msb;
 	UINT8 end_lsb;
-	
+
 	UINT32 smpl_start;
 	UINT32 smpl_end;
 } C140_VOICE;
@@ -198,7 +198,7 @@ typedef struct _c140_state
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
-	
+
 	UINT8 BankRegs[0x10];
 	C140_VOICE voi[C140_MAX_VOICE];
 } C140_DATA;
@@ -209,14 +209,14 @@ typedef struct _qsound_channel
 	UINT8 bank;		// bank (x16)
 	INT32 address;	// start address
 	INT32 end;		// end address
-	
+
 	UINT8 key;		// Key on / key off
 } QSOUND_CHANNEL;
 typedef struct qsound_data
 {
 	QSOUND_CHANNEL channel[QSOUND_CHANNELS];
 	UINT16 data;	// register latch data
-	
+
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
@@ -238,11 +238,11 @@ typedef struct _k054539_state
 	//UINT8 regs[0x230];
 	UINT8 flags;
 	UINT8 reg_enable;
-	
+
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
-	
+
 	K054539_CHANNEL channels[8];
 } K054539_DATA;
 
@@ -257,11 +257,11 @@ typedef struct _k053260_channel
 typedef struct k053260_data
 {
 	UINT8	mode;
-	
+
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
-	
+
 	K053260_CHANNEL	channels[4];
 } K053260_DATA;
 
@@ -270,10 +270,10 @@ typedef struct upd7759_data
 	UINT8		fifo_in;		// last data written to the sound chip
 	UINT8		reset;			// current state of the RESET line
 	UINT8		start;			// current state of the START line
-	
+
 	//INT8		state;			// current overall chip state
-	UINT32		romoffset;		// ROM offset to make save/restore 
-	
+	UINT32		romoffset;		// ROM offset to make save/restore
+
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
@@ -299,10 +299,10 @@ typedef struct multipcm_data
 	UINT8* ROMData;
 	UINT8* ROMUsage;
 	UINT8 SmplMask[0x200];	// Bit 7 - Sample Table, Bit 1 - BankR, Bit 0 - BankL
-	
+
 	UINT32 BankL;
 	UINT32 BankR;
-	
+
 	UINT8 CurSlot;
 	UINT8 Address;
 	MULTIPCM_SLOT slot[28];
@@ -327,7 +327,7 @@ typedef struct x1010_data
 	UINT32 ROMSize;
 	INT8 *ROMData;
 	UINT8* ROMUsage;
-	
+
 	UINT8 m_reg[0x2000];
 } X1_010_DATA;
 
@@ -358,7 +358,7 @@ typedef struct
 	UINT16  end_addr;
 	UINT16  repeat_addr;
 	UINT32  flag;
-	
+
 	UINT16  start;
 	UINT16  repeat;
 	//UINT32  current_addr;
@@ -369,11 +369,11 @@ typedef struct c352_data
 	UINT32 ROMSize;
 	INT8 *ROMData;
 	UINT8* ROMUsage;
-	
+
 	C352_CHANNEL channels[32];
 } C352_DATA;
 
-typedef struct 
+typedef struct
 {
 	UINT32 start;
 	UINT32 end;
@@ -384,7 +384,7 @@ typedef struct ga20_data
 	UINT32 ROMSize;
 	UINT8 *ROMData;
 	UINT8* ROMUsage;
-	
+
 	GA20_CHANNEL channels[4];
 } GA20_DATA;
 
@@ -404,7 +404,7 @@ typedef struct es5503_data
 	UINT32 ROMSize;
 	UINT8* ROMData;
 	UINT8* ROMUsage;
-	
+
 	ES5503_OSC oscillators[32];
 } ES5503_DATA;
 
@@ -423,7 +423,7 @@ typedef struct ymf278b_data
 	UINT8* RAMData;
 	UINT8* RAMUsage;
 	UINT8 SmplMask[0x200];	// Bit 7 - Sample Table, Bit 0 - Sample Data
-	
+
 	YMF278B_SLOT slots[24];
 	INT8 wavetblhdr;
 	INT8 memmode;
@@ -468,7 +468,7 @@ typedef struct es5506_rom
 typedef struct es5506_data
 {
 	ES5506_ROM Rgn[4];	// ROM regions
-	
+
 	UINT32 writeLatch;
 	UINT8 chipType;		// 0 - ES5505, 1 - ES5506
 	UINT8 curPage;
@@ -550,7 +550,7 @@ void InitAllChips(void)
 	UINT8 CurChip;
 	UINT8 CurChn;
 	YM_DELTAT* TempYDT;
-	
+
 	if (ChipData == NULL)
 		ChipData = (ALL_CHIPS*)malloc(ChipCount * sizeof(ALL_CHIPS));
 	memset(ChipData, 0x00, ChipCount * sizeof(ALL_CHIPS));
@@ -558,7 +558,7 @@ void InitAllChips(void)
 	{
 		ChDat = ChipData + CurChip;
 		memset(ChDat->SegaPCM.RAMData, 0xFF, 0x800);
-		
+
 		ChDat->SegaPCM.intf_bank = SPCM_BANK_512;
 		// DELTA-T unit
 		TempYDT = &ChDat->YM2608.DeltaT;
@@ -583,7 +583,7 @@ void InitAllChips(void)
 			TempYDT->portstate = 0;
 			TempYDT->control2  = 0;
 			TempYDT->DRAMportshift = dram_rightshift[TempYDT->control2 & 3];
-		
+
 		ChDat->YMF278B.RAMBase = 0x200000;	// default ROM size is 2 MB
 		//ChDat->UPD7759.state = STATE_IDLE;
 		ChDat->UPD7759.reset = 1;
@@ -592,13 +592,13 @@ void InitAllChips(void)
 		ChDat->K054539.flags = K054539_RESET_FLAGS;
 		ChDat->C140.banking_type = 0x00;
 		ChDat->ES5506.voiceCount = 32;
-		
+
 		for (CurChn = 0; CurChn < 28; CurChn ++)
 			ChDat->MultiPCM.slot[CurChn].SmplID = 0xFFFF;
 	}
-	
+
 	SetChipSet(0x00);
-	
+
 	return;
 }
 
@@ -606,17 +606,17 @@ void FreeAllChips(void)
 {
 	if (ChipData == NULL)
 		return;
-	
+
 	free(ChipData);
 	ChipData = NULL;
-	
+
 	return;
 }
 
 void SetChipSet(UINT8 ChipID)
 {
 	ChDat = ChipData + ChipID;
-	
+
 	return;
 }
 
@@ -628,7 +628,7 @@ void segapcm_mem_write(UINT16 Offset, UINT8 Data)
 	UINT32 StAddr;
 	UINT32 EndAddr;
 	UINT32 Addr;
-	
+
 	if (Offset >= 0xFFF0)
 	{
 		Addr = (Offset & 0x03) * 8;
@@ -636,7 +636,7 @@ void segapcm_mem_write(UINT16 Offset, UINT8 Data)
 		chip->intf_bank |=  (Data << Addr);
 		return;
 	}
-	
+
 	CurChn = (Offset & 0x78) / 8;
 	RAMBase = chip->RAMData + CurChn * 8;
 	chip->RAMData[Offset] = Data;
@@ -661,17 +661,17 @@ void segapcm_mem_write(UINT16 Offset, UINT8 Data)
 				StAddr = Addr;
 			EndAddr = (RAMBase[0x06] + 0x01) << 8;
 			//StAddr &= ~0x00FF;
-			
+
 			Addr = (RAMBase[0x86] & chip->bankmask) << chip->bankshift;
 			StAddr = (Addr + StAddr) & chip->rgnmask;
 			EndAddr = (Addr + EndAddr) & chip->rgnmask;
-			
+
 			for (Addr = StAddr; Addr < EndAddr; Addr ++)
 				chip->ROMUsage[Addr] |= 0x01;
 		}
 		break;
 	}
-	
+
 	return;
 }
 
@@ -679,11 +679,11 @@ void ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	YM2608_DATA* chip;
 	UINT16 RegVal;
-	
+
 	chip = &ChDat->YM2608;
 	RegVal = (Port << 8) | Register;
 	chip->RegData[RegVal] = Data;
-	
+
 	switch(RegVal & 0x1F0)
 	{
 	case 0x010:	// ADPCM A
@@ -691,11 +691,11 @@ void ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	case 0x100:	// DeltaT ADPCM
 		if ((RegVal & 0x0F) == 0x0E)
 			break;
-		
+
 		YM_DELTAT_ADPCM_Write(&chip->DeltaT, RegVal & 0x0F, Data);
 		break;
 	}
-	
+
 	return;
 }
 
@@ -703,11 +703,11 @@ void ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	YM2610_DATA* chip;
 	UINT16 RegVal;
-	
+
 	chip = &ChDat->YM2610;
 	RegVal = (Port << 8) | Register;
 	chip->RegData[RegVal] = Data;
-	
+
 	switch(RegVal & 0x1F0)
 	{
 	case 0x010:	// DeltaT ADPCM
@@ -721,17 +721,17 @@ void ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		FM_ADPCMAWrite(chip, RegVal & 0xFF, Data);
 		break;
 	}
-	
+
 	return;
 }
 
 void y8950_write(UINT8 Register, UINT8 Data)
 {
 	Y8950_DATA* chip;
-	
+
 	chip = &ChDat->Y8950;
 	chip->RegData[Register] = Data;
-	
+
 	if (Register >= 0x07 && Register < 0x015)	// DeltaT ADPCM
 	{
 		if (Register >= 0x13)
@@ -740,7 +740,7 @@ void y8950_write(UINT8 Register, UINT8 Data)
 			Data &= 0x0F;
 		YM_DELTAT_ADPCM_Write(&chip->DeltaT, Register - 0x07, Data);
 	}
-	
+
 	return;
 }
 
@@ -767,7 +767,7 @@ static void FM_ADPCMAWrite(YM2610_DATA *F2610, UINT8 r, UINT8 v)
 				{
 					// *** start adpcm ***
 					adpcm[c].flag = 1;
-					
+
 					adpcm[c].end &= (1 << 20) - 1;	// YM2610 checks only 20 bits while playing
 					adpcm[c].end |= adpcm[c].start & ~((1 << 20) - 1);
 					if (adpcm[c].end < adpcm[c].start)
@@ -792,7 +792,7 @@ static void FM_ADPCMAWrite(YM2610_DATA *F2610, UINT8 r, UINT8 v)
 						//continue;	// uncomment to ignore the fact that the complete rom
 									// may be used
 					}
-					
+
 					SampleLen = adpcm[c].end - adpcm[c].start;
 					MaskBase = &F2610->AP_ROMUsage[adpcm[c].start];
 					for (CurSmpl = 0x00; CurSmpl < SampleLen; CurSmpl ++)
@@ -813,7 +813,7 @@ static void FM_ADPCMAWrite(YM2610_DATA *F2610, UINT8 r, UINT8 v)
 	default:
 		c = r&0x07;
 		if( c >= 0x06 ) return;
-		
+
 		switch( r&0x38 ){
 		case 0x08:	// Pan, Instrument Level
 			break;
@@ -821,7 +821,7 @@ static void FM_ADPCMAWrite(YM2610_DATA *F2610, UINT8 r, UINT8 v)
 		case 0x18:
 			adpcm[c].start  = ((F2610->ADPCMReg[0x18 + c] * 0x0100 |
 								F2610->ADPCMReg[0x10 + c]) << ADPCMA_ADDRESS_SHIFT);
-			
+
 			if (adpcm[c].flag)
 			{
 				printf("ADPCM-A Ch %u StartAddr: %06X\n", c, adpcm[c].start);
@@ -833,7 +833,7 @@ static void FM_ADPCMAWrite(YM2610_DATA *F2610, UINT8 r, UINT8 v)
 								F2610->ADPCMReg[0x20 + c]) << ADPCMA_ADDRESS_SHIFT);
 			adpcm[c].end   += (1<<ADPCMA_ADDRESS_SHIFT) - 1;
 			//adpcm[c].end   += (2<<ADPCMA_ADDRESS_SHIFT) - 1; // Puzzle De Pon-Patch
-			
+
 			if (adpcm[c].flag)
 			{
 				printf("ADPCM-A Ch %u EndAddr: %06X\n", c, adpcm[c].end);
@@ -841,7 +841,7 @@ static void FM_ADPCMAWrite(YM2610_DATA *F2610, UINT8 r, UINT8 v)
 			break;
 		}
 	}
-	
+
 	return;
 }
 
@@ -851,7 +851,7 @@ static void YM_DELTAT_ADPCM_Write(YM_DELTAT *DELTAT, UINT8 r, UINT8 v)
 	UINT32 SampleLen;
 	UINT32 CurSmpl;
 	UINT8* MaskBase;
-	
+
 	if(r>=0x10) return;
 	DELTAT->reg[r] = v;	// stock data
 
@@ -963,7 +963,7 @@ static void YM_DELTAT_ADPCM_Write(YM_DELTAT *DELTAT, UINT8 r, UINT8 v)
 		//logerror("DELTAT limit: 0c=%2x 0d=%2x addr=%8x\n",DELTAT->reg[0xc], DELTAT->reg[0xd],DELTAT->limit );
 		break;
 	}
-	
+
 	return;
 }
 
@@ -974,7 +974,7 @@ void ymz280b_write(UINT8 Register, UINT8 Data)
 	UINT32 SampleLen;
 	UINT32 CurSmpl;
 	UINT8* MaskBase;
-	
+
 	chip = &ChDat->YMZ280B;
 	if (Register < 0x80)
 	{
@@ -999,7 +999,7 @@ void ymz280b_write(UINT8 Register, UINT8 Data)
 					//continue;	// uncomment to ignore the fact that the complete rom
 								// may be used
 				}
-				
+
 				SampleLen = voice->stop - voice->start;
 				MaskBase = &chip->ROMUsage[voice->start];
 				for (CurSmpl = 0x00; CurSmpl < SampleLen; CurSmpl ++)
@@ -1046,7 +1046,7 @@ void ymz280b_write(UINT8 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	return;
 }
 
@@ -1061,7 +1061,7 @@ static void rf5c_mark_sample(RF5C_DATA* chip, UINT32 Addr, UINT16 SmplStep)
 	}
 	if (Addr >= chip->RAMSize)
 		return;
-	
+
 	// The chip can skip the first terminator sample, so leave enough
 	// samples that it works with the current frequency.
 	SmplStep = (SmplStep + 0x7FF) >> 11;
@@ -1078,7 +1078,7 @@ static void rf5c_mark_sample(RF5C_DATA* chip, UINT32 Addr, UINT16 SmplStep)
 		chip->RAMUsage[Addr] |= 0x01;
 		Addr ++;
 	}
-	
+
 	return;
 }
 
@@ -1086,7 +1086,7 @@ static void rf5c_write(RF5C_DATA* chip, UINT8 Register, UINT8 Data)
 {
 	RF5C_CHANNEL* chan;
 	UINT8 CurChn;
-	
+
 	switch(Register)
 	{
 	case 0x02:	// Sample Step Low
@@ -1143,7 +1143,7 @@ static void rf5c_write(RF5C_DATA* chip, UINT8 Register, UINT8 Data)
 		}
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1165,7 +1165,7 @@ static void ymf271_write_fm_reg(YMF271_DATA* chip, UINT8 SlotNum, UINT8 Register
 	UINT32 Addr;
 	UINT32 CurByt;
 	UINT32 DataLen;
-	
+
 	switch(Register)
 	{
 	case 0x00:
@@ -1182,7 +1182,7 @@ static void ymf271_write_fm_reg(YMF271_DATA* chip, UINT8 SlotNum, UINT8 Register
 				SlotNum &= ~0x03;
 				slot = &chip->slots[SlotNum];
 			}
-			
+
 			DataLen = slot->endaddr + 1;
 			if (slot->bits != 8)
 			DataLen = (DataLen * slot->bits + 7) / 8;	// scale up for 12-bit samples
@@ -1199,7 +1199,7 @@ static void ymf271_write_fm_reg(YMF271_DATA* chip, UINT8 SlotNum, UINT8 Register
 		slot->waveform = Data & 0x07;
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1210,10 +1210,10 @@ static void ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 	UINT8 SlotNum;
 	UINT8 SyncMode;
 	UINT8 SyncReg;
-	
+
 	if ((Register & 0x03) == 0x03)
 		return;
-	
+
 	SlotNum = ((Register & 0x0C) / 0x04 * 0x03) + (Register & 0x03);
 	slot = &chip->slots[12 * Port + SlotNum];
 	SlotReg = (Register >> 4) & 0x0F;
@@ -1222,7 +1222,7 @@ static void ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 		printf("Error in YMF271 Data!");
 		return;
 	}
-	
+
 	// check if the register is a synchronized register
 	SyncReg = 0;
 	switch(SlotReg)
@@ -1238,7 +1238,7 @@ static void ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 	default:
 		break;
 	}
-	
+
 	// check if the slot is key on slot for synchronizing
 	SyncMode = 0;
 	switch(chip->groups[SlotNum].sync)
@@ -1295,7 +1295,7 @@ static void ymf271_write_fm(YMF271_DATA* chip, UINT8 Port, UINT8 Register, UINT8
 	{
 		ymf271_write_fm_reg(chip, (12 * Port) + SlotNum, SlotReg, Data);
 	}
-	
+
 	return;
 }
 
@@ -1306,7 +1306,7 @@ void ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	YMF271_GROUP* group;
 	UINT8 SlotNum;
 	//UINT8 Addr;
-	
+
 	switch(Port)
 	{
 	case 0x00:
@@ -1318,11 +1318,11 @@ void ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	case 0x04:
 		if ((Register & 0x03) == 0x03)
 			return;
-		
+
 		SlotNum = ((Register & 0x0C) / 0x04 * 0x03) + (Register & 0x03);
 		//Addr = (Register >> 4) % 3;
 		slot = &chip->slots[SlotNum * 4];
-		
+
 		switch((Register >> 4) & 0x0F)
 		{
 		case 0:
@@ -1371,7 +1371,7 @@ void ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		{
 			if ((Register & 0x03) == 0x03)
 				return;
-			
+
 			SlotNum = ((Register & 0x0C) / 0x04 * 0x03) + (Register & 0x03);
 			if (SlotNum >= 12)
 			{
@@ -1414,7 +1414,7 @@ void ymf271_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		}
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1428,26 +1428,26 @@ static void okim6295_command_write(OKIM6295_DATA* chip, UINT8 Command)
 	UINT32 CurSmpl;
 	UINT8* MaskBase;
 	UINT8 BankID;
-	
+
 	// if a command is pending, process the second half
 	if (chip->command != 0xFF)
 	{
 		voicemask = Command >> 4;
-		
+
 		// determine which voice(s) (voice is set by a 1 bit in the upper 4 bits of the second byte)
 		//for (voicenum = 0; voicenum < OKIM6295_VOICES; voicenum ++, voicemask >>= 1)
 		if (voicemask & 0x0F)
 		{
 			//if (! (voicemask & 1))
 			//	continue;
-			
+
 			for (voicenum = 0; voicenum < OKIM6295_VOICES; voicenum ++, voicemask >>= 1)
 			{
 				if (voicemask & 1)
 					break;
 			}
 			voice = &chip->voice[voicenum];
-			
+
 			// determine the start/stop positions
 			base = chip->command * 8;
 			if (! chip->nmk_mode)
@@ -1462,17 +1462,17 @@ static void okim6295_command_write(OKIM6295_DATA* chip, UINT8 Command)
 					BankID = 0x00;
 				base |= (chip->nmk_bank[BankID & 0x03] << 16);
 			}
-			
+
 			voice->start  = chip->ROMData[base + 0] << 16;
 			voice->start |= chip->ROMData[base + 1] <<  8;
 			voice->start |= chip->ROMData[base + 2] <<  0;
 			voice->start &= 0x3FFFF;
-			
+
 			voice->stop  = chip->ROMData[base + 3] << 16;
 			voice->stop |= chip->ROMData[base + 4] <<  8;
 			voice->stop |= chip->ROMData[base + 5] <<  0;
 			voice->stop &= 0x3FFFF;
-			
+
 			if (! chip->nmk_mode)
 			{
 				voice->start |= chip->bank_offs;
@@ -1489,18 +1489,18 @@ static void okim6295_command_write(OKIM6295_DATA* chip, UINT8 Command)
 				if ((voice->start & ~0xFFFF) != (voice->stop & ~0xFFFF))
 					printf("Warning: NMK112 Start Bank != Stop Bank!\n");
 			}
-			
+
 			SampleLen = 0x80 * 8;	// header memory
 			base &= ~0x3FF;			// enforce storing the full table
 			MaskBase = &chip->ROMUsage[base];
 			for (CurSmpl = 0x00; CurSmpl < SampleLen; CurSmpl ++)
 				MaskBase[CurSmpl] |= 0x01;
-			
+
 			// set up the voice to play this sample
 			if (voice->start < voice->stop)
 			{
 				voice->playing = true;
-				
+
 				SampleLen = voice->stop - voice->start + 1;
 				MaskBase = &chip->ROMUsage[voice->start];
 				for (CurSmpl = 0x00; CurSmpl < SampleLen; CurSmpl ++)
@@ -1513,7 +1513,7 @@ static void okim6295_command_write(OKIM6295_DATA* chip, UINT8 Command)
 						voicenum, chip->command);
 			}
 		}
-		
+
 		// reset the command
 		chip->command = 0xFF;
 	}
@@ -1525,14 +1525,14 @@ static void okim6295_command_write(OKIM6295_DATA* chip, UINT8 Command)
 	{
 		// determine which voice(s) (voice is set by a 1 bit in bits 3-6 of the command
 		voicemask = Command >> 3;
-		
+
 		for (voicenum = 0; voicenum < OKIM6295_VOICES; voicenum++, voicemask >>= 1)
 		{
 			if (voicemask & 1)
 				chip->voice[voicenum].playing = false;
 		}
 	}
-	
+
 	return;
 }
 
@@ -1542,7 +1542,7 @@ void okim6295_write(UINT8 Offset, UINT8 Data)
 	UINT32 TempLng;
 	UINT8 CurChn;
 	UINT8 ChnMask;
-	
+
 	switch(Offset)
 	{
 	case 0x00:
@@ -1555,17 +1555,17 @@ void okim6295_write(UINT8 Offset, UINT8 Data)
 		TempLng = Data << 18;
 		if (chip->bank_offs == TempLng)
 			return;
-		
+
 		ChnMask = 0x00;
 		for (CurChn = 0; CurChn < OKIM6295_VOICES; CurChn ++)
 			ChnMask |= chip->voice[CurChn].playing << CurChn;
-		
+
 		if (ChnMask)
 		{
 			UINT32 SampleLen;
 			UINT32 CurSmpl;
 			UINT8* MaskBase;
-			
+
 			printf("Warning! OKIM6295 Bank change (%X -> %X) while channel ",
 					chip->bank_offs, TempLng);
 			for (CurChn = 0; CurChn < OKIM6295_VOICES; CurChn ++)
@@ -1573,7 +1573,7 @@ void okim6295_write(UINT8 Offset, UINT8 Data)
 				if (ChnMask & (1 << CurChn))
 				{
 					printf("%c", '0' + CurChn);
-					
+
 					SampleLen = chip->voice[CurChn].stop - chip->voice[CurChn].start + 1;
 					MaskBase = &chip->ROMUsage[TempLng | chip->voice[CurChn].start];
 					for (CurSmpl = 0x00; CurSmpl < SampleLen; CurSmpl ++)
@@ -1591,7 +1591,7 @@ void okim6295_write(UINT8 Offset, UINT8 Data)
 		chip->nmk_bank[Offset & 0x03] = Data;
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1631,13 +1631,13 @@ void c140_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 	C140_VOICE* TempChn;
 	UINT16 RegVal;
 	UINT32 Addr;
-	
+
 	if (Port == 0xFF)
 	{
 		chip->banking_type = Data;
 		return;
 	}
-	
+
 	RegVal = (Port << 8) | (Offset << 0);
 	if (RegVal >= 0x1F0)
 	{
@@ -1648,7 +1648,7 @@ void c140_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 	}
 	if (RegVal >= 0x180)
 		return;
-	
+
 	TempChn = &chip->voi[RegVal >> 4];
 	switch(RegVal & 0x0F)
 	{
@@ -1663,7 +1663,7 @@ void c140_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 									TempChn->start_lsb, TempChn->bank, Offset >> 4);
 			TempChn->smpl_end = c140_sample_addr(chip, TempChn->end_msb,
 									TempChn->end_lsb, TempChn->bank, Offset >> 4);
-			
+
 			for (Addr = TempChn->smpl_start; Addr < TempChn->smpl_end; Addr ++)
 				chip->ROMUsage[Addr] |= 0x01;
 		}
@@ -1681,21 +1681,21 @@ void c140_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 		TempChn->end_lsb = Data;
 		break;
 	}
-	
+
 	return;
 }
 
 void qsound_write(UINT8 Offset, UINT16 Value)
 {
 	QSOUND_DATA* chip = &ChDat->QSound;
-	
+
 	UINT8 ch;
 	UINT8 reg;
 	QSOUND_CHANNEL* TempChn;
 	INT16 StAddr;
 	INT16 EndAddr;
 	UINT32 Addr;
-	
+
 	if (Offset < 0x80)
 	{
 		ch = Offset >> 3;
@@ -1734,7 +1734,7 @@ void qsound_write(UINT8 Offset, UINT16 Value)
 	{
 		return;
 	}
-	
+
 	TempChn = &chip->channel[ch];
 	switch(reg)
 	{
@@ -1766,7 +1766,7 @@ void qsound_write(UINT8 Offset, UINT16 Value)
 		{
 			// Key on
 			TempChn->key = 1;
-			
+
 			StAddr = TempChn->address;
 			EndAddr = TempChn->end;
 			StAddr %= chip->ROMSize;
@@ -1777,7 +1777,7 @@ void qsound_write(UINT8 Offset, UINT16 Value)
 		}
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1787,13 +1787,13 @@ static void k054539_proc_channel(K054539_DATA* chip, UINT8 Chn)
 	UINT32 Addr;
 	UINT16 TempSht;
 	UINT32 Step;
-	
+
 	TempChn = &chip->channels[Chn];
 	Addr =	(TempChn->pos_reg[2] << 16) |
 			(TempChn->pos_reg[1] <<  8) |
 			(TempChn->pos_reg[0] <<  0);
 	Step = (TempChn->mode_reg & 0x20) ? -1 : +1;
-	
+
 	switch((TempChn->mode_reg & 0x0C) >> 2)
 	{
 	case 0x00:	// 8-bit PCM
@@ -1802,7 +1802,7 @@ static void k054539_proc_channel(K054539_DATA* chip, UINT8 Chn)
 			chip->ROMUsage[Addr] |= 0x01;
 			if (chip->ROMData[Addr] == 0x80)
 				break;
-			
+
 			Addr += Step;
 		}
 		break;
@@ -1816,7 +1816,7 @@ static void k054539_proc_channel(K054539_DATA* chip, UINT8 Chn)
 						(chip->ROMData[Addr + 0x01] << 8);
 			if (TempSht == 0x8000)
 				break;
-			
+
 			Addr += Step;
 		}
 		break;
@@ -1826,7 +1826,7 @@ static void k054539_proc_channel(K054539_DATA* chip, UINT8 Chn)
 			chip->ROMUsage[Addr] |= 0x01;
 			if (chip->ROMData[Addr] == 0x88)
 				break;
-			
+
 			Addr += Step;
 		}
 		break;
@@ -1835,7 +1835,7 @@ static void k054539_proc_channel(K054539_DATA* chip, UINT8 Chn)
 				TempChn->mode_reg, Chn);
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1847,15 +1847,15 @@ void k054539_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 	UINT8 CurChn;
 	UINT8 offs;
 	bool latch;
-	
+
 	if (Port == 0xFF)
 	{
 		info->flags = Data;
 		return;
 	}
-	
+
 	RegVal = (Port << 8) | (Offset << 0);
-	
+
 	if (RegVal < 0x100)
 	{
 		offs = RegVal & 0x1F;
@@ -1887,12 +1887,12 @@ void k054539_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 						RegVal, Data);
 		}
 	}
-	
+
 	switch(RegVal)
 	{
 	case 0x214:
 		latch = (info->flags & K054539_UPDATE_AT_KEYON) && (info->reg_enable & 1);
-		
+
 		for (CurChn = 0; CurChn < 8; CurChn ++)
 		{
 			if (Data & (1 << CurChn))
@@ -1905,10 +1905,10 @@ void k054539_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 					TempChn->pos_reg[1] = TempChn->pos_latch[1];
 					TempChn->pos_reg[2] = TempChn->pos_latch[2];
 				}
-				
+
 				if (! (info->reg_enable & 0x80))
 					TempChn->key_on = true;
-				
+
 				k054539_proc_channel(info, CurChn);
 			}
 		}
@@ -1937,7 +1937,7 @@ void k054539_write(UINT8 Port, UINT8 Offset, UINT8 Data)
 		info->reg_enable = Data;
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1950,7 +1950,7 @@ void k053260_write(UINT8 Register, UINT8 Data)
 	UINT32 Addr;
 	UINT32 CurByt;
 	UINT32 DataLen;
-	
+
 	switch(Register & 0xF8)
 	{
 	case 0x00:	// communication registers
@@ -2031,7 +2031,7 @@ void k053260_write(UINT8 Register, UINT8 Data)
 		}
 		break;
 	}
-	
+
 	return;
 }
 
@@ -2044,16 +2044,16 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 	UINT8 BlkHdr;
 	UINT16 NibbleCnt;
 	UINT32 CurOfs;
-	
+
 	if (! chip->ROMSize)
 		return;
-	
+
 	switch(Port)
 	{
 	case 0x00:	// upd7759_reset_w
 		OldVal = chip->reset;
 		chip->reset = (Data != 0);
-		
+
 		// on the falling edge, reset everything
 		if (OldVal && ! chip->reset)
 		{
@@ -2065,16 +2065,16 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 	case 0x01:	// upd7759_start_w
 		OldVal = chip->start;
 		chip->start = (Data != 0);
-		
+
 		// on the rising edge, if we're idle, start going, but not if we're held in reset
 		if (! (/*chip->state == STATE_IDLE &&*/ ! OldVal && chip->start && chip->reset))
 			break;
-		
+
 		//chip->state = STATE_START;
 		ReqSmpl = chip->fifo_in;
-		
+
 		//chip->state = STATE_FIRST_REQ;
-		
+
 		//chip->state = STATE_LAST_SAMPLE;
 		LastSmpl = chip->ROMData[chip->romoffset | 0x00000];
 		if (ReqSmpl > LastSmpl)
@@ -2082,24 +2082,24 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 			//chip->state = STATE_IDLE;
 			break;
 		}
-		
+
 		//chip->state = STATE_DUMMY1;
 		NibbleCnt = 0x08 + LastSmpl * 2;
 		for (CurOfs = 0x00; CurOfs < NibbleCnt; CurOfs ++)
 			chip->ROMUsage[chip->romoffset | CurOfs] |= 0x01;
-		
+
 		//chip->state = STATE_ADDR_MSB;
 		CurOfs = chip->ROMData[chip->romoffset | (ReqSmpl * 2 + 5)] << 9;
-		
+
 		//chip->state = STATE_ADDR_LSB;
 		CurOfs |= chip->ROMData[chip->romoffset | (ReqSmpl * 2 + 6)] << 1;
-		
+
 		//chip->state = STATE_DUMMY2;
 		chip->ROMUsage[chip->romoffset | (CurOfs & 0x1FFFF)] |= 0x01;
 		CurOfs ++;
 		//chip->first_valid_header = 0;
 		OldVal = 0;
-		
+
 		//chip->state = STATE_BLOCK_HEADER;
 		ReqSmpl = 0x00;	// Exit Loop = 0;
 		do
@@ -2107,7 +2107,7 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 			BlkHdr = chip->ROMData[chip->romoffset | (CurOfs & 0x1FFFF)];
 			chip->ROMUsage[chip->romoffset | (CurOfs & 0x1FFFF)] |= 0x01;
 			CurOfs ++;
-			
+
 			// our next step depends on the top two bits
 			switch(BlkHdr & 0xC0)
 			{
@@ -2135,7 +2135,7 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 				NibbleCnt = 0;
 				break;
 			}
-			
+
 			if (BlkHdr)
 				OldVal = 1;
 			if (NibbleCnt)
@@ -2150,13 +2150,13 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 			}
 		//} while(chip->state == STATE_BLOCK_HEADER);
 		} while(! OldVal || BlkHdr);
-		
+
 		if (CurOfs & 0x01)
 		{
 			// pad to even bytes
 			chip->ROMUsage[chip->romoffset | (CurOfs & 0x1FFFF)] |= 0x01;
 		}
-		
+
 		break;
 	case 0x02:	// upd7759_port_w
 		chip->fifo_in = Data;
@@ -2165,7 +2165,7 @@ void upd7759_write(UINT8 Port, UINT8 Data)
 		chip->romoffset = Data * 0x20000;
 		break;
 	}
-	
+
 	return;
 }
 
@@ -2174,10 +2174,10 @@ void nes_apu_write(UINT8 Register, UINT8 Data)
 	NES_APU_DATA* chip = &ChDat->NES_APU;
 	UINT16 RemBytes;
 	UINT16 CurAddr;
-	
+
 	if (Register >= 0x20)
 		return;
-	
+
 	switch(Register)
 	{
 //	case 0x12:	// APU_WRE2
@@ -2201,7 +2201,7 @@ void nes_apu_write(UINT8 Register, UINT8 Data)
 		break;
 	}
 	chip->RegData[Register] = Data;
-	
+
 	return;
 }
 
@@ -2214,7 +2214,7 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 	UINT32 AddrEnd;
 	UINT32 CurAddr;
 	UINT8 MaskBit;
-	
+
 	switch(Port)
 	{
 	case 0x00:
@@ -2233,7 +2233,7 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 	if (chip->CurSlot == 0xFF)
 		return;
 	TempChn = &chip->slot[chip->CurSlot];
-	
+
 	switch(chip->Address)
 	{
 	case 0x00:	// Pan
@@ -2243,13 +2243,13 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 		if (TempChn->SmplID == Data)
 			return;
 		TempChn->SmplID = Data;
-		
+
 #if 0
 		// mark single sample
 		if (chip->SmplMask[TempChn->SmplID] & 0x80)
 			break;
 		chip->SmplMask[TempChn->SmplID] |= 0x80;
-		
+
 		AddrSt = TempChn->SmplID * 0x0C;
 		AddrEnd = AddrSt + 0x0C;
 #else
@@ -2257,7 +2257,7 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 		if (chip->SmplMask[0x00] & 0x80)
 			break;
 		chip->SmplMask[0x00] |= 0x80;
-		
+
 		AddrSt = 0x00;
 		AddrEnd = 0x200 * 0x0C;
 		// find the real end of the sample table (assume padding with FF)
@@ -2281,7 +2281,7 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 	}
 	if (! TempChn->Playing)
 		return;
-	
+
 	// I use 2 separate bits for BankL (bit 0) and BankR (bit 1)
 	MaskBit = (TempChn->Pan & 0x80) ? 0x01 : 0x02;
 	// Was this sample marked already?
@@ -2289,7 +2289,7 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 		return;
 	// if not, set the bit to speed the process up
 	chip->SmplMask[TempChn->SmplID] |= MaskBit;
-	
+
 	TOCAddr = TempChn->SmplID * 0x0C;
 	AddrSt =	(chip->ROMData[TOCAddr + 0x00] << 16) |
 				(chip->ROMData[TOCAddr + 0x01] <<  8) |
@@ -2302,22 +2302,22 @@ void multipcm_write(UINT8 Port, UINT8 Data)
 		AddrSt |= (TempChn->Pan & 0x80) ? chip->BankL : chip->BankR;
 	}
 	AddrEnd = AddrSt + (0x10000 - AddrEnd);
-	
+
 	for (CurAddr = AddrSt; CurAddr < AddrEnd; CurAddr ++)
 		chip->ROMUsage[CurAddr] |= 0x01;
-	
+
 	return;
 }
 
 void multipcm_bank_write(UINT8 Port, UINT16 Data)
 {
 	MULTIPCM_DATA* chip = &ChDat->MultiPCM;
-	
+
 	if (Port & 0x01)
 		chip->BankL = Data << 16;
 	if (Port & 0x02)
 		chip->BankR = Data << 16;
-	
+
 	return;
 }
 
@@ -2327,26 +2327,26 @@ void x1_010_write(UINT16 offset, UINT8 data)
 	X1_010_CHANNEL *reg;
 	int channel, regi;
 	UINT32 addr, startpos, endpos;
-	
+
 	channel = offset/sizeof(X1_010_CHANNEL);
 	regi    = offset%sizeof(X1_010_CHANNEL);
-	
+
 	/* Control register write */
 	if( channel < SETA_NUM_CHANNELS && regi == 0)
 	{
 		reg = (X1_010_CHANNEL *)&(chip->m_reg[channel*sizeof(X1_010_CHANNEL)]);
-		
+
 		/* Key on and PCM mode set? */
-		
+
 		// check at key off (or next status write). Leaving this in case the other condition breaks something.
 		//if( (reg->status&1) && !(reg->status&2) )
-		
+
 		// Check at key on. should work better for guardians.
 		if((data&1) && !(data&02))
 		{
 			startpos = reg->start*0x1000;
 			endpos = ((0x100-reg->end)*0x1000)&0xfffff;
-			
+
 			for (addr = startpos; addr < endpos; addr ++)
 				chip->ROMUsage[addr] |= 0x01;
 		}
@@ -2361,12 +2361,12 @@ void c352_write(UINT16 Offset, UINT16 val)
 	C352_CHANNEL* TempChn;
 	UINT16 address = Offset* 2;
 	UINT32 addr, startpos, endpos, reptpos;
-	
+
 	UINT16 chan;
 	int i, rev, wrap, ldir;
-	
+
 	chan = (address >> 4) & 0xfff;
-	
+
 	if (address >= 0x400)
 	{
 		switch(address)
@@ -2381,26 +2381,26 @@ void c352_write(UINT16 Offset, UINT16 val)
 					{
 						rev = TempChn->flag & C352_FLG_REVERSE;
 						ldir = TempChn->flag & C352_FLG_LDIR;
-						
+
 						// reverse loops are actually bidirectional, the loop direction flag decides
 						// the initial direction. If it is unset, the sample will play "forwards" first
 						// and should thus be treated as a forwards sample
 						if((TempChn->flag & C352_FLG_LOOP) && !ldir)
 							rev = 0;
-						
+
 						wrap = rev ? TempChn->end_addr > TempChn->start_addr
 								   : TempChn->end_addr < TempChn->start_addr;
-						
+
 						startpos = wrap && rev ? ((TempChn->bank-1)<<16) : (TempChn->bank<<16);
 						endpos = wrap && !rev ? ((TempChn->bank+1)<<16) : (TempChn->bank<<16);
 						reptpos = (endpos & 0x00FF0000) + TempChn->repeat_addr;
-						
+
 						startpos += rev ? TempChn->end_addr : TempChn->start_addr;
 						endpos += rev ? TempChn->start_addr : TempChn->end_addr;
-						
+
 						if ((TempChn->flag & C352_FLG_LOOP) && reptpos<startpos)
 							startpos=reptpos;
-						
+
 						if (startpos < chip->ROMSize)
 						{
 							if (endpos <= chip->ROMSize)
@@ -2434,7 +2434,7 @@ void c352_write(UINT16 Offset, UINT16 val)
 		}
 		return;
 	}
-	
+
 	if (chan > 31)
 		return;
 	TempChn = &chip->channels[chan];
@@ -2476,12 +2476,12 @@ void c352_write(UINT16 Offset, UINT16 val)
 	default:
 		break;
 	}
-	
+
 	if (startpos != (UINT32)-1)
 	{
 		if (startpos >= chip->ROMSize)
 			return;
-		
+
 		if (endpos < startpos)
 			endpos += 0x10000;
 		if (endpos <= chip->ROMSize)
@@ -2508,7 +2508,7 @@ void ga20_write(UINT8 offset, UINT8 data)
 	GA20_CHANNEL* TempChn;
 	int channel;
 	UINT32 addr, startpos, endpos;
-	
+
 	channel = offset >> 3;
 	TempChn = &chip->channels[channel];
 	switch (offset & 0x7)
@@ -2548,7 +2548,7 @@ void es5503_write(UINT8 Register, UINT8 Data)
 	UINT32 AddrSt;
 	UINT32 AddrEnd;
 	UINT32 CurAddr;
-	
+
 	if (Register < 0xE0)
 	{
 		TempOsc = &chip->oscillators[Register & 0x1F];
@@ -2571,7 +2571,7 @@ void es5503_write(UINT8 Register, UINT8 Data)
 			{
 				if ((TempOsc->control & 0x08) && ! TempOsc->vol)
 					break;	// IRQ + Vol 0 -> probably used for timing
-				
+
 				AddrSt = TempOsc->wavetblpointer & es5503_wavemasks[TempOsc->wavetblsize];
 				AddrEnd = AddrSt + TempOsc->wtsize;
 				for (CurAddr = AddrSt; CurAddr < AddrEnd; CurAddr ++)
@@ -2583,7 +2583,7 @@ void es5503_write(UINT8 Register, UINT8 Data)
 				if ((TempOsc->control & 0x06) == 0x06)	// 'swap' mode
 				{
 					TempOsc = &chip->oscillators[(Register & 0x1F) ^ 0x01];
-					
+
 					AddrSt = TempOsc->wavetblpointer & es5503_wavemasks[TempOsc->wavetblsize];
 					AddrEnd = AddrSt + TempOsc->wtsize;
 					for (CurAddr = AddrSt; CurAddr < AddrEnd; CurAddr ++)
@@ -2600,7 +2600,7 @@ void es5503_write(UINT8 Register, UINT8 Data)
 				TempOsc->wavetblpointer |= 0x10000;
 			else
 				TempOsc->wavetblpointer &= 0x0FFFF;
-			
+
 			TempOsc->wavetblsize = (Data & 0x38) >> 3;
 			TempOsc->wtsize = 0x100 << TempOsc->wavetblsize;
 			//TempOsc->resolution = (Data & 0x07);
@@ -2616,7 +2616,7 @@ void es5503_write(UINT8 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	return;
 }
 
@@ -2631,7 +2631,7 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	UINT32 AddrEnd;
 	UINT32 CurAddr;
 	UINT16 tblBaseSmpl;
-	
+
 	if (Port != 0x02)	// Port 0/1 = FM, Port 2 = PCM
 		return;
 	if (Register >= 0x08 && Register < 0xF8)
@@ -2643,19 +2643,19 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		case 0x00:	// Sample ID LSB (bits 0-7)
 			slot->SmplID &= 0x100;
 			slot->SmplID |= Data;
-			
+
 			if (slot->SmplID < 384 || ! chip->wavetblhdr)
 				tblBaseSmpl = 0;
 			else
 				tblBaseSmpl = 384;
-			
+
 			// --- mark Sample Table ---
 #if 0
 			// mark single sample
 			if (! (chip->SmplMask[slot->SmplID] & 0x80))
 			{
 				chip->SmplMask[slot->SmplID] |= 0x80;
-				
+
 				if (slot->SmplID < 384 || ! chip->wavetblhdr)
 					AddrSt = slot->SmplID * 0x0C;
 				else
@@ -2680,9 +2680,9 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			{
 				const UINT8* MemData;
 				UINT8* MemUsage;
-				
+
 				chip->SmplMask[tblBaseSmpl] |= 0x80;
-				
+
 				AddrSt = (tblBaseSmpl) ? (chip->wavetblhdr * 0x80000) : 0x00;
 				// get address of first sample
 				if (AddrSt < chip->RAMBase)
@@ -2719,7 +2719,7 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 					if (AddrEnd > 512 * 0x0C)
 						AddrEnd = 512 * 0x0C;
 				}
-				
+
 				if (AddrSt < chip->RAMBase)
 				{
 					MemData = chip->ROMData;
@@ -2745,14 +2745,14 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 					MemUsage[CurAddr] |= 0x01;
 			}
 #endif
-			
+
 			// --- mark actual Sample Data ---
 			if (! (chip->SmplMask[slot->SmplID] & 0x01))
 			{
 				const UINT8* MemData;
-				
+
 				chip->SmplMask[slot->SmplID] |= 0x01;
-				
+
 				if (slot->SmplID < 384 || ! chip->wavetblhdr)
 					TOCAddr = slot->SmplID * 0x0C;
 				else
@@ -2787,7 +2787,7 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 				else if (SmplBits == 3)	// invalid
 					AddrEnd = 0;
 				AddrEnd += AddrSt;
-				
+
 				if (AddrSt < chip->RAMBase)
 				{
 					printf("mark Sample %u, ROM offset 0x%06X\n", slot->SmplID, AddrSt);
@@ -2828,7 +2828,7 @@ void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	return;
 }
 
@@ -2839,17 +2839,17 @@ static void es550x_do_ctrl(ES5506_DATA* chip, ES5506_VOICE* voice)
 	UINT32 AddrSt;
 	UINT32 AddrEnd;
 	UINT32 CurAddr;
-	
+
 	if ((chip->curPage & 0x1F) >= chip->voiceCount)
 		return;
 	if (voice->control & ES6CTRL_STOPMASK)
 		return;
-	
+
 	if (voice->start == voice->end)
 		return;
 	if (voice->start > voice->end)
 		return;
-	
+
 	CurAddr = voice->accum >> 11;
 	AddrSt = voice->start >> 11;
 	AddrEnd = voice->end >> 11;
@@ -2866,13 +2866,13 @@ static void es550x_do_ctrl(ES5506_DATA* chip, ES5506_VOICE* voice)
 			AddrEnd = CurAddr;
 	}
 	AddrEnd ++;	// turn <= into <
-	
+
 	// Offsets are indices into 16-Bit data.
 	baseOfs *= 2;
 	AddrSt *= 2;	AddrEnd *= 2;
 	for (CurAddr = AddrSt; CurAddr < AddrEnd; CurAddr ++)
 		romBase->ROMUsage[baseOfs + CurAddr] |= 0x01;
-	
+
 	return;
 }
 
@@ -2885,13 +2885,13 @@ static void es5506_w(ES5506_DATA* chip, UINT8 Offset, UINT8 Data)
 	ES5506_VOICE* voice = &chip->voice[chip->curPage & 0x1F];
 	int shift = 8 * (Offset & 0x03);
 	Offset >>= 2;
-	
+
 	// build a 32-Bit Big Endian value
 	chip->writeLatch &= ~(0xFF000000 >> shift);
 	chip->writeLatch |= (Data << (24 - shift));
 	if (shift != 24)
 		return;
-	
+
 	if (Offset >= 0x68/8)	// PAGE
 	{
 		switch(Offset)
@@ -2968,9 +2968,9 @@ static void es5506_w(ES5506_DATA* chip, UINT8 Offset, UINT8 Data)
 		// es5506_reg_write_test
 		// nothing important here
 	}
-	
+
 	chip->writeLatch = 0;
-	
+
 	return;
 }
 
@@ -2978,13 +2978,13 @@ static void es5506_w(ES5506_DATA* chip, UINT8 Offset, UINT8 Data)
 void es550x_w(UINT8 Offset, UINT8 Data)
 {
 	ES5506_DATA* chip = &ChDat->ES5506;
-	
+
 	if (Offset == 0xFF)
 	{
 		chip->chipType = Data;
 		return;
 	}
-	
+
 	if (Offset < 0x40)
 	{
 		if (! chip->chipType)
@@ -3002,7 +3002,7 @@ void es550x_w(UINT8 Offset, UINT8 Data)
 void es550x_w16(UINT8 Offset, UINT16 Data)
 {
 	ES5506_DATA* chip = &ChDat->ES5506;
-	
+
 	if (Offset < 0x40)
 	{
 		if (! chip->chipType)
@@ -3053,7 +3053,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 	X1_010_DATA* x1_010;
 	C352_DATA* c352;
 	GA20_DATA* ga20;
-	
+
 	switch(ROMType)
 	{
 	case 0x80:	// SegaPCM ROM
@@ -3061,37 +3061,37 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 		if (spcm->ROMSize != ROMSize)
 		{
 			UINT32 mask, rom_mask;
-			
+
 			// fix wrong ROM Sizes (like 0x60000)
 			for (rom_mask = 1; rom_mask < ROMSize; rom_mask *= 2);
 			ROMSize = rom_mask;
-			
+
 			spcm->ROMData = (UINT8*)realloc(spcm->ROMData, ROMSize);
 			spcm->ROMUsage = (UINT8*)realloc(spcm->ROMUsage, ROMSize);
 			spcm->ROMSize = ROMSize;
 			memset(spcm->ROMData, 0xFF, ROMSize);
 			memset(spcm->ROMUsage, 0x02, ROMSize);
-			
+
 			// recalculate bankmask
 			spcm->bankshift = (UINT8)(spcm->intf_bank);
 			mask = spcm->intf_bank >> 16;
 			if (! mask)
 				mask = SPCM_BANK_MASK7 >> 16;
-			
+
 			spcm->rgnmask = ROMSize - 1;
 			for (rom_mask = 1; rom_mask < ROMSize; rom_mask *= 2);
 			rom_mask --;
-			
+
 			spcm->bankmask = mask & (rom_mask >> spcm->bankshift);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(spcm->ROMData + DataStart, ROMData, DataLength);
 		memset(spcm->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x81:	// YM2608 DELTA-T ROM
 		ym2608 = &ChDat->YM2608;
-		
+
 		if (ym2608->DT_ROMSize != ROMSize)
 		{
 			ym2608->DT_ROMData = (UINT8*)realloc(ym2608->DT_ROMData, ROMSize);
@@ -3099,19 +3099,19 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			ym2608->DT_ROMSize = ROMSize;
 			memset(ym2608->DT_ROMData, 0xFF, ROMSize);
 			memset(ym2608->DT_ROMUsage, 0x02, ROMSize);
-			
+
 			ym2608->DeltaT.memory_size = ym2608->DT_ROMSize;
 			ym2608->DeltaT.memory = ym2608->DT_ROMData;
 			ym2608->DeltaT.memory_usg = ym2608->DT_ROMUsage;
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ym2608->DT_ROMData + DataStart, ROMData, DataLength);
 		memset(ym2608->DT_ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x82:	// YM2610 ADPCM ROM
 		ym2610 = &ChDat->YM2610;
-		
+
 		if (ym2610->AP_ROMSize != ROMSize)
 		{
 			ym2610->AP_ROMData = (UINT8*)realloc(ym2610->AP_ROMData, ROMSize);
@@ -3120,14 +3120,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(ym2610->AP_ROMData, 0xFF, ROMSize);
 			memset(ym2610->AP_ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ym2610->AP_ROMData + DataStart, ROMData, DataLength);
 		memset(ym2610->AP_ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x83:	// YM2610 DELTA-T ROM
 		ym2610 = &ChDat->YM2610;
-		
+
 		if (ym2610->DT_ROMSize != ROMSize)
 		{
 			ym2610->DT_ROMData = (UINT8*)realloc(ym2610->DT_ROMData, ROMSize);
@@ -3135,19 +3135,19 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			ym2610->DT_ROMSize = ROMSize;
 			memset(ym2610->DT_ROMData, 0xFF, ROMSize);
 			memset(ym2610->DT_ROMUsage, 0x02, ROMSize);
-			
+
 			ym2610->DeltaT.memory_size = ym2610->DT_ROMSize;
 			ym2610->DeltaT.memory = ym2610->DT_ROMData;
 			ym2610->DeltaT.memory_usg = ym2610->DT_ROMUsage;
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ym2610->DT_ROMData + DataStart, ROMData, DataLength);
 		memset(ym2610->DT_ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x84:	// YMF278B ROM
 		ymf278 = &ChDat->YMF278B;
-		
+
 		if (ymf278->ROMSize != ROMSize)
 		{
 			ymf278->ROMData = (UINT8*)realloc(ymf278->ROMData, ROMSize);
@@ -3157,14 +3157,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(ymf278->ROMData, 0xFF, ROMSize);
 			memset(ymf278->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ymf278->ROMData + DataStart, ROMData, DataLength);
 		memset(ymf278->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x85:	// YMF271 ROM
 		ymf271 = &ChDat->YMF271;
-		
+
 		if (ymf271->ROMSize != ROMSize)
 		{
 			ymf271->ROMData = (UINT8*)realloc(ymf271->ROMData, ROMSize);
@@ -3173,14 +3173,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(ymf271->ROMData, 0xFF, ROMSize);
 			memset(ymf271->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ymf271->ROMData + DataStart, ROMData, DataLength);
 		memset(ymf271->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x86:	// YMZ280B ROM
 		ymz280b = &ChDat->YMZ280B;
-		
+
 		if (ymz280b->ROMSize != ROMSize)
 		{
 			ymz280b->ROMData = (UINT8*)realloc(ymz280b->ROMData, ROMSize);
@@ -3189,14 +3189,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(ymz280b->ROMData, 0xFF, ROMSize);
 			memset(ymz280b->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ymz280b->ROMData + DataStart, ROMData, DataLength);
 		memset(ymz280b->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x87:	// YMF278B RAM
 		ymf278 = &ChDat->YMF278B;
-		
+
 		if (ymf278->RAMSize != ROMSize)
 		{
 			ymf278->RAMData = (UINT8*)realloc(ymf278->RAMData, ROMSize);
@@ -3205,14 +3205,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(ymf278->RAMData, 0xFF, ROMSize);
 			memset(ymf278->RAMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(ymf278->RAMData + DataStart, ROMData, DataLength);
 		memset(ymf278->RAMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x88:	// Y8950 DELTA-T ROM
 		y8950 = &ChDat->Y8950;
-		
+
 		if (y8950->DT_ROMSize != ROMSize)
 		{
 			y8950->DT_ROMData = (UINT8*)realloc(y8950->DT_ROMData, ROMSize);
@@ -3220,19 +3220,19 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			y8950->DT_ROMSize = ROMSize;
 			memset(y8950->DT_ROMData, 0xFF, ROMSize);
 			memset(y8950->DT_ROMUsage, 0x02, ROMSize);
-			
+
 			y8950->DeltaT.memory_size = y8950->DT_ROMSize;
 			y8950->DeltaT.memory = y8950->DT_ROMData;
 			y8950->DeltaT.memory_usg = y8950->DT_ROMUsage;
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(y8950->DT_ROMData + DataStart, ROMData, DataLength);
 		memset(y8950->DT_ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x89:	// MultiPCM ROM
 		multipcm = &ChDat->MultiPCM;
-		
+
 		if (multipcm->ROMSize != ROMSize)
 		{
 			multipcm->ROMData = (UINT8*)realloc(multipcm->ROMData, ROMSize);
@@ -3242,14 +3242,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(multipcm->ROMUsage, 0x02, ROMSize);
 			memset(multipcm->SmplMask, 0x00, 0x200);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(multipcm->ROMData + DataStart, ROMData, DataLength);
 		memset(multipcm->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x8A:	// uPD7759 ROM
 		upd7759 = &ChDat->UPD7759;
-		
+
 		if (upd7759->ROMSize != ROMSize)
 		{
 			upd7759->ROMData = (UINT8*)realloc(upd7759->ROMData, ROMSize);
@@ -3258,14 +3258,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(upd7759->ROMData, 0xFF, ROMSize);
 			memset(upd7759->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(upd7759->ROMData + DataStart, ROMData, DataLength);
 		memset(upd7759->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x8B:	// OKIM6295 ROM
 		okim6295 = &ChDat->OKIM6295;
-		
+
 		if (okim6295->ROMSize != ROMSize)
 		{
 			okim6295->ROMData = (UINT8*)realloc(okim6295->ROMData, ROMSize);
@@ -3274,14 +3274,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(okim6295->ROMData, 0xFF, ROMSize);
 			memset(okim6295->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(okim6295->ROMData + DataStart, ROMData, DataLength);
 		memset(okim6295->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x8C:	// K054539 ROM
 		k054539 = &ChDat->K054539;
-		
+
 		if (k054539->ROMSize != ROMSize)
 		{
 			k054539->ROMData = (UINT8*)realloc(k054539->ROMData, ROMSize);
@@ -3290,14 +3290,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(k054539->ROMData, 0xFF, ROMSize);
 			memset(k054539->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(k054539->ROMData + DataStart, ROMData, DataLength);
 		memset(k054539->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x8D:	// C140 ROM
 		c140 = &ChDat->C140;
-		
+
 		if (c140->ROMSize != ROMSize)
 		{
 			c140->ROMData = (UINT8*)realloc(c140->ROMData, ROMSize);
@@ -3306,14 +3306,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(c140->ROMData, 0xFF, ROMSize);
 			memset(c140->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(c140->ROMData + DataStart, ROMData, DataLength);
 		memset(c140->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x8E:	// K053260 ROM
 		k053260 = &ChDat->K053260;
-		
+
 		if (k053260->ROMSize != ROMSize)
 		{
 			k053260->ROMData = (UINT8*)realloc(k053260->ROMData, ROMSize);
@@ -3322,14 +3322,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(k053260->ROMData, 0xFF, ROMSize);
 			memset(k053260->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(k053260->ROMData + DataStart, ROMData, DataLength);
 		memset(k053260->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x8F:	// QSound ROM
 		qsound = &ChDat->QSound;
-		
+
 		if (qsound->ROMSize != ROMSize)
 		{
 			qsound->ROMData = (UINT8*)realloc(qsound->ROMData, ROMSize);
@@ -3338,7 +3338,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(qsound->ROMData, 0xFF, ROMSize);
 			memset(qsound->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(qsound->ROMData + DataStart, ROMData, DataLength);
 		memset(qsound->ROMUsage + DataStart, 0x00, DataLength);
@@ -3348,7 +3348,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			UINT8 curRgn;
 			UINT8 is8Bit;	// 8-bit ROM mapped to 16-bit address space
 			ES5506_ROM* esRgn;
-			
+
 			es5506 = &ChDat->ES5506;
 			curRgn = (DataStart >> 28) & 0x03;
 			is8Bit = (DataStart >> 31) & 0x01;
@@ -3358,7 +3358,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 				printf("Error! ES5506 using 8-Bit Sample ROM!\n");
 				return;
 			}
-			
+
 			esRgn = &es5506->Rgn[curRgn];
 			if (esRgn->ROMSize != ROMSize)
 			{
@@ -3368,7 +3368,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 				memset(esRgn->ROMData, 0xFF, ROMSize);
 				memset(esRgn->ROMUsage, 0x02, ROMSize);
 			}
-			
+
 			ROM_BORDER_CHECK
 			memcpy(esRgn->ROMData + DataStart, ROMData, DataLength);
 			memset(esRgn->ROMUsage + DataStart, 0x00, DataLength);
@@ -3376,7 +3376,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 		break;
 	case 0x91:	// X1-010 ROM
 		x1_010 = &ChDat->X1_010;
-		
+
 		if (x1_010->ROMSize != ROMSize)
 		{
 			x1_010->ROMData = (INT8*)realloc(x1_010->ROMData, ROMSize);
@@ -3390,7 +3390,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 		break;
 	case 0x92:	// C352 ROM
 		c352 = &ChDat->C352;
-		
+
 		if (c352->ROMSize != ROMSize)
 		{
 			c352->ROMData = (INT8*)realloc(c352->ROMData, ROMSize);
@@ -3399,13 +3399,13 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(c352->ROMData, 0xFF, ROMSize);
 			memset(c352->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		memcpy(c352->ROMData + DataStart, ROMData, DataLength);
 		memset(c352->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0x93:	// GA20 ROM
 		ga20 = &ChDat->GA20;
-		
+
 		if (ga20->ROMSize != ROMSize)
 		{
 			ga20->ROMData = (UINT8*)realloc(ga20->ROMData, ROMSize);
@@ -3414,14 +3414,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(ga20->ROMData, 0xFF, ROMSize);
 			memset(ga20->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		memcpy(ga20->ROMData + DataStart, ROMData, DataLength);
 		memset(ga20->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0xC0:	// RF5C68 RAM
 	case 0xC1:	// RF5C164 RAM
 		rf5c = (ROMType == 0xC0) ? &ChDat->RF5C68 : &ChDat->RF5C164;
-		
+
 		ROMSize = 0x10000;
 		if (rf5c->RAMSize != ROMSize)
 		{
@@ -3431,7 +3431,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(rf5c->RAMData, 0xFF, ROMSize);
 			memset(rf5c->RAMUsage, 0x02, ROMSize);
 		}
-		
+
 		DataStart += rf5c->SelBank;
 		ROM_BORDER_CHECK
 		memcpy(rf5c->RAMData + DataStart, ROMData, DataLength);
@@ -3439,7 +3439,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 		break;
 	case 0xC2:	// NES APU ROM Bank
 		nes_apu = &ChDat->NES_APU;
-		
+
 		ROMSize = 0x10000;
 		if (nes_apu->ROMSize != ROMSize)
 		{
@@ -3449,14 +3449,14 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(nes_apu->ROMData, 0xFF, ROMSize);
 			memset(nes_apu->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(nes_apu->ROMData + DataStart, ROMData, DataLength);
 		memset(nes_apu->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	case 0xE1:	// ES5503 RAM
 		es5503 = &ChDat->ES5503;
-		
+
 		ROMSize = 0x20000;
 		if (es5503->ROMSize != ROMSize)
 		{
@@ -3466,13 +3466,13 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 			memset(es5503->ROMData, 0xFF, ROMSize);
 			memset(es5503->ROMUsage, 0x02, ROMSize);
 		}
-		
+
 		ROM_BORDER_CHECK
 		memcpy(es5503->ROMData + DataStart, ROMData, DataLength);
 		memset(es5503->ROMUsage + DataStart, 0x00, DataLength);
 		break;
 	}
-	
+
 	return;
 }
 
@@ -3499,132 +3499,132 @@ UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData)
 	X1_010_DATA* x1_010;
 	C352_DATA* c352;
 	GA20_DATA* ga20;
-	
+
 	switch(ROMType)
 	{
 	case 0x80:	// SegaPCM ROM
 		spcm = &ChDat->SegaPCM;
-		
+
 		*MaskData = spcm->ROMUsage;
 		return spcm->ROMSize;
 	case 0x81:	// YM2608 DELTA-T ROM
 		ym2608 = &ChDat->YM2608;
-		
+
 		*MaskData = ym2608->DT_ROMUsage;
 		return ym2608->DT_ROMSize;
 	case 0x82:	// YM2610 ADPCM ROM
 		ym2610 = &ChDat->YM2610;
-		
+
 		*MaskData = ym2610->AP_ROMUsage;
 		return ym2610->AP_ROMSize;
 	case 0x83:	// YM2610 DELTA-T ROM
 		ym2610 = &ChDat->YM2610;
-		
+
 		*MaskData = ym2610->DT_ROMUsage;
 		return ym2610->DT_ROMSize;
 	case 0x84:	// YMF278B ROM
 		ymf278 = &ChDat->YMF278B;
-		
+
 		*MaskData = ymf278->ROMUsage;
 		return ymf278->ROMSize;
 	case 0x85:	// YMF271 ROM
 		ymf271 = &ChDat->YMF271;
-		
+
 		*MaskData = ymf271->ROMUsage;
 		return ymf271->ROMSize;
 	case 0x86:	// YMZ280B ROM
 		ymz280b = &ChDat->YMZ280B;
-		
+
 		*MaskData = ymz280b->ROMUsage;
 		return ymz280b->ROMSize;
 	case 0x87:	// YMF278B RAM
 		ymf278 = &ChDat->YMF278B;
-		
+
 		*MaskData = ymf278->RAMUsage;
 		return ymf278->RAMSize;
 	case 0x88:	// Y8950 DELTA-T ROM
 		y8950 = &ChDat->Y8950;
-		
+
 		*MaskData = y8950->DT_ROMUsage;
 		return y8950->DT_ROMSize;
 	case 0x89:	// MultiPCM ROM
 		multipcm = &ChDat->MultiPCM;
-		
+
 		*MaskData = multipcm->ROMUsage;
 		return multipcm->ROMSize;
 	case 0x8A:	// uPD7759 ROM
 		upd7759 = &ChDat->UPD7759;
-		
+
 		*MaskData = upd7759->ROMUsage;
 		return upd7759->ROMSize;
 	case 0x8B:	// OKIM6295 ROM
 		okim6295 = &ChDat->OKIM6295;
-		
+
 		*MaskData = okim6295->ROMUsage;
 		return okim6295->ROMSize;
 	case 0x8C:	// K054539 ROM
 		k054539 = &ChDat->K054539;
-		
+
 		*MaskData = k054539->ROMUsage;
 		return k054539->ROMSize;
 	case 0x8D:	// C140 ROM
 		c140 = &ChDat->C140;
-		
+
 		*MaskData = c140->ROMUsage;
 		return c140->ROMSize;
 	case 0x8E:	// K053260 ROM
 		k053260 = &ChDat->K053260;
-		
+
 		*MaskData = k053260->ROMUsage;
 		return k053260->ROMSize;
 		break;
 	case 0x8F:	// QSound ROM
 		qsound = &ChDat->QSound;
-		
+
 		*MaskData = qsound->ROMUsage;
 		return qsound->ROMSize;
 	case 0x90:	// ES5506 ROM
 		es5506 = &ChDat->ES5506;
-		
+
 		*MaskData = es5506->Rgn->ROMUsage;
 		return es5506->Rgn->ROMSize;
 	case 0x91:	// X1-010 ROM
 		x1_010 = &ChDat->X1_010;
-		
+
 		*MaskData = x1_010->ROMUsage;
 		return x1_010->ROMSize;
 	case 0x92:	// C352 ROM
 		c352 = &ChDat->C352;
-		
+
 		*MaskData = c352->ROMUsage;
 		return c352->ROMSize;
 	case 0x93:	// GA20 ROM
 		ga20 = &ChDat->GA20;
-		
+
 		*MaskData = ga20->ROMUsage;
 		return ga20->ROMSize;
 	case 0xC0:	// RF5C68 RAM
 		rf5c = &ChDat->RF5C68;
-		
+
 		*MaskData = rf5c->RAMUsage;
 		return rf5c->RAMSize;
 	case 0xC1:	// RF5C164 RAM
 		rf5c = &ChDat->RF5C164;
-		
+
 		*MaskData = rf5c->RAMUsage;
 		return rf5c->RAMSize;
 	case 0xC2:	// NES APU ROM Bank
 		nes_apu = &ChDat->NES_APU;
-		
+
 		*MaskData = nes_apu->ROMUsage;
 		return nes_apu->ROMSize;
 	case 0xE1:	// ES5503 RAM
 		es5503 = &ChDat->ES5503;
-		
+
 		*MaskData = es5503->ROMUsage;
 		return es5503->ROMSize;
 	}
-	
+
 	return 0x00;
 }
 
@@ -3651,97 +3651,97 @@ UINT32 GetROMData(UINT8 ROMType, UINT8** ROMData)
 	X1_010_DATA* x1_010;
 	C352_DATA* c352;
 	GA20_DATA* ga20;
-	
+
 	switch(ROMType)
 	{
 	case 0x80:	// SegaPCM ROM
 		spcm = &ChDat->SegaPCM;
-		
+
 		*ROMData = spcm->ROMData;
 		return spcm->ROMSize;
 	case 0x81:	// YM2608 DELTA-T ROM
 		ym2608 = &ChDat->YM2608;
-		
+
 		*ROMData = ym2608->DT_ROMData;
 		return ym2608->DT_ROMSize;
 	case 0x82:	// YM2610 ADPCM ROM
 		ym2610 = &ChDat->YM2610;
-		
+
 		*ROMData = ym2610->AP_ROMData;
 		return ym2610->AP_ROMSize;
 	case 0x83:	// YM2610 DELTA-T ROM
 		ym2610 = &ChDat->YM2610;
-		
+
 		*ROMData = ym2610->DT_ROMData;
 		return ym2610->DT_ROMSize;
 	case 0x84:	// YMF278B ROM
 		ymf278 = &ChDat->YMF278B;
-		
+
 		*ROMData = ymf278->ROMData;
 		return ymf278->ROMSize;
 	case 0x85:	// YMF271 ROM
 		ymf271 = &ChDat->YMF271;
-		
+
 		*ROMData = ymf271->ROMData;
 		return ymf271->ROMSize;
 	case 0x86:	// YMZ280B ROM
 		ymz280b = &ChDat->YMZ280B;
-		
+
 		*ROMData = ymz280b->ROMData;
 		return ymz280b->ROMSize;
 	case 0x87:	// YMF278B RAM
 		ymf278 = &ChDat->YMF278B;
-		
+
 		*ROMData = ymf278->RAMData;
 		return ymf278->RAMSize;
 	case 0x88:	// Y8950 DELTA-T ROM
 		y8950 = &ChDat->Y8950;
-		
+
 		*ROMData = y8950->DT_ROMData;
 		return y8950->DT_ROMSize;
 	case 0x89:	// MultiPCM ROM
 		multipcm = &ChDat->MultiPCM;
-		
+
 		*ROMData = multipcm->ROMData;
 		return multipcm->ROMSize;
 	case 0x8A:	// uPD7759 ROM
 		upd7759 = &ChDat->UPD7759;
-		
+
 		*ROMData = upd7759->ROMData;
 		return upd7759->ROMSize;
 	case 0x8B:	// OKIM6295 ROM
 		okim6295 = &ChDat->OKIM6295;
-		
+
 		*ROMData = okim6295->ROMData;
 		return okim6295->ROMSize;
 	case 0x8C:	// K054539 ROM
 		k054539 = &ChDat->K054539;
-		
+
 		*ROMData = k054539->ROMData;
 		return k054539->ROMSize;
 	case 0x8D:	// C140 ROM
 		c140 = &ChDat->C140;
-		
+
 		*ROMData = c140->ROMData;
 		return c140->ROMSize;
 	case 0x8E:	// K053260 ROM
 		k053260 = &ChDat->K053260;
-		
+
 		*ROMData = k053260->ROMData;
 		return k053260->ROMSize;
 	case 0x8F:	// QSound ROM
 		qsound = &ChDat->QSound;
-		
+
 		*ROMData = qsound->ROMData;
 		return qsound->ROMSize;
 	case 0x90:	// ES5506 ROM
 		es5506 = &ChDat->ES5506;
-		
+
 		*ROMData = es5506->Rgn->ROMData;
 		return es5506->Rgn->ROMSize;
 	case 0x91:	// X1-010 ROM
 		x1_010 = &ChDat->X1_010;
-		
+
 		*ROMData = (UINT8*)x1_010->ROMData;
 		return x1_010->ROMSize;
 	case 0x92:	// C352 ROM
@@ -3751,30 +3751,30 @@ UINT32 GetROMData(UINT8 ROMType, UINT8** ROMData)
 		return c352->ROMSize;
 	case 0x93:	// GA20 ROM
 		ga20 = &ChDat->GA20;
-		
+
 		*ROMData = ga20->ROMData;
 		return ga20->ROMSize;
 	case 0xC0:	// RF5C68 RAM
 		rf5c = &ChDat->RF5C68;
-		
+
 		*ROMData = rf5c->RAMData;
 		return rf5c->RAMSize;
 	case 0xC1:	// RF5C164 RAM
 		rf5c = &ChDat->RF5C164;
-		
+
 		*ROMData = rf5c->RAMData;
 		return rf5c->RAMSize;
 	case 0xC2:	// NES APU ROM Bank
 		nes_apu = &ChDat->NES_APU;
-		
+
 		*ROMData = nes_apu->ROMData;
 		return nes_apu->ROMSize;
 	case 0xE1:	// ES5503 RAM
 		es5503 = &ChDat->ES5503;
-		
+
 		*ROMData = es5503->ROMData;
 		return es5503->ROMSize;
 	}
-	
+
 	return 0x00;
 }

--- a/chip_strp.c
+++ b/chip_strp.c
@@ -139,16 +139,16 @@ STRIP_DATA* StpDat;
 void InitAllChips(void)
 {
 	UINT8 CurChip;
-	
+
 	if (ChipData == NULL)
 		ChipData = (ALL_CHIPS*)malloc(ChipCount * sizeof(ALL_CHIPS));
 	for (CurChip = 0x00; CurChip < ChipCount; CurChip ++)
 	{
 		memset(ChipData, 0xFF, ChipCount * sizeof(ALL_CHIPS));
 	}
-	
+
 	SetChipSet(0x00);
-	
+
 	return;
 }
 
@@ -156,10 +156,10 @@ void FreeAllChips(void)
 {
 	if (ChipData == NULL)
 		return;
-	
+
 	free(ChipData);
 	ChipData = NULL;
-	
+
 	return;
 }
 
@@ -167,17 +167,17 @@ void SetChipSet(UINT8 ChipID)
 {
 	ChDat = ChipData + ChipID;
 	StpDat = StripVGM + ChipID;
-	
+
 	return;
 }
 
 bool GGStereo(UINT8 Data)
 {
 	STRIP_PSG* strip = &StpDat->SN76496;
-	
+
 	if (strip->All || (strip->Other & 0x01))
 		return false;
-	
+
 	return true;
 }
 
@@ -186,10 +186,10 @@ bool sn76496_write(UINT8 Command)
 	SN76496_DATA* chip = &ChDat->SN76496;
 	STRIP_PSG* strip = &StpDat->SN76496;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
-	
+
 	if (Command & 0x80)
 	{
 		Channel = (Command & 0x60) >> 1;
@@ -199,7 +199,7 @@ bool sn76496_write(UINT8 Command)
 	{
 		Channel = chip->LastChn;
 	}
-	
+
 	if (strip->ChnMask & (0x01 << Channel))
 		return false;
 	return true;
@@ -208,7 +208,7 @@ bool sn76496_write(UINT8 Command)
 bool ym2413_write(UINT8 Register, UINT8 Data)
 {
 	STRIP_OPL* strip = &StpDat->YM2413;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -223,7 +223,7 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	STRIP_OPN* strip = &StpDat->YM2612;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -238,10 +238,10 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	// no OPN Prescaler Registers for YM2612
 	case 0x28:
 		Channel = Data & 0x07;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = 0x00;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -266,10 +266,10 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			RegVal &= 0x0FC;	// Registers A4-A6 (AC-AE for Ch3) write to the same offset
 			break;*/
 		}
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
@@ -282,7 +282,7 @@ bool ym2151_write(UINT8 Register, UINT8 Data)
 	YM2151_DATA* chip;
 	STRIP_OPM* strip = &StpDat->YM2151;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -293,14 +293,14 @@ bool ym2151_write(UINT8 Register, UINT8 Data)
 		Channel = Data & 0x07;
 		if (! chip->MCFirst[Channel] && (Data & 0xF8) == chip->MCMask[Channel])
 			return false;
-		
+
 		chip->MCFirst[Channel] = 0x00;
 		chip->MCMask[Channel] = Data & 0xF8;
 		break;
 	default:
 		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 			return false;
-		
+
 		chip->RegFirst[Register] = 0x00;
 		chip->RegData[Register] = Data;
 		break;
@@ -312,10 +312,10 @@ bool segapcm_mem_write(UINT16 Offset, UINT8 Data)
 {
 	STRIP_PCM* strip = &StpDat->SegaPCM;
 	UINT8 CurChn;
-	
+
 	if (strip->All)
 		return false;
-	
+
 	CurChn = (Offset & 0x78) >> 3;
 	if (strip->ChnMask & (0x01 << CurChn))
 		return false;
@@ -326,10 +326,10 @@ bool rf5cxx_reg_write(RF5C68_DATA* chip, STRIP_PCM* strip, UINT8 Register, UINT8
 {
 	UINT8 CurChn;
 	UINT8 ChnMask;
-	
+
 	if (strip->All)
 		return false;
-	
+
 	switch(Register)
 	{
 	case 0x00:	// Envelope
@@ -363,11 +363,11 @@ bool rf5cxx_reg_write(RF5C68_DATA* chip, STRIP_PCM* strip, UINT8 Register, UINT8
 			//      Channel Enable &&    Strip Channel
 			if (! (*Data & ChnMask) && (strip->ChnMask & (0x01 << CurChn)))
 				*Data |= ChnMask;	// disable channel
-			
+
 		}
 		return true;
 	}
-	
+
 	if (strip->ChnMask & (0x01 << CurChn))
 		return false;
 	return true;
@@ -377,7 +377,7 @@ bool rf5c68_reg_write(UINT8 Register, UINT8* Data)
 {
 	RF5C68_DATA* chip = &ChDat->RF5C68;
 	STRIP_PCM* strip = &StpDat->RF5C68;
-	
+
 	return rf5cxx_reg_write(chip, strip, Register, Data);
 }
 
@@ -385,10 +385,10 @@ bool rf5c68_mem_write(UINT16 Offset, UINT8 Data)
 {
 	//RF5C68_DATA* chip = &ChDat->RF5C68;
 	STRIP_PCM* strip = &StpDat->RF5C68;
-	
+
 	if (strip->All || (strip->Other & 0x01))
 		return false;
-	
+
 	return true;
 }
 
@@ -397,7 +397,7 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 	YM2203_DATA* chip;
 	STRIP_OPN* strip = &StpDat->YM2203;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -417,10 +417,10 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 		break;
 	case 0x28:
 		Channel = Data & 0x03;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = 0x00;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -442,10 +442,10 @@ bool ym2203_write(UINT8 Register, UINT8 Data)
 			RegVal &= 0x0FC;	// Registers A4-A6 (AC-AE for Ch3) write to the same offset
 			break;*/
 		}
-		
+
 		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
 			return false;
-		
+
 		chip->RegFirst[Register] = 0x00;
 		chip->RegData[Register] = Data;
 		break;
@@ -459,7 +459,7 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	STRIP_OPN* strip = &StpDat->YM2608;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -479,10 +479,10 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		break;
 	case 0x28:
 		Channel = Data & 0x07;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = 0x00;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -509,10 +509,10 @@ bool ym2608_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			RegVal &= 0x0FC;	// Registers A4-A6 (AC-AE for Ch3) write to the same offset
 			break;*/
 		}
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
@@ -526,7 +526,7 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	STRIP_OPN* strip = &StpDat->YM2610;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -541,10 +541,10 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	// no OPN Prescaler Registers for YM2610
 	case 0x28:
 		Channel = Data & 0x07;
-		
+
 		if (! chip->KeyFirst[Channel] && Data == chip->KeyOn[Channel])
 			return false;
-		
+
 		chip->KeyFirst[Channel] = 0x00;
 		chip->KeyOn[Channel] = Data;
 		break;
@@ -572,10 +572,10 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 			RegVal &= 0x0FC;	// Registers A4-A6 (AC-AE for Ch3) write to the same offset
 			break;*/
 		}
-		
+
 		if (! chip->RegFirst[RegVal] && Data == chip->RegData[RegVal])
 			return false;
-		
+
 		chip->RegFirst[RegVal] = 0x00;
 		chip->RegData[RegVal] = Data;
 		break;
@@ -586,7 +586,7 @@ bool ym2610_write(UINT8 Port, UINT8 Register, UINT8 Data)
 bool ym3812_write(UINT8 Register, UINT8 Data)
 {
 	STRIP_OPL* strip = &StpDat->YM3812;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -598,7 +598,7 @@ bool ym3812_write(UINT8 Register, UINT8 Data)
 bool ym3526_write(UINT8 Register, UINT8 Data)
 {
 	STRIP_OPL* strip = &StpDat->YM3526;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -610,7 +610,7 @@ bool ym3526_write(UINT8 Register, UINT8 Data)
 bool y8950_write(UINT8 Register, UINT8 Data)
 {
 	STRIP_OPL* strip = &StpDat->Y8950;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -623,10 +623,10 @@ bool ymf262_write(UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	STRIP_OPL* strip = &StpDat->YMF262;
 	UINT16 RegVal;
-	
+
 	if (strip->All)
 		return false;
-	
+
 	RegVal = (Port << 8) | Register;
 	return true;
 	ChDat->YMF262.RegFirst[RegVal] = 0x00;
@@ -637,7 +637,7 @@ bool ymf262_write(UINT8 Port, UINT8 Register, UINT8 Data)
 bool ymz280b_write(UINT8 Register, UINT8 Data)
 {
 	STRIP_YMZ* strip = &StpDat->YMZ280B;
-	
+
 	if (strip->All)
 		return false;
 	return true;
@@ -650,7 +650,7 @@ bool rf5c164_reg_write(UINT8 Register, UINT8* Data)
 {
 	RF5C68_DATA* chip = &ChDat->RF5C164;
 	STRIP_PCM* strip = &StpDat->RF5C164;
-	
+
 	return rf5cxx_reg_write(chip, strip, Register, Data);
 }
 
@@ -658,10 +658,10 @@ bool rf5c164_mem_write(UINT16 Offset, UINT8 Data)
 {
 	//RF5C68_DATA* chip = &ChDat->RF5C164;
 	STRIP_PCM* strip = &StpDat->RF5C164;
-	
+
 	if (strip->All || (strip->Other & 0x01))
 		return false;
-	
+
 	return true;
 }
 
@@ -671,23 +671,23 @@ bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	C140_DATA* chip = &ChDat->C140;
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	if (strip->All)
 		return false;
-	
+
 	if (Port == 0xFF)
 	{
 		chip->BankType = Data;
 		return true;
 	}
-	
+
 	RegVal = (Port << 8) | Register;
 	RegVal &= 0x1FF;
-	
+
 	// mirror the bank registers on the 219, fixes bkrtmaq
 	if ((RegVal >= 0x1F8) && (chip->BankType >= 0x02))
 		RegVal &= 0x1F7;
-	
+
 	if (RegVal < 0x180)
 	{
 		Channel = RegVal >> 4;
@@ -699,7 +699,7 @@ bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		if (strip->Other & 0x01)
 			return false;
 	}
-	
+
 	return true;
 }
 

--- a/chiptext.c
+++ b/chiptext.c
@@ -279,14 +279,14 @@ void InitChips(UINT32* ChipCounts)
 	CacheOKI6295[1].Command = 0xFF;
 	ChpCur = 0x00;
 	ChipStr = RedirectStr + 0xF0;
-	
+
 	return;
 }
 
 void SetChip(UINT8 ChipID)
 {
 	ChpCur = ChipID;
-	
+
 	return;
 }
 
@@ -303,12 +303,12 @@ INLINE const char* Enable(UINT32 Value)
 INLINE UINT8 YM2151_Note(UINT8 FNum, UINT8 Block)
 {
 	UINT8 NoteVal;
-	
+
 	if (FNum > 0xF)
 		return 0xFF;	// Invalid FNum
 	if (Block > 0x07)
 		Block = 0x07;
-	
+
 	if (! ((FNum & 0x03) == 0x03))
 	{
 		NoteVal = FNum >> 2;
@@ -319,10 +319,10 @@ INLINE UINT8 YM2151_Note(UINT8 FNum, UINT8 Block)
 	{
 		NoteVal = 0xFF;
 	}
-	
+
 	if (NoteVal == 0xFF)
 		return 0xFF;
-	
+
 	return NoteVal + (Block - 0x04) * 12;
 }
 
@@ -330,7 +330,7 @@ INLINE UINT32 GetChipName(UINT8 ChipType, const char** RetName)
 {
 	const char* ChipName;
 	UINT32 ChipCnt;
-	
+
 	switch(ChipType)
 	{
 	case 0x00:	// SN76496 / T6W28
@@ -505,7 +505,7 @@ INLINE UINT32 GetChipName(UINT8 ChipType, const char** RetName)
 		ChipCnt = 0x00;
 		break;
 	}
-	
+
 	*RetName = ChipName;
 	return ChipCnt;
 }
@@ -514,7 +514,7 @@ INLINE void WriteChipID(UINT8 ChipType)
 {
 	const char* ChipName;
 	UINT32 ChipCnt;
-	
+
 	ChipCnt = GetChipName(ChipType, &ChipName);
 	switch(ChipType)
 	{
@@ -526,7 +526,7 @@ INLINE void WriteChipID(UINT8 ChipType)
 		}
 		break;
 	}
-	
+
 	ChipCnt &= ~0x80000000;
 	if (ChipCnt <= 0x01)
 		sprintf(ChipStr, "%s:", ChipName);
@@ -535,7 +535,7 @@ INLINE void WriteChipID(UINT8 ChipType)
 	if (strlen(ChipStr) < 0x08)
 		strcat(ChipStr, "\t");
 	strcat(ChipStr, "\t");
-	
+
 	return;
 }
 
@@ -544,10 +544,10 @@ void GetFullChipName(char* TempStr, UINT8 ChipType)
 	const char* ChipName;
 	UINT32 ChipCnt;
 	UINT8 CurChip;
-	
+
 	CurChip = ChpCur | (ChipType >> 7);
 	ChipType &= 0x7F;
-	
+
 	ChipCnt = GetChipName(ChipType, &ChipName);
 	switch(ChipType)
 	{
@@ -558,37 +558,37 @@ void GetFullChipName(char* TempStr, UINT8 ChipType)
 		}
 		break;
 	}
-	
+
 	ChipCnt &= ~0x80000000;
 	if (ChipCnt <= 0x01)
 		sprintf(TempStr, "%s:", ChipName);
 	else
 		sprintf(TempStr, "%s #%u:", ChipName, CurChip);
-	
+
 	return;
 }
 
 static UINT8 GetLogVolPercent(UINT8 VolLevel, UINT8 Steps_6db, UINT8 Silent)
 {
 	float TempVol;
-	
+
 	if (VolLevel >= Silent)
 		return 0;
-	
+
 	TempVol = (float)pow(2.0, -1.0 * VolLevel / Steps_6db);
-	
+
 	return (UINT8)(100 * TempVol + 0.5f);
 }
 
 static UINT8 GetDBTblPercent(UINT8 VolLevel, const float* DBTable, UINT8 Silent)
 {
 	float TempVol;
-	
+
 	if (VolLevel >= Silent)
 		return 0;
-	
+
 	TempVol = (float)pow(2.0, -DBTable[VolLevel] / 6.0f);
-	
+
 	return (UINT8)(100 * TempVol + 0.5f);
 }
 
@@ -598,7 +598,7 @@ void GGStereo(char* TempStr, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	// Format:
 	//	Bit	76543210
 	//	L/R	LLLLRRRR
@@ -613,7 +613,7 @@ void GGStereo(char* TempStr, UINT8 Data)
 		StrPos ++;
 	}
 	TempStr[StrPos] = 0x00;
-	
+
 	return;
 }
 
@@ -621,7 +621,7 @@ void sn76496_write(char* TempStr, UINT8 Command)
 {
 	UINT8 CurChn;
 	UINT8 CurData;
-	
+
 	WriteChipID(0x00);
 	if (! (Command & 0x80))
 	{
@@ -642,7 +642,7 @@ void sn76496_write(char* TempStr, UINT8 Command)
 		case 0xE0:
 			sprintf(WriteStr, "%s, %s", SN76496_NOISE_TYPE[(Command & 0x04) >> 2],
 					SN76496_NOISE_FREQ[Command & 0x03]);
-			
+
 			sprintf(TempStr, "%sNoise Type: %u - %s", ChipStr, CurData, WriteStr);
 			break;
 		case 0x90:
@@ -654,7 +654,7 @@ void sn76496_write(char* TempStr, UINT8 Command)
 			break;
 		}
 	}
-	
+
 	return;
 }
 
@@ -662,7 +662,7 @@ void ym2413_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x01);
 	sprintf(TempStr, "%sReg 0x%02X Data 0x%02X", ChipStr, Register, Data);
-	
+
 	return;
 }
 
@@ -674,7 +674,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 	UINT8 Slot;
 	float TempSng;
 	UINT8 TempByt;
-	
+
 	RegVal = (Port << 8) | Register;
 	if ((RegVal & 0x1F0) == 0x000 && (FMOPN_TYPES[Mode] & OPN_TYPE_SSG))
 	{
@@ -692,7 +692,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x22:	// LFO FREQ (YM2608/YM2610/YM2610B/YM2612)
 			if (! (FMOPN_TYPES[Mode] & OPN_TYPE_LFOPAN))
 				goto WriteRegData;
-			
+
 			if (Data & 0x08) // LFO enabled ?
 				sprintf(TempStr, "Low Frequency Oscillator: %s Hz",
 						OPN_LFOFreqs[Data & 0x07]);
@@ -711,11 +711,11 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x27:	// mode, timer control
 			sprintf(TempStr, "CSM Mode: %s", Enable(Data & 0x80));
 			sprintf(TempStr, "%s, 3 Slot Mode: %s", TempStr, Enable(Data & 0x40));
-			
+
 			sprintf(TempStr, "%s, Enable Timer: %c%c, Timer IRQ Enable: %c%c, Reset Timer Status: %c%c",
 					TempStr,
 					(Data & 0x01) ? 'A' : '-', (Data & 0x02) ? 'B' : '-',
-					(Data & 0x04) ? 'A' : '-', (Data & 0x08) ? 'B' : '-', 
+					(Data & 0x04) ? 'A' : '-', (Data & 0x08) ? 'B' : '-',
 					(Data & 0x10) ? 'A' : '-', (Data & 0x20) ? 'B' : '-');
 			break;
 		case 0x28:	// key on / off
@@ -727,9 +727,9 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			}
 			if ((Data & 0x04) && (FMOPN_TYPES[Mode] & OPN_TYPE_6CH))
 				Channel += 3;
-			
+
 			sprintf(TempStr, "Channel %u Key On/Off: ", Channel);
-			
+
 			sprintf(TempStr, "%sSlot1 %s, Slot2 %s, Slot3 %s, Slot4 %s", TempStr,
 					OnOff(Data & 0x10), OnOff(Data & 0x20), OnOff(Data & 0x40),
 					OnOff(Data & 0x80));
@@ -737,27 +737,27 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x29:	// SCH,xx,xxx,EN_ZERO,EN_BRDY,EN_EOS,EN_TB,EN_TA
 			if (! (FMOPN_TYPES[Mode] & OPN_TYPE_DAC))
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "OPNA Mode: %s (%u FM channels), IRQ Mask: 0x%02X",
 					Enable(Data & 0x80), (Data & 0x80) ? 6 : 3, Data & 0x1F);
 			break;
 		case 0x2A:	// DAC data (YM2612)
 			if (! (FMOPN_TYPES[Mode] & OPN_TYPE_DAC))
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "DAC = %02X", Data);
 			break;
 		case 0x2B:	// DAC Sel (YM2612)
 			if (! (FMOPN_TYPES[Mode] & OPN_TYPE_DAC))
 				goto WriteRegData;
-			
+
 			// b7 = dac enable
 			sprintf(TempStr, "DAC %s", Enable(Data & 0x80));
 			break;
 		case 0x2C:	// DAC Test  Register (YM2612)
 			if (! (FMOPN_TYPES[Mode] & OPN_TYPE_DAC))
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "DAC Test Register: Special DAC Mode %s", Enable(Data & 0x20));
 			break;
 		default:
@@ -775,7 +775,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		if (Port)
 			Channel += 3;
 		Slot = (Register & 0x0C) >> 2;
-		
+
 		switch(Register & 0xF0)
 		{
 		case 0x30:	// DET , MUL
@@ -842,7 +842,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			case 0x08:	// 0xa8-0xaa : 3CH FNUM1
 				if (Port)
 					goto WriteRegData;
-				
+
 				/*UINT32 fn = (((UINT32)(OPN->SL3.fn_h&7))<<8) + v;
 				UINT8 blk = OPN->SL3.fn_h>>3;
 				// keyscale code
@@ -857,7 +857,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			case 0x0C:	// 0xac-0xae : 3CH FNUM2,BLK
 				if (Port)
 					goto WriteRegData;
-				
+
 				//OPN->SL3.fn_h = v&0x3f;
 				sprintf(WriteStr, "F-Num Op %u (prepare) MSB = %01X, Octave %u", Channel,
 						Data & 0x07, (Data & 0x38) >> 3);
@@ -881,13 +881,13 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			case 0x04:	// 0xb4-0xb6 : L , R , AMS , PMS (YM2612/YM2610B/YM2610/YM2608)
 				if (! (FMOPN_TYPES[Mode] & OPN_TYPE_LFOPAN))
 					goto WriteRegData;
-				
+
 				// b0-2 PMS
 				//CH->pms = (v & 7) * 32; // CH->pms = PM depth * 32 (index in lfo_pm_table)
-				
+
 				// b4-5 AMS
 				//CH->ams = lfo_ams_depth_shift[(v>>4) & 0x03];
-				
+
 				// PAN :  b7 = L, b6 = R
 				/*OPN->pan[ c*2   ] = (v & 0x80) ? ~0 : 0;
 				OPN->pan[ c*2+1 ] = (v & 0x40) ? ~0 : 0;*/
@@ -902,7 +902,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		default:
 			goto WriteRegData;
 		}
-		
+
 		if (Register < 0xA0)
 			sprintf(TempStr, "Ch %u Slot %u %s", Channel, Slot, WriteStr);
 		else
@@ -949,7 +949,7 @@ static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 	{
 		goto WriteRegData;
 	}
-	
+
 	return;
 
 WriteRegData:
@@ -958,7 +958,7 @@ WriteRegData:
 		sprintf(TempStr, "Reg 0x%02X Data 0x%02X", Register, Data);
 	else
 		sprintf(TempStr, "Reg 0x%01X%02X Data 0x%02X", Port, Register, Data);
-	
+
 	return;
 }
 
@@ -966,9 +966,9 @@ void ym2612_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x02);
 	opn_write(RedirectStr, OPN_YM2612, Port, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -976,7 +976,7 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	UINT8 Channel;
 	UINT8 Operator;
-	
+
 	WriteChipID(0x03);
 	//sprintf(TempStr, "%sReg 0x%02X Data 0x%02X", ChipStr, Register, Data);
 	if (Register < 0x20)
@@ -1010,7 +1010,7 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 		case 0x14:	// CSM, irq flag reset, irq enable, timer start/stop
 			sprintf(WriteStr, "CSM Mode: %s", Enable(Data & 0x80));
 			//chip->irq_enable = v;	// bit 3-timer B, bit 2-timer A, bit 7 - CSM
-			
+
 			sprintf(WriteStr, "%s, Enable Timer: %c%c, Timer IRQ Enable: %c%c, Reset Timer Status: %c%c",
 					WriteStr,
 					(Data & 0x01) ? 'A' : '-', (Data & 0x02) ? 'B' : '-',
@@ -1044,7 +1044,7 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 			sprintf(WriteStr, "Undocumented register #%02X, Value 0x%02X", Register, Data);
 			break;
 		}
-		
+
 		sprintf(TempStr, "%s%s", ChipStr, WriteStr);
 	}
 	else
@@ -1163,10 +1163,10 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 			/*{
 				UINT32 oldks = op->ks;
 				UINT32 oldar = op->ar;
-				
+
 				op->ks = 5-(v>>6);
 				op->ar = (v&0x1f) ? 32 + ((v&0x1f)<<1) : 0;
-				
+
 				if ( (op->ar != oldar) || (op->ks != oldks) )
 				{
 					if ((op->ar + (op->kc>>op->ks)) < 32+62)
@@ -1180,7 +1180,7 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 						op->eg_sel_ar = 17*RATE_STEPS;
 					}
 				}
-				
+
 				if (op->ks != oldks)
 				{
 					op->eg_sh_d1r = eg_rate_shift [op->d1r + (op->kc>>op->ks) ];
@@ -1222,13 +1222,13 @@ void ym2151_write(char* TempStr, UINT8 Register, UINT8 Data)
 			op->eg_sel_rr = eg_rate_select[op->rr  + (op->kc>>op->ks) ];*/
 			break;
 		}
-		
+
 		if (Register < 0x40)
 			sprintf(TempStr, "%sCh %u %s", ChipStr, Channel, WriteStr);
 		else
 			sprintf(TempStr, "%sCh %u Op %u %s", ChipStr, Channel, Operator, WriteStr);
 	}
-	
+
 	return;
 }
 
@@ -1236,13 +1236,13 @@ void segapcm_mem_write(char* TempStr, UINT16 Offset, UINT8 Data)
 {
 	UINT8 Channel;
 	UINT16 RelOffset;
-	
+
 	WriteChipID(0x04);
-	
+
 	Offset &= 0x07FF;
 	Channel = (Offset >> 3) & 0xF;
 	RelOffset = Offset & ~0x0078;
-	
+
 	//sprintf(TempStr, "SegaPCM:\tOffset 0x%04X Data 0x%02X", Offset, Data);
 	switch(RelOffset)
 	{
@@ -1275,9 +1275,9 @@ void segapcm_mem_write(char* TempStr, UINT16 Offset, UINT8 Data)
 		sprintf(WriteStr, "Write Offset 0x%03X, Data 0x%02X", Offset, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%sCh %u %s", ChipStr, Channel, WriteStr);
-	
+
 	return;
 }
 
@@ -1286,7 +1286,7 @@ static void rf5cxx_reg_write(char* TempStr, UINT8 Register, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	bool ChnEn;
-	
+
 	switch(Register)
 	{
 	case 0x00:	// Evelope
@@ -1334,10 +1334,10 @@ static void rf5cxx_reg_write(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(WriteStr, "Reg 0x%02X, Data 0x%02X", Register, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
 	//sprintf(TempStr, "%sReg 0x%02X Data 0x%02X", ChipStr, Register, Data);
-	
+
 	return;
 }
 
@@ -1345,7 +1345,7 @@ void rf5c68_reg_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x05);
 	rf5cxx_reg_write(TempStr, Register, Data);
-	
+
 	return;
 }
 
@@ -1353,7 +1353,7 @@ void rf5c68_mem_write(char* TempStr, UINT16 Offset, UINT8 Data)
 {
 	WriteChipID(0x05);
 	sprintf(TempStr, "%sMem 0x%04X Data 0x%02X", ChipStr, Offset, Data);
-	
+
 	return;
 }
 
@@ -1361,9 +1361,9 @@ void ym2203_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x06);
 	opn_write(RedirectStr, OPN_YM2203, 0x00, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -1371,9 +1371,9 @@ void ym2608_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x07);
 	opn_write(RedirectStr, OPN_YM2608, Port, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -1381,9 +1381,9 @@ void ym2610_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x08);
 	opn_write(RedirectStr, OPN_YM2610, Port, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -1392,7 +1392,7 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 {
 	UINT8 Channel;
 	UINT8 Operator;
-	
+
 	if (Register < 0x20)
 	{
 		// 00-1f:control
@@ -1401,19 +1401,19 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x01:	// waveform select enable
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_WAVESEL) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "Waveform Select: %s", Enable(Data & 0x20));
 			break;
 		case 0x02:	// Timer 1
 			if (Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "Timer 1 = %u", (0x100 - Data) * 0x04);
 			break;
 		case 0x03:	// Timer 2
 			if (Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "Timer 2 = %u", (0x100 - Data) * 0x10);
 			break;
 		case 0x04:	// IRQ clear / mask and Timer enable
@@ -1429,14 +1429,14 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 					sprintf(TempStr, "Set IRQ Mask: 0x%02X", Data >> 3);
 					sprintf(TempStr, "%s, Timer 1: %s", TempStr, Enable(Data & 0x01));
 					sprintf(TempStr, "%s, Timer 2: %s", TempStr, Enable(Data & 0x02));
-					
+
 					// IRQRST,T1MSK,t2MSK,EOSMSK,BRMSK,x,ST2,ST1
 				}
 				break;
 			case 0x01:
 				if (! (FMOPL_TYPES[Mode] & OPL_TYPE_OPL3))
 					goto WriteRegData;
-				
+
 				sprintf(TempStr, "4-Op Mode: ");
 				sprintf(TempStr, "%sCh 0-3: %s, ", TempStr, Enable(Data & 0x01));
 				sprintf(TempStr, "%sCh 1-4: %s, ", TempStr, Enable(Data & 0x02));
@@ -1450,7 +1450,7 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x05:	// OPL3/OPL4 Mode Enable
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_OPL3) || ! Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "OPL3 Mode: %s", Enable(Data & 0x01));
 			if (FMOPL_TYPES[Mode] & OPL_TYPE_OPL4)
 				sprintf(TempStr, "%s, OPL4 Mode: %s", TempStr, Enable(Data & 0x02));
@@ -1458,25 +1458,25 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x06:		// Key Board OUT
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_KEYBOARD) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "Key Board Write: 0x%02X", Data);
 			break;
 		case 0x07:	// DELTA-T control 1 : START,REC,MEMDATA,REPT,SPOFF,x,x,RST
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_ADPCM) || Port)
 				goto WriteRegData;
-			
+
 			//sprintf(TempStr, "DELTA-T Control 1: 0x%02X", Data);
 			YM_DELTAT_ADPCM_Write(TempStr, Register - 0x07, Data);
 			break;
 		case 0x08:	// MODE,DELTA-T control 2 : CSM,NOTESEL,x,x,smpl,da/ad,64k,rom
 			if (Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "CSM %s, Note Select: %s", OnOff(Data & 0x80), OnOff(Data & 0x40));
-			
+
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_ADPCM))
 				break;
-			
+
 			strcat(TempStr, ", ");
 			YM_DELTAT_ADPCM_Write(TempStr + strlen(TempStr), Register - 0x07, (Data & 0x0F) | 0xC0);
 			break;
@@ -1492,37 +1492,37 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		case 0x12: 		// ADPCM volume
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_ADPCM) || Port)
 				goto WriteRegData;
-			
+
 			YM_DELTAT_ADPCM_Write(TempStr, Register - 0x07, Data);
 			break;
 		case 0x15:		// DAC data high 8 bits (F7,F6...F2)
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_ADPCM) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "DAC Write High: 0x%02X", Data);
 			break;
 		case 0x16:		// DAC data low 2 bits (F1, F0 in bits 7,6)
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_ADPCM) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "DAC Write Low: 0x%02X", Data);
 			break;
 		case 0x17:		// DAC data shift (S2,S1,S0 in bits 2,1,0)
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_ADPCM) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "DAC Write Data Shift: 0x%02X", Data);
 			break;
 		case 0x18:		// I/O CTRL (Direction)
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_IO) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "I/O Direction: 0x%02X", Data & 0x0F);
 			break;
 		case 0x19:		// I/O DATA
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_IO) || Port)
 				goto WriteRegData;
-			
+
 			sprintf(TempStr, "I/O Data/Latch: 0x%02X", Data);
 			break;
 		default:
@@ -1557,7 +1557,7 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			{
 				sprintf(WriteStr, "AM Depth: %.1f, Vibrato Depth: %u cent, Rhythm Mode %s",
 						(Data & 0x80) ? 4.8 : 1.0, (Data & 0x40) ? 14 : 7, Enable(Data & 0x20));
-				
+
 				if (Data & 0x20)
 				{
 					sprintf(WriteStr, "%s, BD %s, SD %s, TOM %s, CYM %s, HH %s", WriteStr,
@@ -1566,11 +1566,11 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 				}
 				break;
 			}
-			
+
 			// keyon,block,fnum
 			if ((Register & 0x0F) > 8)
 				goto WriteRegData;
-			
+
 			if (! (Register & 0x10))
 			{	// a0-a8
 				sprintf(WriteStr, "F-Num LSB = %02X", Data);
@@ -1585,7 +1585,7 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			// FB,C
 			if ((Register & 0x1F) > 8)
 				goto WriteRegData;
-			
+
 			sprintf(WriteStr, "Algorithm: %s, Feedback %u", (Data & 0x01) ? "AM" : "FM",
 					(Data & 0x0E) >> 1);
 			break;
@@ -1593,16 +1593,16 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 			// TODO: - ignore write if Wave Select is not enabled in test register (OPL2 only)
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_WAVESEL))
 				goto WriteRegData;
-			
+
 			if (! (FMOPL_TYPES[Mode] & OPL_TYPE_OPL3))
 				Data &= 0x03;	// only 2 wave forms on OPL2
 			sprintf(WriteStr, "Waveform Select: %u", Data & 0x07);
-			
+
 			break;
 		default:
 			goto WriteRegData;
 		}
-		
+
 		if (Register < 0xA0 || Register >= 0xE0)
 			sprintf(TempStr, "Ch %u Op %u %s", Channel, Operator, WriteStr);
 		else if (Register != 0xBD)
@@ -1610,7 +1610,7 @@ static void opl_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
 		else
 			sprintf(TempStr, "%s", WriteStr);
 	}
-	
+
 	return;
 
 WriteRegData:
@@ -1619,7 +1619,7 @@ WriteRegData:
 		sprintf(TempStr, "Reg 0x%02X Data 0x%02X", Register, Data);
 	else
 		sprintf(TempStr, "Reg 0x%01X%02X Data 0x%02X", Port, Register, Data);
-	
+
 	return;
 }
 
@@ -1627,9 +1627,9 @@ void ym3812_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x09);
 	opl_write(RedirectStr, OPL_YM3812, 0x00, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -1637,9 +1637,9 @@ void ym3526_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x0A);
 	opl_write(RedirectStr, OPL_YM3526, 0x00, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -1647,9 +1647,9 @@ void y8950_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x0B);
 	opl_write(RedirectStr, OPL_Y8950, 0x00, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -1657,10 +1657,10 @@ void ymf262_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x0C);
 	opl_write(RedirectStr, OPL_YMF262, Port, Register, Data);
-	
+
 	sprintf(TempStr, "%sPort %X %s", ChipStr, Port, RedirectStr);
 	//sprintf(TempStr, "YMF262:\tReg 0x%02X Data 0x%02X", Register | (Port << 8), Data);
-	
+
 	return;
 }
 
@@ -1668,7 +1668,7 @@ void ymz280b_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	UINT8 Voice;
 	UINT8 Addr;
-	
+
 	WriteChipID(0x0F);
 	if (Register < 0x80)
 	{
@@ -1744,7 +1744,7 @@ void ymz280b_write(char* TempStr, UINT8 Register, UINT8 Data)
 		}
 		sprintf(TempStr, "%s%s", ChipStr, WriteStr);
 	}
-	
+
 	return;
 }
 
@@ -1755,13 +1755,13 @@ void ymf278b_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 	UINT8 ChnReg;
 	UINT16 TempSht;
 	INT8 TempSByt;
-	
+
 	WriteChipID(0x0D);
-	
+
 	if (Port <= 0x01)
 	{
 		opl_write(RedirectStr, OPL_YMF278, Port, Register, Data);
-		
+
 		sprintf(TempStr, "%sFM Port %X %s", ChipStr, Port, RedirectStr);
 		return;
 	}
@@ -1771,7 +1771,7 @@ void ymf278b_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 		{
 			Channel = (Register - 0x08) % 24;
 			ChnReg = (Register - 0x08) / 24;
-			
+
 			switch(ChnReg)
 			{
 			case 0x00:	// sample ID (bits 0-7) / load sample
@@ -1873,16 +1873,16 @@ void ymf278b_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 	{
 		sprintf(TempStr, "%sPort %x Reg 0x%02X Data 0x%02X", ChipStr, Port, Register, Data);
 	}
-	
+
 	return;
 }
 
 /*void ymf271_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x0E);
-	
+
 	sprintf(TempStr, "%sPort %x Reg 0x%02X Data 0x%02X", ChipStr, Port, Register, Data);
-	
+
 	return;
 }*/
 
@@ -1890,7 +1890,7 @@ void rf5c164_reg_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x10);
 	rf5cxx_reg_write(TempStr, Register, Data);
-	
+
 	return;
 }
 
@@ -1898,7 +1898,7 @@ void rf5c164_mem_write(char* TempStr, UINT16 Offset, UINT8 Data)
 {
 	WriteChipID(0x10);
 	sprintf(TempStr, "%sMem 0x%04X Data 0x%02X", ChipStr, Offset, Data);
-	
+
 	return;
 }
 
@@ -1907,7 +1907,7 @@ static void ay8910_part_write(char* TempStr, UINT8 Register, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	switch(Register)
 	{
 	case 0x00:	// AY_AFINE
@@ -1933,7 +1933,7 @@ static void ay8910_part_write(char* TempStr, UINT8 Register, UINT8 Data)
 			StrPos ++;
 		}
 		TempStr[StrPos] = 0x00;
-		
+
 		sprintf(TempStr, "%s, Noise ", TempStr);
 		StrPos = strlen(TempStr);
 		for (CurChn = 0; CurChn < 3; CurChn ++)
@@ -1943,7 +1943,7 @@ static void ay8910_part_write(char* TempStr, UINT8 Register, UINT8 Data)
 			StrPos ++;
 		}
 		TempStr[StrPos] = 0x00;
-		
+
 		sprintf(TempStr, "%s, Port ", TempStr);
 		StrPos = strlen(TempStr);
 		// Ports are just INPUT (off) or OUTPUT (on) mode
@@ -1980,18 +1980,18 @@ static void ay8910_part_write(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(TempStr, "Reg 0x%02X, Data 0x%02X", Register, Data);
 		break;
 	}
-	
+
 	return;
 }
 
 void ay8910_reg_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x12);
-	
+
 	ay8910_part_write(RedirectStr, Register, Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -2005,21 +2005,21 @@ void ay8910_stereo_mask_write(char* TempStr, UINT8 Data)
 		ay8910_stereo_names [(Data >>0) &3],
 		ay8910_stereo_names [(Data >>2) &3],
 		ay8910_stereo_names [(Data >>4) &3]
-	);	
+	);
 	return;
 }
 
 void pwm_write(char* TempStr, UINT16 Port, UINT16 Data)
 {
 	UINT8 PortVal;
-	
+
 	WriteChipID(0x11);
-	
+
 	PortVal = (Port > 0x05) ? 0x05 : Port;
 	sprintf(WriteStr, "%s, Data 0x%03X", PWM_PORTS[PortVal], Data);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -2085,7 +2085,7 @@ static void ymf271_write_fm_reg(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(TempStr, "Invalid Register");
 		break;
 	}
-	
+
 	return;
 }
 
@@ -2095,13 +2095,13 @@ static void ymf271_write_fm(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Dat
 	UINT8 SlotNum;
 	UINT8 SyncMode;
 	UINT8 SyncReg;
-	
+
 	if ((Register & 0x03) == 0x03)
 	{
 		sprintf(RedirectStr, "Invalid Slot");
 		return;
 	}
-	
+
 	SlotNum = ((Register & 0x0F) / 0x04 * 0x03) + (Register & 0x03);
 	SlotReg = (Register >> 4) & 0x0F;
 	if (SlotNum >= 12 || 12 * Port > 48)
@@ -2109,7 +2109,7 @@ static void ymf271_write_fm(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Dat
 		sprintf(RedirectStr, "Progrmm Error");
 		return;
 	}
-	
+
 	// check if the register is a synchronized register
 	SyncReg = 0;
 	switch(SlotReg)
@@ -2125,7 +2125,7 @@ static void ymf271_write_fm(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Dat
 	default:
 		break;
 	}
-	
+
 	// check if the slot is key on slot for synchronizing
 	SyncMode = 0;
 	switch(CacheYMF271[ChpCur].group_sync[SlotNum])
@@ -2145,9 +2145,9 @@ static void ymf271_write_fm(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Dat
 	default:
 		break;
 	}
-	
+
 	ymf271_write_fm_reg(WriteStr, SlotReg, Data);
-	
+
 	if (SyncMode && SyncReg)		// key-on slot & synced register
 	{
 		switch(CacheYMF271[ChpCur].group_sync[SlotNum])
@@ -2182,7 +2182,7 @@ static void ymf271_write_fm(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Dat
 	{
 		sprintf(TempStr, "Slot %u: %s", (12 * Port) + SlotNum, WriteStr);
 	}
-	
+
 	return;
 }
 
@@ -2190,11 +2190,11 @@ void ymf271_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	UINT8 SlotNum;
 	UINT8 Addr;
-	
+
 	WriteChipID(0x0E);
-	
+
 	//sprintf(TempStr, "%sPort %x Reg 0x%02X Data 0x%02X", ChipStr, Port, Register, Data);
-	
+
 	switch(Port)
 	{
 	case 0x00:
@@ -2212,7 +2212,7 @@ void ymf271_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 		{
 			SlotNum = ((Register & 0x0F) / 0x04 * 0x03) + (Register & 0x03);
 			Addr = (Register >> 4) % 3;
-			
+
 			switch((Register >> 4) & 0x0F)
 			{
 			case 0:
@@ -2250,7 +2250,7 @@ void ymf271_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 				sprintf(RedirectStr, "Group Register: Invalid Channel");
 				break;
 			}
-			
+
 			SlotNum = ((Register & 0x0F) / 0x04 * 0x03) + (Register & 0x03);
 			CacheYMF271[ChpCur].group_sync[SlotNum] = Data & 0x03;
 			sprintf(RedirectStr, "Group Register: Slot %u, Sync Mode: %u (%s)",
@@ -2272,7 +2272,7 @@ void ymf271_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 			case 0x13:	// Timer A/B Load, Timer A/B IRQ Enable, Timer A/B Reset
 				sprintf(RedirectStr, "Enable Timer: %c%c, Timer IRQ Enable: %c%c, Reset Timer Status: %c%c",
 						(Data & 0x01) ? 'A' : '-', (Data & 0x02) ? 'B' : '-',
-						(Data & 0x04) ? 'A' : '-', (Data & 0x08) ? 'B' : '-', 
+						(Data & 0x04) ? 'A' : '-', (Data & 0x08) ? 'B' : '-',
 						(Data & 0x10) ? 'A' : '-', (Data & 0x20) ? 'B' : '-');
 				break;
 			case 0x14:
@@ -2294,9 +2294,9 @@ void ymf271_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 		sprintf(RedirectStr, "Invalid Port");
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
@@ -2305,9 +2305,9 @@ void gb_sound_write(char* TempStr, UINT8 Register, UINT8 Data)
 	UINT8 TempByt;
 	INT8 TempSByt;
 	UINT32 StrPos;
-	
+
 	WriteChipID(0x13);
-	
+
 	switch(Register)
 	{
 	//MODE 1
@@ -2416,7 +2416,7 @@ void gb_sound_write(char* TempStr, UINT8 Register, UINT8 Data)
 			StrPos ++;
 		}
 		WriteStr[StrPos] = 0x00;
-		
+
 		sprintf(WriteStr, "%s, Right: ", WriteStr);
 		StrPos = strlen(WriteStr);
 		for (TempByt = 0x00; TempByt < 0x04; TempByt ++)
@@ -2441,18 +2441,18 @@ void gb_sound_write(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(WriteStr, "Reg 0x%02X, Data 0x%02X", Register, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
 void nes_psg_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	UINT8 CurChn;
-	
+
 	WriteChipID(0x14);
-	
+
 	switch(Register & 0xE0)
 	{
 	case 0x00:	// NES APU
@@ -2600,9 +2600,9 @@ void nes_psg_write(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(WriteStr, "Reg 0x%02X, Data 0x%02X", Register, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -2610,16 +2610,16 @@ void c140_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 {
 	UINT16 RegVal;
 	UINT8 Channel;
-	
+
 	WriteChipID(0x1C);
-	
+
 	RegVal = (Port << 8) | Register;
 	RegVal &= 0x1FF;
-	
+
 	// mirror the bank registers on the 219, fixes bkrtmaq (and probably xday2 based on notes in the HLE)
 	if ((RegVal >= 0x1F8) /*&& (info->banking_type == C140_TYPE_ASIC219)*/)
 		RegVal -= 0x008;
-	
+
 	if (RegVal < 0x180)
 	{
 		Channel = RegVal >> 4;
@@ -2671,7 +2671,7 @@ void c140_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 			sprintf(WriteStr, "Unknown Reg = 0x%02X", Data);
 			break;
 		}
-		
+
 		sprintf(TempStr, "%sCh %u %s", ChipStr, Channel, WriteStr);
 	}
 	else
@@ -2684,17 +2684,17 @@ void c140_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 		{
 			sprintf(WriteStr, "Reg 0x%03X, Data 0x%02X", RegVal, Data);
 		}
-		
+
 		sprintf(TempStr, "%s%s", ChipStr, WriteStr);
 	}
-	
+
 	return;
 }
 
 void c6280_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x1B);
-	
+
 	switch(Register & 0x0F)
 	{
 	case 0x00: // Channel select
@@ -2745,9 +2745,9 @@ void c6280_write(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(WriteStr, "Reg 0x%02X, Data 0x%02X", Register & 0x0F, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -2756,9 +2756,9 @@ void qsound_write(char* TempStr, UINT8 Offset, UINT16 Value)
 	UINT8 ch;
 	UINT8 reg;
 	INT8 TempByt;
-	
+
 	WriteChipID(0x1F);
-	
+
 	if (Offset < 0x80) // PCM registers
 	{
 		ch = Offset >> 3;
@@ -2853,7 +2853,7 @@ void qsound_write(char* TempStr, UINT8 Offset, UINT16 Value)
 		sprintf(TempStr, "%s%s", ChipStr, WriteStr);
 		return;
 	}
-	
+
 	switch(reg)
 	{
 	case 0: // Bank
@@ -2921,9 +2921,9 @@ void k053260_write(char* TempStr, UINT8 Register, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	WriteChipID(0x1D);
-	
+
 	if (Register < 0x08)
 	{
 		// communication registers
@@ -2960,7 +2960,7 @@ void k053260_write(char* TempStr, UINT8 Register, UINT8 Data)
 					Data & 0x7F, ((Data & 0x7F) * 100 + 0x3E) / 0x7F);
 			break;
 		}
-		
+
 		sprintf(WriteStr, "Ch %u: %s", (Register - 8) / 8, RedirectStr);
 	}
 	else
@@ -2985,7 +2985,7 @@ void k053260_write(char* TempStr, UINT8 Register, UINT8 Data)
 			{
 				if (! (CurChn & 0x03))
 					StrPos = strchr(WriteStr + StrPos, '-') - WriteStr;
-				
+
 				if (Data & (0x01 << CurChn))
 					WriteStr[StrPos] = '0' + (CurChn & 0x03);
 				StrPos ++;
@@ -3013,16 +3013,16 @@ void k053260_write(char* TempStr, UINT8 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
 void pokey_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	WriteChipID(0x1E);
-	
+
 	Register &= 0x0F;
 	switch(Register)
 	{
@@ -3068,9 +3068,9 @@ void pokey_write(char* TempStr, UINT8 Register, UINT8 Data)
 		sprintf(WriteStr, "SK Control: 0x%02X", Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3079,9 +3079,9 @@ void k051649_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	WriteChipID(0x19);
-	
+
 	switch(Port)
 	{
 	case 0x00:	// k051649_waveform_w
@@ -3126,9 +3126,9 @@ void k051649_write(char* TempStr, UINT8 Port, UINT8 Register, UINT8 Data)
 		sprintf(WriteStr, "Port %x Reg 0x%02X Data 0x%02X", Port, Register, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3137,9 +3137,9 @@ void okim6295_write(char* TempStr, UINT8 Port, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	WriteChipID(0x18);
-	
+
 	switch(Port)
 	{
 	case 0x00:	// okim6295_write_command
@@ -3155,7 +3155,7 @@ void okim6295_write(char* TempStr, UINT8 Port, UINT8 Data)
 			}
 			sprintf(WriteStr + StrPos, ", Volume: 0x%01X = %u%%",
 					Data & 0x0F, 100 * okim6295_voltbl[Data & 0x0F] / 0x20);
-			
+
 			CacheOKI6295[ChpCur].Command = 0xFF;
 		}
 		else if (Data & 0x80)
@@ -3209,16 +3209,16 @@ void okim6295_write(char* TempStr, UINT8 Port, UINT8 Data)
 		sprintf(WriteStr, "Port %02X: 0x%02X", Port, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
 void okim6258_write(char* TempStr, UINT8 Port, UINT8 Data)
 {
 	WriteChipID(0x17);
-	
+
 	switch(Port)
 	{
 	case 0x00:
@@ -3259,9 +3259,9 @@ void okim6258_write(char* TempStr, UINT8 Port, UINT8 Data)
 		sprintf(WriteStr, "Port %02X: 0x%02X", Port, Data);
 		break;
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3270,7 +3270,7 @@ static void FM_ADPCMAWrite(char* TempStr, UINT8 Register, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	switch(Register)
 	{
 	case 0x00:	// DM,--,C5,C4,C3,C2,C1,C0
@@ -3316,7 +3316,7 @@ static void FM_ADPCMAWrite(char* TempStr, UINT8 Register, UINT8 Data)
 		}
 	}
 	sprintf(TempStr, "ADPCM A: %s", WriteStr);
-	
+
 	return;
 }
 
@@ -3373,17 +3373,17 @@ static void YM_DELTAT_ADPCM_Write(char* TempStr, UINT8 Register, UINT8 Data)
 		break;
 	}
 	sprintf(TempStr, "DELTA-T: %s", WriteStr);
-	
+
 	return;
 }
 
 void multipcm_write(char* TempStr, UINT8 Port, UINT8 Data)
 {
 	MULTIPCM_DATA* TempMPCM;
-	
+
 	TempMPCM = &CacheMultiPCM[ChpCur];
 	WriteChipID(0x15);
-	
+
 	switch(Port)
 	{
 	case 0:		// Data write
@@ -3402,14 +3402,14 @@ void multipcm_write(char* TempStr, UINT8 Port, UINT8 Data)
 		break;
 	}
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 
 static void multipcm_WriteSlot(char* TempStr, INT8 Slot, UINT8 Register, UINT8 Data)
 {
 	INT8 TempSByt;
-	
+
 	switch(Register)
 	{
 	case 0:	// PANPOT
@@ -3443,19 +3443,19 @@ static void multipcm_WriteSlot(char* TempStr, INT8 Slot, UINT8 Register, UINT8 D
 		break;
 	}
 	sprintf(TempStr, "Channel %d: %s", Slot, WriteStr);
-	
+
 	return;
 }
 
 void multipcm_bank_write(char* TempStr, UINT8 Port, UINT16 Data)
 {
 	WriteChipID(0x15);
-	
+
 	sprintf(WriteStr, "Set Bank %c%c to 0x%06X",
 			(Port & 0x01) ? 'L' : '-', (Port & 0x02) ? 'R' : '-', Data << 16);
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3466,9 +3466,9 @@ void upd7759_write(char* TempStr, UINT8 Port, UINT8 Data)
 		CacheUPD7759[ChpCur].HasROM = Data ? true : false;
 		return;
 	}
-	
+
 	WriteChipID(0x16);
-	
+
 	switch(Port)
 	{
 	case 0:
@@ -3491,14 +3491,14 @@ void upd7759_write(char* TempStr, UINT8 Port, UINT8 Data)
 		break;
 	}
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
 void scsp_write(char* TempStr, UINT16 Register, UINT8 Data)
 {
 	WriteChipID(0x16);
-	
+
 	if (Register < 0x400)
 	{
 		int slot=Register/0x20;
@@ -3531,7 +3531,7 @@ void scsp_write(char* TempStr, UINT16 Register, UINT8 Data)
 	else
 		sprintf(WriteStr, "Register %03X: 0x%02X", Register, Data);
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3539,9 +3539,9 @@ void vsu_write(char* TempStr, UINT16 Register, UINT8 Data)
 {
 	UINT8 CurChn;
 	WriteChipID(0x22);
-	
+
 	Register <<= 2;	// all documentation uses offsets multiplied by 4
-	
+
 	if (Register < 0x280)
 	{
 		sprintf(WriteStr, "Chn %u WaveData 0x%02X = 0x%02X",
@@ -3602,9 +3602,9 @@ void vsu_write(char* TempStr, UINT16 Register, UINT8 Data)
 	{
 		sprintf(WriteStr, "Reg 0x%02X, Data 0x%02X", Register, Data);
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3613,9 +3613,9 @@ void saa1099_write(char* TempStr, UINT8 Register, UINT8 Data)
 	UINT8 CurChn;
 	UINT32 StrPos;
 	UINT8 ChnEn;
-	
+
 	WriteChipID(0x23);
-	
+
 	if (Register < 0x10)
 	{
 		CurChn = Register & 0x07;
@@ -3671,18 +3671,18 @@ void saa1099_write(char* TempStr, UINT8 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
 void x1_010_write(char* TempStr, UINT16 Offset, UINT8 val)
 {
 	UINT8 chan, pos;
-	
+
 	WriteChipID(0x26);
-	
+
 	if (Offset < 0x80)
 	{
 		chan = (Offset >> 3) & 0xfff;
@@ -3693,15 +3693,15 @@ void x1_010_write(char* TempStr, UINT16 Offset, UINT8 val)
 			if(val & 0x80)
 				sprintf(WriteStr, "%s, Divide Frequency", WriteStr);
 			if(val & 0x04)
-				sprintf(WriteStr, "%s, Loop", WriteStr);	
+				sprintf(WriteStr, "%s, Loop", WriteStr);
 			if(val & 0x02)
-				sprintf(WriteStr, "%s, Waveform", WriteStr);	
+				sprintf(WriteStr, "%s, Waveform", WriteStr);
 			else
 				sprintf(WriteStr, "%s, PCM", WriteStr);
 			if(val & 0x01)
-				sprintf(WriteStr, "%s, Key On", WriteStr);	
+				sprintf(WriteStr, "%s, Key On", WriteStr);
 			else
-				sprintf(WriteStr, "%s, Key Off", WriteStr);	
+				sprintf(WriteStr, "%s, Key Off", WriteStr);
 			break;
 		case 0x1:
 			sprintf(WriteStr, "Ch %u, Volume: %02X", chan, val);
@@ -3727,7 +3727,7 @@ void x1_010_write(char* TempStr, UINT16 Offset, UINT8 val)
 	{
 		chan = (Offset>>7)&0x1f;
 		pos = Offset&0x7f;
-		
+
 		if(Offset < 0x1000)
 		{
 			sprintf(WriteStr, "Envelope %u, position %02x: %02X", chan, pos, val);
@@ -3738,11 +3738,11 @@ void x1_010_write(char* TempStr, UINT16 Offset, UINT8 val)
 		}
 		else
 			sprintf(WriteStr, "Offset 0x%04X, Data 0x%2X", Offset, val);
-			
-		
+
+
 	}
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3750,9 +3750,9 @@ void c352_write(char* TempStr, UINT16 Offset, UINT16 val)
 {
 	UINT16 address = Offset* 2;
 	UINT8 chan;
-	
+
 	WriteChipID(0x27);
-	
+
 	if (address < 0x200)
 	{
 		chan = (address >> 4) & 0xfff;
@@ -3804,16 +3804,16 @@ void c352_write(char* TempStr, UINT16 Offset, UINT16 val)
 		}
 	}
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
 void es5503_write(char* TempStr, UINT8 Register, UINT8 Data)
 {
 	UINT8 CurChn;
-	
+
 	WriteChipID(0x24);
-	
+
 	if (Register < 0xE0)
 	{
 		CurChn = Register & 0x1F;
@@ -3864,9 +3864,9 @@ void es5503_write(char* TempStr, UINT8 Register, UINT8 Data)
 			break;
 		}
 	}
-	
+
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
-	
+
 	return;
 }
 
@@ -3877,10 +3877,10 @@ void es5506_w(char* TempStr, UINT8 offset, UINT8 data)
 		CacheES5506[ChpCur].Mode = data;
 		return;
 	}
-	
+
 	WriteChipID(0x25);
 	//opn_write(RedirectStr, OPN_YM2203, 0x00, Register, Data);
-	
+
 	if (offset < 0x40)
 	{
 		/*if (! CacheES5506[ChpCur].Mode)
@@ -3893,7 +3893,7 @@ void es5506_w(char* TempStr, UINT8 offset, UINT8 data)
 		sprintf(RedirectStr, "Set Voice %u Bank: 0x%06X", offset & 0x1F, data << 20);
 	}
 	sprintf(TempStr, "%s%s", ChipStr, RedirectStr);
-	
+
 	return;
 }
 

--- a/common.h
+++ b/common.h
@@ -63,14 +63,14 @@
 static void RemoveNewLines(char* String)
 {
 	char* strPtr;
-	
+
 	strPtr = String + strlen(String) - 1;
 	while(strPtr >= String && (UINT8)*strPtr < 0x20)	// <0x20 -> is Control Character
 	{
 		*strPtr = '\0';
 		strPtr --;
 	}
-	
+
 	return;
 }
 
@@ -78,35 +78,35 @@ static void RemoveQuotationMarks(char* String)
 {
 	size_t strLen;
 	char* endQMark;
-	
+
 	if (String[0] != QMARK_CHR)
 		return;
-	
+
 	strLen = strlen(String);
 	memmove(String, String + 1, strLen);	// Remove first char
 	endQMark = strrchr(String, QMARK_CHR);
 	if (endQMark != NULL)
 		*endQMark = '\0';	// Remove last Quot.-Mark
-	
+
 	return;
 }
 
 static void ReadFilename(char* buffer, size_t bufsize)
 {
 	char* retStr;
-	
+
 	retStr = fgets(buffer, bufsize, stdin);
 	if (retStr == NULL)
 		buffer[0] = '\0';
-	
+
 #ifdef _WIN32
 	if (GetConsoleCP() == GetOEMCP())
 		OemToChar(buffer, buffer);	// OEM -> ANSI conversion
 #endif
-	
+
 	RemoveNewLines(buffer);
 	RemoveQuotationMarks(buffer);
-	
+
 	return;
 }
 
@@ -114,10 +114,10 @@ INLINE void DblClickWait(const char* argv0)
 {
 #ifdef _WIN32
 	char* msystem;
-	
+
 	if (argv0[1] != ':')
 		return;	// not called with an absolute path
-	
+
 	msystem = getenv("MSYSTEM");
 	if (msystem != NULL)
 	{
@@ -127,13 +127,13 @@ INLINE void DblClickWait(const char* argv0)
 			! strncmp(msystem, "MSYS", 4))
 			return;
 	}
-	
+
 	// Executed by Double-Clicking (or Drag and Drop),
 	// so let's keep the window open until the user presses a key.
 	if (_kbhit())
 		_getch();
 	_getch();
-	
+
 	return;
 #else
 	// Double-clicking a console application on Unix doesn't open
@@ -148,12 +148,12 @@ static void PrintMinSec(const UINT32 SamplePos, char* TempStr)
 {
 	float TimeSec;
 	UINT16 TimeMin;
-	
+
 	TimeSec = (float)SamplePos / 44100.0f;
 	TimeMin = (UINT16)(TimeSec / 60);
 	TimeSec -= TimeMin * 60;
 	sprintf(TempStr, "%02u:%05.2f", TimeMin, TimeSec);
-	
+
 	return;
 }
 

--- a/dro2vgm.c
+++ b/dro2vgm.c
@@ -67,12 +67,12 @@ int main(int argc, char* argv[])
 	int argbase;
 	int ErrVal;
 	char FileName[0x100];
-	
+
 	printf("DRO to VGM Converter\n--------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenDROFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -93,19 +93,19 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	ConvertDRO2VGM();
-	
+
 	strcpy(FileName, FileBase);
 	strcat(FileName, ".vgm");
 	WriteVGMFile(FileName);
-	
+
 	free(DROData);
 	free(VGMData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -118,11 +118,11 @@ static bool OpenDROFile(const char* FileName)
 	UINT32 TempLng;
 	char* TempPnt;
 	DRO_VER_HEADER_1 DRO_V1;
-	
+
 	hFile = fopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	fseek(hFile, 0x00, SEEK_SET);
 	fread(&fccHeader, 0x01, 0x04, hFile);
 	if (fccHeader != FCC_DRO1)
@@ -130,21 +130,21 @@ static bool OpenDROFile(const char* FileName)
 	fread(&fccHeader, 0x01, 0x04, hFile);
 	if (fccHeader != FCC_DRO2)
 		goto OpenErr;
-	
+
 	fseek(hFile, 0x00, SEEK_END);
 	DRODataLen = ftell(hFile);
-	
+
 	// Read Data
 	DROData = (UINT8*)malloc(DRODataLen);
 	if (DROData == NULL)
 		goto OpenErr;
 	fseek(hFile, 0x00, SEEK_SET);
 	DRODataLen = fread(DROData, 0x01, DRODataLen, hFile);
-	
+
 	CurPos = 0x00;
 	memcpy(&DROHead, &DROData[0x00], sizeof(DRO_HEADER));
 	CurPos += sizeof(DRO_HEADER);
-	
+
 	memcpy(&TempLng, &DROData[0x08], 0x04);
 	if (TempLng & 0xFF00FF00)
 	{
@@ -165,7 +165,7 @@ static bool OpenDROFile(const char* FileName)
 			DROHead.iVersionMajor = TempSht;
 		}
 	}
-	
+
 	switch(DROHead.iVersionMajor)
 	{
 	case 0:	// Version 0 (DosBox Version 0.61)
@@ -182,7 +182,7 @@ static bool OpenDROFile(const char* FileName)
 			CurPos += sizeof(DRO_VER_HEADER_1);
 			break;
 		}
-		
+
 		DROInf.iLengthPairs = DRO_V1.iLengthBytes >> 1;
 		DROInf.iLengthMS = DRO_V1.iLengthMS;
 		switch(DRO_V1.iHardwareType)
@@ -202,18 +202,18 @@ static bool OpenDROFile(const char* FileName)
 		DROInf.iShortDelayCode = 0x00;
 		DROInf.iLongDelayCode = 0x01;
 		DROInf.iCodemapLength = 0x00;
-		
+
 		break;
 	case 2:	// Version 2 (DosBox Version 0.73)
 		// sizeof(DRO_VER_HEADER_2) returns 0x10, but the exact size is 0x0E
 		memcpy(&DROInf, &DROData[CurPos], 0x0E);
 		CurPos += 0x0E;
-		
+
 		break;
 	default:
 		goto OpenErr;
 	}
-	
+
 	if (DROInf.iCodemapLength)
 	{
 		DROCodemap = (UINT8*)malloc(DROInf.iCodemapLength * sizeof(UINT8));
@@ -228,7 +228,7 @@ static bool OpenDROFile(const char* FileName)
 	CurPos += DROInf.iLengthPairs << 1;
 	if (CurPos < DRODataLen)
 		DRODataLen = CurPos;
-	
+
 	// Generate VGM Header
 	memset(&VGMHead, 0x00, sizeof(VGM_HEADER));
 	VGMHead.fccVGM = FCC_VGM;
@@ -251,14 +251,14 @@ static bool OpenDROFile(const char* FileName)
 		VGMHead.lngHzYM3812 = 3579545 | 0x40000000;
 		break;
 	}
-	
+
 	fclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -270,13 +270,13 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	fwrite(VGMData, 0x01, VGMDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -291,10 +291,10 @@ static void ConvertDRO2VGM(void)
 	UINT32 VGMSmplL;
 	UINT32 VGMSmplC;
 	UINT32 SmplVal;
-	
+
 	VGMDataLen = DRODataLen * 0x04; // this should be 200% safe
 	VGMData = (UINT8*)malloc(VGMDataLen);
-	
+
 	printf("DRO File Version: %u.%02u\n", DROHead.iVersionMajor, DROHead.iVersionMinor);
 	DROPos = DRODataStart;
 	VGMPos = VGMHead.lngDataOffset;
@@ -302,12 +302,12 @@ static void ConvertDRO2VGM(void)
 	CurMS = 0x00;
 	VGMSmplL = 0x00;
 	VGMSmplC = 0x00;
-	
+
 	CurChip = 0x00;
 	while(DROPos < DRODataLen)
 	{
 		CurCmd = DROData[DROPos + 0x00];
-		
+
 		if (DROHead.iVersionMajor <= 0x01)
 		{
 			if (CurCmd <= 0x04 && DROPos < 0x20)
@@ -349,11 +349,11 @@ static void ConvertDRO2VGM(void)
 					CurMS += TempSht;
 				else if (CurCmd == DROInf.iLongDelayCode)
 					CurMS += TempSht << 8;
-				
+
 				DROPos += 0x02;
 				break;
 			}
-			
+
 			VGMSmplC = (UINT32)(CurMS * 44.1f + 0.5f);
 		}
 		else if (DROHead.iVersionMajor <= 0x01 && (CurCmd == 0x02 || CurCmd == 0x03))
@@ -372,7 +372,7 @@ static void ConvertDRO2VGM(void)
 						TempSht = (UINT16)SmplVal;
 					else
 						TempSht = 0xFFFF;
-					
+
 					VGMData[VGMPos + 0x00] = 0x61;
 					memcpy(&VGMData[VGMPos + 0x01], &TempSht, 0x02);
 					VGMPos += 0x03;
@@ -380,7 +380,7 @@ static void ConvertDRO2VGM(void)
 				}
 				VGMSmplL = VGMSmplC;
 			}
-			
+
 			switch(DROHead.iVersionMajor)
 			{
 			case 0x00:
@@ -399,7 +399,7 @@ static void ConvertDRO2VGM(void)
 			}
 			CurVal = DROData[DROPos + 0x01];
 			DROPos += 0x02;
-			
+
 			ChipCmd = 0x00;
 			switch(DROInf.iHardwareType)
 			{
@@ -425,23 +425,23 @@ static void ConvertDRO2VGM(void)
 	}
 	VGMData[VGMPos + 0x00] = 0x66;
 	VGMPos += 0x01;
-	
+
 	if (VGMSmplL != VGMHead.lngTotalSamples)
 	{
 		printf("Warning! There was an error during delay calculations!\n");
 		printf("DRO ms Header: %u, counted: %u\n", DROInf.iLengthMS, CurMS);
 		printf("Please relog the file with DosBox 0.73 or higher.\n");
 	}
-	
+
 	VGMDataLen = VGMPos;
 	VGMHead.lngEOFOffset = VGMDataLen;
-	
+
 	SmplVal = VGMHead.lngDataOffset;
 	if (SmplVal > sizeof(VGM_HEADER))
 		SmplVal = sizeof(VGM_HEADER);
 	VGMHead.lngDataOffset -= 0x34;
 	VGMHead.lngEOFOffset -= 0x04;
 	memcpy(&VGMData[0x00], &VGMHead, SmplVal);
-	
+
 	return;
 }

--- a/opl_23.c
+++ b/opl_23.c
@@ -43,9 +43,9 @@ int main(int argc, char* argv[])
 	UINT32 NewClk_OPL2;
 	UINT32 NewClk_OPL3;
 	int OPLout;
-	
+
 	printf("OPL 2<->3 Converter\n-------------------\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	ConvMode = 0xFF;
@@ -80,13 +80,13 @@ int main(int argc, char* argv[])
 		printf("    d22 - Dual OPL2 -> Single OPL2\n");
 		return 0;
 	}
-	
+
 	printf("File Name:\t");
 	strcpy(FileName, argv[argbase + 0]);
 	printf("%s\n", FileName);
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	OPLout = 0;
 	NeedProcessing = false;
 	switch(ConvMode)
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
 		memcpy(&VGMData[0x50], &NewClk_OPL2, 0x04);
 		memcpy(&VGMData[0x5C], &NewClk_OPL3, 0x04);
 		CompressVGMData();
-		
+
 		if (argc > argbase + 1)
 			strcpy(FileName, argv[argbase + 1]);
 		else
@@ -162,13 +162,13 @@ int main(int argc, char* argv[])
 			sprintf(FileName, "%s_opl%u.vgm", FileBase, OPLout);
 		WriteVGMFile(FileName);
 	}
-	
+
 	free(VGMData);
 	//free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -178,20 +178,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -223,7 +223,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -233,7 +233,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -241,14 +241,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -260,14 +260,14 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	//fwrite(DstData, 0x01, DstDataLen, hFile);
 	fwrite(VGMData, 0x01, VGMDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -289,18 +289,18 @@ static void CompressVGMData(void)
 	bool SkipCmdCopy;
 	UINT16 LastOPLCmd;
 	UINT32 LoopPosN;
-	
+
 	UsePosN = false;
 	if (ConvMode == CONV_DUAL2to2)
 		UsePosN = true;
-	
+
 	//DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	VGMPos = VGMHead.lngDataOffset;
 	VGMPosN = VGMPos;
 	//DstPos = VGMHead.lngDataOffset;
 	VGMSmplPos = 0;
 	//memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 	StopVGM = false;
 	SkipCmdCopy = false;
 	LastOPLCmd = 0xFFFF;
@@ -310,7 +310,7 @@ static void CompressVGMData(void)
 			LoopPosN = VGMPosN;
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -329,7 +329,7 @@ static void CompressVGMData(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			ChipID = 0x00;
 			switch(Command)
@@ -364,7 +364,7 @@ static void CompressVGMData(void)
 				}
 				break;
 			}
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -399,7 +399,7 @@ static void CompressVGMData(void)
 							VGMPnt[0x02] |= OPL3_RIGHT;
 						break;
 					}
-					
+
 					if (VGMPnt[0x01] == 0x05)
 					{
 						VGMPnt[0x00] = 0x5F;
@@ -462,10 +462,10 @@ static void CompressVGMData(void)
 				break;
 			case 0x67:	// PCM Data Stream
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				CmdLen = 0x07 + TempLng;
 				break;
 			case 0xE0:	// Seek to PCM Data Bank Pos
@@ -525,7 +525,7 @@ static void CompressVGMData(void)
 				break;
 			}
 		}
-		
+
 		if (UsePosN)
 		{
 			if (SkipCmdCopy)
@@ -543,7 +543,7 @@ static void CompressVGMData(void)
 			break;
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (UsePosN)
 	{
 		if (LoopPosN)
@@ -563,6 +563,6 @@ static void CompressVGMData(void)
 			memcpy(&VGMData[0x14], &TempLng, 0x04);
 		}
 	}
-	
+
 	return;
 }

--- a/opt_oki.c
+++ b/opt_oki.c
@@ -67,7 +67,7 @@ static void MakeDataStream(void);
 static void WriteDACStreamCmd(STRM_CTRL_CMD* StrmCmd, UINT32* DestPos);
 static void RewriteVGMData(void);
 
-#define printdbg	
+#define printdbg
 //#define printdbg	printf
 
 
@@ -108,9 +108,9 @@ int main(int argc, char* argv[])
 	int ErrVal;
 	char FileName[0x100];
 	UINT8 CurChip;
-	
+
 	printf("VGM OKI Optimizer\n-----------------\n\n");
-	
+
 	MaxDrumDelay = 500;
 	DumpDrums = false;
 	Skip80Sample = 0;
@@ -119,9 +119,9 @@ int main(int argc, char* argv[])
 	SplitCmd = 0x00;
 	ErrVal = 0;
 	argbase = 1;
-	
+
 	CHANGING_CLK_RATE = false;
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -134,7 +134,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -142,27 +142,27 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	VGMCtrlCmd = NULL;
 	EnumerateOkiWrite();
 	MakeDrumTable();
 	MakeDataStream();
-	
+
 	for (CurChip = 0x00; CurChip < ChipCnt; CurChip ++)
 	{
 		free(VGMWrite[CurChip]);	VGMWrite[CurChip] = NULL;
 		WriteAlloc[CurChip] = 0x00;
 		WriteCount[CurChip] = 0x00;
 	}
-	
+
 	RewriteVGMData();
-	
+
 	free(VGMCtrlCmd);	VGMCtrlCmd = NULL;
 	CtrlCmdAlloc = 0x00;
 	CtrlCmdCount = 0x00;
 	printf("Data Compression: %u -> %u (%.1f %%)\n",
 			DataSizeA, DataSizeB, 100.0 * DataSizeB / (float)DataSizeA);
-	
+
 	if (DataSizeB < DataSizeA)
 	{
 		if (argc > argbase + 1)
@@ -176,13 +176,13 @@ int main(int argc, char* argv[])
 		}
 		WriteVGMFile(FileName);
 	}
-	
+
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -192,20 +192,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -237,7 +237,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000151)
 		CurPos = 0x40;
@@ -247,7 +247,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -255,14 +255,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -274,7 +274,7 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
@@ -283,9 +283,9 @@ static void WriteVGMFile(const char* FileName)
 	}
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -304,11 +304,11 @@ static void EnumerateOkiWrite(void)
 	UINT32 CmdLen;
 	bool StopVGM;
 	DATA_WRITE* TempWrt;
-	
+
 	VGMLoopSmplOfs = VGMHead.lngTotalSamples - VGMHead.lngLoopSamples;
 	VGMPos = VGMHead.lngDataOffset;
 	VGMSmplPos = 0;
-	
+
 	ChipCnt = (VGMHead.lngHzOKIM6258 & 0x40000000) ? 2 : 1;
 	for (CurChip = 0x00; CurChip < ChipCnt; CurChip ++)
 	{
@@ -322,7 +322,7 @@ static void EnumerateOkiWrite(void)
 	}
 	for (CurChip = 0x00; CurChip < 0x02; CurChip ++)
 		WriteCount[CurChip] = 0x00;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -331,7 +331,7 @@ static void EnumerateOkiWrite(void)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -385,7 +385,7 @@ static void EnumerateOkiWrite(void)
 					}
 					TempWrt = &VGMWrite[CurChip][WriteCount[CurChip]];
 					WriteCount[CurChip] ++;
-					
+
 					TempWrt->Port = VGMData[VGMPos + 0x01] & 0x7F;
 					TempWrt->Value = VGMData[VGMPos + 0x02];
 					TempWrt->SmplPos = VGMSmplPos;
@@ -417,7 +417,7 @@ static void EnumerateOkiWrite(void)
 				TempByt = VGMData[VGMPos + 0x02];
 				memcpy(&TempLng, &VGMData[VGMPos + 0x03], 0x04);
 				TempLng &= 0x7FFFFFFF;
-				
+
 				CmdLen = 0x07 + TempLng;
 				break;
 			case 0x90:	// DAC Ctrl: Setup Chip
@@ -467,11 +467,11 @@ static void EnumerateOkiWrite(void)
 				break;
 			}
 		}
-		
+
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -486,9 +486,9 @@ static void EnumerateOkiWrite(void)
 #endif
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	printf("%u OKI writes found.\n", WriteCount[0]);
-	
+
 	return;
 }
 
@@ -502,7 +502,7 @@ static void AddPlayWrite(DRUM_INF* DrumInf, DRUM_PLAY* DrumPlay)
 	}
 	DrumInf->PlayData[DrumInf->PlayCount] = *DrumPlay;
 	DrumInf->PlayCount ++;
-	
+
 	return;
 }
 
@@ -510,7 +510,7 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 {
 	UINT32 CurDrm;
 	DRUM_INF* TempDrm;
-	
+
 	if (Size == 0x00)
 	{
 		return;
@@ -518,7 +518,7 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 	else if (Size == 0x01)
 	{
 		DATA_WRITE* TempWrt;
-		
+
 		CurDrm = DrumPlay->WriteSt;
 		TempWrt = &VGMWrite[CurDrm >> 31][CurDrm & 0x7FFFFFFF];
 		if (TempWrt->Value == 0x80 || TempWrt->Value == 0x88 || TempWrt->Value == 0x08)
@@ -533,7 +533,7 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 		AddPlayWrite(&DrumTbl.DrumNull, DrumPlay);
 		return;
 	}
-	
+
 	for (CurDrm = 0x00; CurDrm < DrumTbl.DrmCount; CurDrm ++)
 	{
 		TempDrm = &DrumTbl.Drums[CurDrm];
@@ -561,9 +561,9 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 				{
 					char DrumDump_Name[MAX_PATH + 0x10];
 					FILE* hFile;
-					
+
 					sprintf(DrumDump_Name, "%s_%03X.raw", FileBase, CurDrm);
-					
+
 					hFile = fopen(DrumDump_Name, "wb");
 					if (hFile != NULL)
 					{
@@ -571,13 +571,13 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 						fclose(hFile);
 					}
 				}
-				
+
 				AddPlayWrite(TempDrm, DrumPlay);
 				return;
 			}
 		}
 	}
-	
+
 	// not found, add new drum sound
 	if (DrumTbl.DrmCount >= DrumTbl.DrmAlloc)
 	{
@@ -587,7 +587,7 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 	}
 	TempDrm = &DrumTbl.Drums[DrumTbl.DrmCount];
 	//printdbg("Adding Drum %u (0x%X bytes)\n", DrumTbl.DrmCount, Size);
-	
+
 	TempDrm->Data = (UINT8*)malloc(Size);
 	memcpy(TempDrm->Data, Data, Size);
 	TempDrm->Length = Size;
@@ -595,9 +595,9 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 	{
 		char DrumDump_Name[MAX_PATH + 0x10];
 		FILE* hFile;
-		
+
 		sprintf(DrumDump_Name, "%s_%03X.raw", FileBase, DrumTbl.DrmCount);
-		
+
 		hFile = fopen(DrumDump_Name, "wb");
 		if (hFile != NULL)
 		{
@@ -605,14 +605,14 @@ static void AddDrum(UINT32 Size, UINT8* Data, DRUM_PLAY* DrumPlay)
 			fclose(hFile);
 		}
 	}
-	
+
 	TempDrm->PlayCount = 0x00;
 	TempDrm->PlayAlloc = 0x100;
 	TempDrm->PlayData = (DRUM_PLAY*)malloc(TempDrm->PlayAlloc * sizeof(DRUM_PLAY));
 	DrumTbl.DrmCount ++;
-	
+
 	AddPlayWrite(TempDrm, DrumPlay);
-	
+
 	return;
 }
 
@@ -630,20 +630,20 @@ static void MakeDrumTable(void)
 	UINT8 CurClkDiv;
 	UINT8 DrumEnd;
 	UINT32 SkippedWrt;
-	
+
 	if (! WriteCount)
 		return;
-	
+
 	DrumTbl.DrmCount = 0x00;
 	DrumTbl.DrmAlloc = 0x100;
 	DrumTbl.Drums = (DRUM_INF*)malloc(DrumTbl.DrmAlloc * sizeof(DRUM_INF));
 	DrumTbl.DrumNull.PlayCount = 0x00;
 	DrumTbl.DrumNull.PlayAlloc = 0x1000;
 	DrumTbl.DrumNull.PlayData = (DRUM_PLAY*)malloc(DrumTbl.DrumNull.PlayAlloc * sizeof(DRUM_PLAY));
-	
+
 	DrmBufAlloc = 0x10000;	// 64 KB should be enough for now
 	DrumBuf = (UINT8*)malloc(DrmBufAlloc);
-	
+
 	printf("Generating Drum Table ...\n");
 	for (CurChip = 0x00; CurChip < ChipCnt; CurChip ++)
 	{
@@ -707,7 +707,7 @@ static void MakeDrumTable(void)
 			}
 			if (TempWrt->Port == 0x0C)
 				CurClkDiv = TempWrt->Value;
-			
+
 			if (DrumEnd)
 			{
 				if (EarlyDataWrt && DrmBufSize >= 2 && DrumEnd == 0x01)
@@ -722,19 +722,19 @@ static void MakeDrumTable(void)
 							LastWrt --;
 					}
 				}
-				
+
 				printdbg("new drum at SmplOfs %u (buffer %u bytes)\n", SmplLastWrt, DrmBufSize);
 				if (Skip80Sample == 1 && DrmBufSize > 1 &&
 					VGMWrite[CurChip][LastWrt].Value == Smpl80Value)
 				{
 					// Castlevania sends a 0x80 byte when stopping a sound
-					
+
 					// add drum without last data write
 					DrumPlay.WriteEnd = LastWrt - 1;
 					while(DrumPlay.WriteEnd && VGMWrite[CurChip][DrumPlay.WriteEnd].Port != 0x01)
 						DrumPlay.WriteEnd --;
 					AddDrum(DrmBufSize - 1, DrumBuf, &DrumPlay);
-					
+
 					// add that write seperately
 					DrumPlay.WriteSt = LastWrt | (CurChip << 31);
 					DrumPlay.WriteEnd = LastWrt;
@@ -747,7 +747,7 @@ static void MakeDrumTable(void)
 				{
 					// Star Mobile sends one or two 0x08 bytes before starting any sound
 					UINT32 splitWrites;
-					
+
 					// add drum without last data write
 					DrumPlay.WriteEnd = LastWrt - 1;
 					while(DrumPlay.WriteEnd && VGMWrite[CurChip][DrumPlay.WriteEnd].Port != 0x01)
@@ -763,7 +763,7 @@ static void MakeDrumTable(void)
 							DrumPlay.WriteEnd --;
 					}
 					AddDrum(DrmBufSize - splitWrites, DrumBuf, &DrumPlay);
-					
+
 					// add that write seperately
 					DrumPlay.WriteSt = LastWrt | (CurChip << 31);
 					DrumPlay.WriteEnd = LastWrt;
@@ -775,14 +775,14 @@ static void MakeDrumTable(void)
 					VGMWrite[CurChip][LastWrt].Value == Smpl80Value)
 				{
 					// Chase H.Q. sends 2x 0x88 before playing ANYTHING
-					
+
 					// add drum without last data write
 					DrumPlay.WriteEnd = LastWrt - 1;
 					while(DrumPlay.WriteEnd && VGMWrite[CurChip][DrumPlay.WriteEnd].Port != 0x01)
 						DrumPlay.WriteEnd --;
 					DrumPlay.WriteEnd --;
 					AddDrum(DrmBufSize - 2, DrumBuf, &DrumPlay);
-					
+
 					// add that write seperately
 					DrumPlay.WriteSt = LastWrt | (CurChip << 31);
 					DrumPlay.WriteEnd = LastWrt;
@@ -798,7 +798,7 @@ static void MakeDrumTable(void)
 					while(DrumPlay.WriteEnd && VGMWrite[CurChip][DrumPlay.WriteEnd].Port != 0x01)
 						DrumPlay.WriteEnd --;
 					AddDrum(DrmBufSize - 1, DrumBuf, &DrumPlay);
-					
+
 					// add that write seperately
 					DrumPlay.WriteSt = LastWrt | (CurChip << 31);
 					DrumPlay.WriteEnd = LastWrt;
@@ -806,7 +806,7 @@ static void MakeDrumTable(void)
 					DrmBufSize = 0x00;
 					continue;
 				}
-				
+
 				DrumPlay.WriteEnd = LastWrt;
 				AddDrum(DrmBufSize, DrumBuf, &DrumPlay);
 				DrmBufSize = 0x00;
@@ -819,7 +819,7 @@ static void MakeDrumTable(void)
 					DrmBufSize ++;
 				}
 			}
-			
+
 			if (TempWrt->Port == 0x01)
 			{
 				// add data command to buffer
@@ -832,7 +832,7 @@ static void MakeDrumTable(void)
 					DrumPlay.WriteSt = CurWrt | (CurChip << 31);
 				DrumBuf[DrmBufSize] = TempWrt->Value;
 				DrmBufSize ++;
-				
+
 				SmplLastWrt = TempWrt->SmplPos;
 				LastWrt = CurWrt;
 			}
@@ -841,13 +841,13 @@ static void MakeDrumTable(void)
 			VGMWrite[CurChip][LastWrt].Value == Smpl80Value)
 		{
 			// Castlevania sends a 0x80 byte when stopping a sound
-			
+
 			// add drum without last data write
 			DrumPlay.WriteEnd = LastWrt - 1;
 			while(DrumPlay.WriteEnd && VGMWrite[CurChip][DrumPlay.WriteEnd].Port != 0x01)
 				DrumPlay.WriteEnd --;
 			AddDrum(DrmBufSize - 1, DrumBuf, &DrumPlay);
-			
+
 			// add that write seperately
 			DrumPlay.WriteSt = LastWrt | (CurChip << 31);
 			DrumPlay.WriteEnd = LastWrt;
@@ -861,7 +861,7 @@ static void MakeDrumTable(void)
 		}
 	}
 	printf("%u drum sounds found\n", DrumTbl.DrmCount);
-	
+
 	return;
 }
 
@@ -876,7 +876,7 @@ static int drum_sort_compare(const void* p1, const void* p2)
 {
 	DRM_SORT* Drm1 = (DRM_SORT*)p1;
 	DRM_SORT* Drm2 = (DRM_SORT*)p2;
-	
+
 	if (Drm1->SortID < Drm2->SortID)
 		return -1;
 	else if (Drm1->SortID == Drm2->SortID)
@@ -893,7 +893,7 @@ static void MakeDataStream(void)
 {
 	UINT32 BaseFreq;
 	UINT8 LastDiv;
-	
+
 	UINT32 CurDrm;
 	UINT32 CurPlay;
 	UINT32 CurSrt;
@@ -909,18 +909,18 @@ static void MakeDataStream(void)
 	UINT32 SmplDiff;
 	UINT32 FreqVal;
 	UINT8 IsStopped;
-	
+
 	LastDiv = VGMHead.bytOKI6258Flags & 0x03;
 	BaseFreq = (VGMHead.lngHzOKIM6258 + dividers[LastDiv] / 2) / dividers[LastDiv];
 	printf("Calculated base freq: %u\n", BaseFreq);
-	
+
 	// create list of all played drums
 	DrmSrtCount = 0x00;
 	DrmSrtCount += DrumTbl.DrumNull.PlayCount;
 	for (CurDrm = 0x00; CurDrm < DrumTbl.DrmCount; CurDrm ++)
 		DrmSrtCount += DrumTbl.Drums[CurDrm].PlayCount;
 	DrumSort = (DRM_SORT*)malloc(DrmSrtCount * sizeof(DRM_SORT));
-	
+
 	printf("Sorting %u play commands...\n", DrmSrtCount);
 	TempSort = DrumSort;
 	TempDrm = &DrumTbl.DrumNull;
@@ -946,16 +946,16 @@ static void MakeDataStream(void)
 			TempSort ++;
 		}
 	}
-	
+
 	// and sort by WriteID
 	qsort(DrumSort, DrmSrtCount, sizeof(DRM_SORT), &drum_sort_compare);
-	
+
 	// Now general all the special DAC Stream commands.
-	
+
 	// (Command 90/91) * Chip Count + (Command 92/95) * played drums
 	CtrlCmdAlloc = 0x03 * ChipCnt + 0x02 * DrmSrtCount;	// should be just enough
 	VGMCtrlCmd = (STRM_CTRL_CMD*)malloc(CtrlCmdAlloc * sizeof(STRM_CTRL_CMD));
-	
+
 	CtrlCmdCount = 0x00;
 	for (CurChip = 0x00; CurChip < ChipCnt; CurChip ++)
 	{
@@ -967,7 +967,7 @@ static void MakeDataStream(void)
 		TempCmd->DataB1 = 0x17 | (CurChip << 7);	// 0x17 - OKIM6258 chip
 		TempCmd->DataB2 = 0x00;
 		TempCmd->DataB3 = 0x01;		// command 01: data write
-		
+
 		TempCmd = &VGMCtrlCmd[CtrlCmdCount];
 		CtrlCmdCount ++;
 		TempCmd->FileOfs = 0x00;
@@ -978,7 +978,7 @@ static void MakeDataStream(void)
 		TempCmd->DataB3 = 0x00;		// Step Base
 		LastFreq[CurChip] = 0;
 		IsStopped = 0x00;
-		
+
 //#ifndef CHANGING_RATE
 		if (! CHANGING_CLK_RATE)
 		{
@@ -992,7 +992,7 @@ static void MakeDataStream(void)
 		}
 //#endif
 	}
-	
+
 	for (CurSrt = 0x00; CurSrt < DrmSrtCount; CurSrt ++)
 	{
 		TempSort = &DrumSort[CurSrt];
@@ -1002,7 +1002,7 @@ static void MakeDataStream(void)
 			CurPlay = TempSort->PlayID;
 			CurChip = (TempDrm->PlayData[CurPlay].WriteSt & 0x80000000) >> 31;
 			CurWrt = TempDrm->PlayData[CurPlay].WriteSt & 0x7FFFFFFF;
-			
+
 			TempCmd = &VGMCtrlCmd[CtrlCmdCount];
 			CtrlCmdCount ++;
 			TempCmd->FileOfs = VGMWrite[CurChip][CurWrt].FilePos;
@@ -1015,12 +1015,12 @@ static void MakeDataStream(void)
 			IsStopped |= 1 << CurChip;
 			continue;
 		}
-		
+
 		TempDrm = &DrumTbl.Drums[TempSort->DrumID];
 		CurPlay = TempSort->PlayID;
 		CurChip = (TempDrm->PlayData[CurPlay].WriteSt & 0x80000000) >> 31;
 		CurWrt = TempDrm->PlayData[CurPlay].WriteSt & 0x7FFFFFFF;
-		
+
 		if (CHANGING_CLK_RATE)
 		{
 			// calculate frequency
@@ -1036,7 +1036,7 @@ static void MakeDataStream(void)
 				CmdDiff = 44100 * CmdDiff + SmplDiff / 2;
 				FreqVal = (UINT32)(CmdDiff / SmplDiff);
 				//printf("OKI Frequency [Drum %u, No. %u]: %u\n", TempSort->DrumID, CurPlay, FreqVal);
-				
+
 				CmdDiff = 0;
 				for (CurPlay = 0; CurPlay < 6; CurPlay ++)
 				{
@@ -1082,7 +1082,7 @@ static void MakeDataStream(void)
 			}
 		}	// end if (CHANGING_CLK_RATE)
 //#endif
-		
+
 		TempCmd = &VGMCtrlCmd[CtrlCmdCount];
 		CtrlCmdCount ++;
 		TempCmd->FileOfs = VGMWrite[CurChip][CurWrt].FilePos;
@@ -1093,14 +1093,14 @@ static void MakeDataStream(void)
 		IsStopped &= ~(1 << CurChip);
 	}
 	printf("Done.\n");
-	
+
 	return;
 }
 
 static void WriteDACStreamCmd(STRM_CTRL_CMD* StrmCmd, UINT32* DestPos)
 {
 	UINT32 DstPos;
-	
+
 	DstPos = *DestPos;
 	DstData[DstPos + 0x00] = StrmCmd->Command;
 	DstData[DstPos + 0x01] = StrmCmd->StreamID;
@@ -1132,7 +1132,7 @@ static void WriteDACStreamCmd(STRM_CTRL_CMD* StrmCmd, UINT32* DestPos)
 		break;
 	}
 	*DestPos = DstPos;
-	
+
 	return;
 }
 
@@ -1157,10 +1157,10 @@ static void RewriteVGMData(void)
 	bool WriteExtra;
 	UINT32 NewLoopS;
 	UINT32 StrmCmd;
-	
+
 	UINT16 LoopSmplID = (UINT16)-1;
 	UINT16 LastSmplID = (UINT16)-1;
-	
+
 	DstDataLen = VGMDataLen + 0x100;
 	DstData = (UINT8*)malloc(DstDataLen);
 	AllDelay = 0;
@@ -1169,12 +1169,12 @@ static void RewriteVGMData(void)
 	VGMSmplPos = 0;
 	NewLoopS = 0x00;
 	memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
 	StopVGM = false;
-	
+
 	for (TempLng = 0x00; TempLng < DrumTbl.DrmCount; TempLng ++)
 	{
 		TempDrm = &DrumTbl.Drums[TempLng];
@@ -1186,12 +1186,12 @@ static void RewriteVGMData(void)
 		memcpy(&DstData[DstPos + 0x07], TempDrm->Data, TempDrm->Length);
 		DstPos += 0x07 + TempDrm->Length;
 	}
-	
+
 	for (StrmCmd = 0x00; StrmCmd < CtrlCmdCount; StrmCmd ++)
 	{
 		if (VGMCtrlCmd[StrmCmd].FileOfs)
 			break;
-		
+
 		//printdbg("Write DAC command %u, DstPos 0x%X\n", StrmCmd, DstPos);
 		WriteDACStreamCmd(&VGMCtrlCmd[StrmCmd], &DstPos);
 	}
@@ -1205,7 +1205,7 @@ static void RewriteVGMData(void)
 		//if (VGMPos == VGMHead.lngLoopOffset)
 		//	WriteExtra = true;
 		WriteExtra = (VGMPos == VGMHead.lngLoopOffset);
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -1273,7 +1273,7 @@ static void RewriteVGMData(void)
 				TempByt = VGMData[VGMPos + 0x02];
 				memcpy(&TempLng, &VGMData[VGMPos + 0x03], 0x04);
 				TempLng &= 0x7FFFFFFF;
-				
+
 				CmdLen = 0x07 + TempLng;
 				break;
 			case 0x90:	// DAC Ctrl: Setup Chip
@@ -1323,7 +1323,7 @@ static void RewriteVGMData(void)
 				break;
 			}
 		}
-		
+
 		if (WriteEvent || WriteExtra)
 		{
 			if (VGMPos != VGMHead.lngLoopOffset)
@@ -1337,7 +1337,7 @@ static void RewriteVGMData(void)
 					TempSht = (UINT16)AllDelay;
 				else
 					TempSht = 0xFFFF;
-				
+
 				if (! TempSht)
 				{
 					// don't do anything - I just want to be safe
@@ -1393,13 +1393,13 @@ static void RewriteVGMData(void)
 			}
 			AllDelay = CmdDelay;
 			CmdDelay = 0x00;
-			
+
 			if (VGMPos == VGMHead.lngLoopOffset)
 			{
 				NewLoopS = DstPos;
 				LoopSmplID = LastSmplID;
 			}
-			
+
 			if (WriteEvent)
 			{
 				memcpy(&DstData[DstPos], &VGMData[VGMPos], CmdLen);
@@ -1449,7 +1449,7 @@ static void RewriteVGMData(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -1475,7 +1475,7 @@ static void RewriteVGMData(void)
 		memcpy(&DstData[0x1C], &NewLoopS, 0x04);
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		VGMPos = VGMHead.lngGD3Offset;
@@ -1484,7 +1484,7 @@ static void RewriteVGMData(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			VGMHead.lngGD3Offset = DstPos;
 			TempLng = DstPos - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
@@ -1493,16 +1493,16 @@ static void RewriteVGMData(void)
 		}
 	}
 	DstDataLen = DstPos;
-	
+
 	if (VGMHead.lngVersion < 0x00000160)
 	{
 		VGMHead.lngVersion = 0x00000160;
 		memcpy(&DstData[0x08], &VGMHead.lngVersion, 0x04);
 	}
-	
+
 	TempLng = DstDataLen - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);
-	
+
 	if (NewLoopS)
 	{
 		if (LoopSmplID != LastSmplID)
@@ -1511,6 +1511,6 @@ static void RewriteVGMData(void)
 			_getch();
 		}
 	}
-	
+
 	return;
 }

--- a/optvgmrf.c
+++ b/optvgmrf.c
@@ -94,12 +94,12 @@ int main(int argc, char* argv[])
 	int argbase;
 	int ErrVal;
 	char FileName[0x100];
-	
+
 	printf("VGM RF-PCM Optimizer\n--------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 1;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -120,7 +120,7 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	DstData = NULL;
 	if (VGMHead.lngVersion < 0x00000151)
 	{
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
 		ErrVal = 2;
 		goto BreakProgress;
 	}
-	
+
 	CancelFlag = false;
 	OptMode = 0x00;
 	printf("Step 1: Merge single memory writes into larger blocks ...\n");
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
 		free(VGMData);
 		VGMData = DstData;
 		DstData = NULL;
-		
+
 		printf("Step 2: Generate Block Data ...\n");
 		EnumeratePCMData();
 		if (CancelFlag)
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
 	}
 	printf("Data Compression: %u -> %u (%.1f %%)\n",
 			DataSizeA, DataSizeB, 100.0f * DataSizeB / DataSizeA);
-	
+
 	if (DataSizeB < DataSizeA)
 	{
 		if (argc > argbase + 1)
@@ -180,14 +180,14 @@ int main(int argc, char* argv[])
 		}
 		WriteVGMFile(FileName);
 	}
-	
+
 BreakProgress:
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -197,20 +197,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -231,7 +231,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000151)
 		CurPos = 0x40;
@@ -241,7 +241,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -249,14 +249,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -268,13 +268,13 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -285,7 +285,7 @@ static void WritePCMDataBlk(UINT32* DstPos, const UINT8 BlkType, const UINT32 Da
 	UINT32 DBlkLen;
 	UINT8 DBlkType;
 	const UINT8* Data;
-	
+
 	Data = RF_RData[BlkType].PCMRam + DataStart;
 	DBlkType = DBLK_TYPES[BlkType];
 	DstData[*DstPos + 0x00] = 0x67;
@@ -295,7 +295,7 @@ static void WritePCMDataBlk(UINT32* DstPos, const UINT8 BlkType, const UINT32 Da
 	{
 		DBlkLen = DataLen + 0x02;
 		memcpy(&DstData[*DstPos + 0x03], &DBlkLen, 0x04);
-		
+
 		memcpy(&DstData[*DstPos + 0x07], &DataStart, 0x02);
 		memcpy(&DstData[*DstPos + 0x09], Data, DataLen);
 	}
@@ -303,12 +303,12 @@ static void WritePCMDataBlk(UINT32* DstPos, const UINT8 BlkType, const UINT32 Da
 	{
 		DBlkLen = DataLen + 0x04;
 		memcpy(&DstData[*DstPos + 0x03], &DBlkLen, 0x04);
-		
+
 		memcpy(&DstData[*DstPos + 0x07], &DataStart, 0x04);
 		memcpy(&DstData[*DstPos + 0x0B], Data, DataLen);
 	}
 	*DstPos += 0x07 + DBlkLen;
-	
+
 	return;
 }
 
@@ -335,14 +335,14 @@ static void MergePCMData(void)
 	UINT32 WriteLen;
 	UINT32 BlkFound;
 	UINT8 BlkType;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	VGMPos = VGMHead.lngDataOffset;
 	DstPos = VGMHead.lngDataOffset;
 	VGMSmplPos = 0;
 	NewLoopS = 0x00;
 	memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 	memset(RF_RData, 0x00, sizeof(RF_CHIP_DATA) * RFDATA_BLOCKS);
 	RF_RData[RF5C68_MODE].RAMSize	= 0x10000;	// 64 KB
 	RF_RData[RF5C164_MODE].RAMSize	= 0x10000;	// 64 KB
@@ -352,7 +352,7 @@ static void MergePCMData(void)
 		RF_RData[TempByt].PCMRam = (UINT8*)malloc(RF_RData[TempByt].RAMSize);
 		RF_RData[TempByt].FirstBnkWrt = true;
 	}
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -364,7 +364,7 @@ static void MergePCMData(void)
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		WriteEvent = true;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -428,12 +428,12 @@ static void MergePCMData(void)
 				TempByt = VGMData[VGMPos + 0x02];
 				memcpy(&BlockLen, &VGMData[VGMPos + 0x03], 0x04);
 				BlockLen &= 0x7FFFFFFF;
-				
+
 				CmdLen = 0x07 + BlockLen;
-				
+
 				if ((TempByt & 0xC0) != 0xC0)
 					break;
-				
+
 				if (TempByt == 0xC0)
 					BlkType = RF5C68_MODE;
 				else if (TempByt == 0xC1)
@@ -461,7 +461,7 @@ static void MergePCMData(void)
 							memcpy(&TempLng, &VGMData[VGMPos + 0x07], 0x04);
 						}
 						TempRFD->RAMStart = TempLng;
-						
+
 						if (BLOCK_POS == BP_FRONT)
 						{
 							while(TempRFD->DataLen)
@@ -470,7 +470,7 @@ static void MergePCMData(void)
 									WriteLen = 0x1000;
 								else
 									WriteLen = TempRFD->DataLen;
-								
+
 								WritePCMDataBlk(&DstPos, BlkType, WriteLen, TempLng);
 								TempLng += WriteLen;
 								TempRFD->DataLen -= WriteLen;
@@ -484,7 +484,7 @@ static void MergePCMData(void)
 						DataLen = BlockLen - 0x02;
 					else
 						DataLen = BlockLen - 0x04;
-					
+
 					if ((BLOCK_POS == BP_BACK && ! TempRFD->RAMSkip) ||
 						(BLOCK_POS == BP_MIDDLE &&
 							(TempRFD->RAMSkip >= TempRFD->DataLen / 2 &&
@@ -497,13 +497,13 @@ static void MergePCMData(void)
 								WriteLen = 0x1000;
 							else
 								WriteLen = TempRFD->DataLen;
-							
+
 							WritePCMDataBlk(&DstPos, BlkType, WriteLen, TempSht);
 							TempSht += (UINT16)WriteLen;
 							TempRFD->DataLen -= WriteLen;
 						}
 					}
-					
+
 					WriteEvent = false;
 					TempRFD->RAMSkip -= DataLen;
 				}
@@ -517,7 +517,7 @@ static void MergePCMData(void)
 			case 0xB0:	// RF5C68 register write
 			case 0xB1:	// RF5C164 register write
 				CmdLen = 0x03;
-				
+
 				if (VGMData[VGMPos + 0x01] == 0x07 && ! (VGMData[VGMPos + 0x02] & 0x40))
 				{
 					if (Command == 0xB0)
@@ -526,10 +526,10 @@ static void MergePCMData(void)
 						TempRFD = &RF_RData[RF5C164_MODE];
 					else
 						TempRFD = NULL;
-					
+
 					// Bank Select
 					TempRFD->BankReg = (VGMData[VGMPos + 0x02] & 0x0F) << 12;
-				
+
 					// write Bank Select just one time, the memory write includes all
 					// neccessary data
 					if (TempRFD->FirstBnkWrt)
@@ -547,7 +547,7 @@ static void MergePCMData(void)
 			case 0xC1:	// RF5C68 memory write
 			case 0xC2:	// RF5C164 memory write
 				CmdLen = 0x04;
-				
+
 				if (Command == 0xC1)
 					BlkType = RF5C68_MODE;
 				else if (Command == 0xC2)
@@ -567,7 +567,7 @@ static void MergePCMData(void)
 						TempRFD->RAMSkip = TempRFD->DataLen;
 						memcpy(&TempSht, &VGMData[VGMPos + 0x01], 0x02);
 						TempRFD->RAMStart = TempRFD->BankReg + TempSht;
-						
+
 						if (BLOCK_POS == BP_FRONT)
 						{
 							WritePCMDataBlk(&DstPos, BlkType, TempRFD->DataLen,
@@ -592,7 +592,7 @@ static void MergePCMData(void)
 						WritePCMDataBlk(&DstPos, BlkType, TempRFD->DataLen,
 										TempRFD->RAMStart);
 					}
-					
+
 					WriteEvent = false;
 					TempRFD->RAMSkip --;
 				}
@@ -640,7 +640,7 @@ static void MergePCMData(void)
 				break;
 			}
 		}
-		
+
 		if (VGMPos == VGMHead.lngLoopOffset)
 			NewLoopS = DstPos;
 		if (WriteEvent)
@@ -651,7 +651,7 @@ static void MergePCMData(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -676,7 +676,7 @@ static void MergePCMData(void)
 			NewLoopS -= 0x1C;
 		memcpy(&DstData[0x1C], &NewLoopS, 0x04);
 	}
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		VGMPos = VGMHead.lngGD3Offset;
@@ -685,7 +685,7 @@ static void MergePCMData(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			VGMHead.lngGD3Offset = DstPos;
 			TempLng = VGMHead.lngGD3Offset - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
@@ -697,15 +697,15 @@ static void MergePCMData(void)
 	VGMHead.lngEOFOffset = DstDataLen;
 	TempLng = VGMHead.lngEOFOffset - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);
-	
+
 	OptMode = (BlkFound == 0x01) ? 0x00 : 0x01;
-	
+
 	for (TempByt = 0x00; TempByt < RFDATA_BLOCKS; TempByt ++)
 	{
 		free(RF_RData[TempByt].PCMRam);
 		RF_RData[TempByt].PCMRam = NULL;
 	}
-	
+
 	return;
 }
 
@@ -724,19 +724,19 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 	bool StopVGM;
 	UINT16 BankReg;	// this function mustn't change the global one
 	UINT8 BlkType;
-	
+
 	TempRFD = &RF_RData[RFMode];
 	TmpPos = VGMPos;
 	BankReg = TempRFD->BankReg;
 	PCMPos = 0xFFFFFFFF;
 	DataLen = 0x00;
-	
+
 	StopVGM = false;
 	while(TmpPos < VGMHead.lngEOFOffset)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[TmpPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -781,12 +781,12 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 				TempByt = VGMData[TmpPos + 0x02];
 				memcpy(&BlkLen, &VGMData[TmpPos + 0x03], 0x04);
 				BlkLen &= 0x7FFFFFFF;
-				
+
 				CmdLen = 0x07 + BlkLen;
-				
+
 				if ((TempByt & 0xC0) != 0xC0)
 					break;
-				
+
 				if (TempByt == 0xC0)
 					BlkType = RF5C68_MODE;
 				else if (TempByt == 0xC1)
@@ -797,7 +797,7 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 					break;
 				if (BlkType != RFMode)
 					break;
-				
+
 				if (! (TempByt & 0x20))
 				{
 					memcpy(&TempSht, &VGMData[TmpPos + 0x07], 0x02);
@@ -817,7 +817,7 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 					StopVGM = true;
 					break;
 				}
-				
+
 				if (BlkLen > TempRFD->RAMSize)
 					BlkLen = TempRFD->RAMSize;
 				if (! (TempByt & 0x20))
@@ -845,7 +845,7 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 				if ((Command == 0xB0 && RFMode != RF5C68_MODE) ||
 					(Command == 0xB1 && RFMode != RF5C164_MODE))
 					break;
-				
+
 				if (VGMData[TmpPos + 0x01] == 0x07 && ! (VGMData[TmpPos + 0x02] & 0x40))
 				{
 					// Bank Select
@@ -859,7 +859,7 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 				if ((Command == 0xC1 && RFMode != RF5C68_MODE) ||
 					(Command == 0xC2 && RFMode != RF5C164_MODE))
 					break;
-				
+
 				memcpy(&TempSht, &VGMData[TmpPos + 0x01], 0x02);
 				TempSht += BankReg;
 				if (PCMPos == 0xFFFFFFFF)
@@ -869,7 +869,7 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 					StopVGM = true;
 					break;
 				}
-				
+
 				TempRFD->PCMRam[PCMPos] = VGMData[TmpPos + 0x03];
 				PCMPos ++;
 				DataLen ++;
@@ -935,12 +935,12 @@ static UINT32 ReadConsecutiveMemWrites(UINT8 RFMode)
 				break;
 			}
 		}
-		
+
 		TmpPos += CmdLen;
 		if (StopVGM || PCMPos >= TempRFD->RAMSize)
 			break;
 	}
-	
+
 	return DataLen;
 }
 
@@ -969,7 +969,7 @@ static void EnumeratePCMData(void)
 	UINT8 BlkType;
 	UINT32 BlkStart;
 	const UINT8* BlkData;
-	
+
 	RFBlkAlloc = 0x40;	// usually there are only few blocks ...
 	RFBlock = (RF_BLK_DATA*)malloc(RFBlkAlloc * sizeof(RF_BLK_DATA));
 	RFBlkCount = 0x00;
@@ -977,10 +977,10 @@ static void EnumeratePCMData(void)
 	InFileList = (IN_FILE_LIST*)malloc(InFileAlloc * sizeof(IN_FILE_LIST));
 	InFileCount = 0x00;
 	BlkUsage = BlkSize = 0x00;
-	
+
 	VGMPos = VGMHead.lngDataOffset;
 	VGMSmplPos = 0;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -989,7 +989,7 @@ static void EnumeratePCMData(void)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -1053,12 +1053,12 @@ static void EnumeratePCMData(void)
 				TempByt = VGMData[VGMPos + 0x02];
 				memcpy(&BlockLen, &VGMData[VGMPos + 0x03], 0x04);
 				BlockLen &= 0x7FFFFFFF;
-				
+
 				CmdLen = 0x07 + BlockLen;
-				
+
 				if ((TempByt & 0xC0) != 0xC0)
 					break;
-				
+
 				if (TempByt == 0xC0)
 					BlkType = RF5C68_MODE;
 				else if (TempByt == 0xC1)
@@ -1067,7 +1067,7 @@ static void EnumeratePCMData(void)
 					BlkType = SCSP_MODE;
 				else
 					break;
-				
+
 				if (! (TempByt & 0x20))
 				{
 					memcpy(&TempSht, &VGMData[VGMPos + 0x07], 0x02);
@@ -1087,14 +1087,14 @@ static void EnumeratePCMData(void)
 					TempBlk = &RFBlock[CurBlk];
 					if (TempBlk->Mode != BlkType)
 						continue;
-					
+
 					//if (TempBlk->DataStart != BlkStart)
 					//	break;
 					if (TempBlk->DataSize < DataLen)
 						TempLng = TempBlk->DataSize;
 					else
 						TempLng = DataLen;
-					
+
 					if (CompareData(TempLng, BlkData, TempBlk->Data))
 					{
 						if (TempBlk->DataSize < DataLen)
@@ -1106,7 +1106,7 @@ static void EnumeratePCMData(void)
 							memcpy(TempBlk->Data, BlkData, DataLen);
 							BlkSize += DataLen;
 						}
-						
+
 						if (InFileCount >= InFileAlloc)
 						{
 							InFileAlloc += 0x1000;
@@ -1121,7 +1121,7 @@ static void EnumeratePCMData(void)
 						TempBlk->UsageCounter ++;
 						InFileCount ++;
 						BlkUsage ++;
-						
+
 						FoundBlk = true;
 					}
 				}
@@ -1133,17 +1133,17 @@ static void EnumeratePCMData(void)
 						RFBlock = (RF_BLK_DATA*)realloc(RFBlock,
 														RFBlkAlloc * sizeof(RF_BLK_DATA));
 					}
-					
+
 					TempBlk = &RFBlock[RFBlkCount];
 					RFBlkCount ++;
-					
+
 					TempBlk->Mode = BlkType;
 					TempBlk->DataSize = DataLen;
 					TempBlk->Data = (UINT8*)malloc(DataLen);
 					memcpy(TempBlk->Data, BlkData, DataLen);
 					TempBlk->UsageCounter = 0x00;
 					BlkSize += DataLen;
-					
+
 					if (InFileCount >= InFileAlloc)
 					{
 						InFileAlloc += 0x1000;
@@ -1206,11 +1206,11 @@ static void EnumeratePCMData(void)
 				break;
 			}
 		}
-		
+
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -1225,7 +1225,7 @@ static void EnumeratePCMData(void)
 #endif
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	BlkSngUse = 0x00;
 	for (CurBlk = 0x00; CurBlk < RFBlkCount; CurBlk ++)
 	{
@@ -1236,7 +1236,7 @@ static void EnumeratePCMData(void)
 			BlkSngUse ++;
 		}
 	}
-	
+
 	printf("%u Blocks created (%.2f MB, %ux used, %ux single use).\n",
 			RFBlkCount, BlkSize / 1048576.0f, BlkUsage, BlkSngUse);
 	if (BlkUsage == BlkSngUse)
@@ -1244,7 +1244,7 @@ static void EnumeratePCMData(void)
 		printf("Can't optimize further.\n");
 		CancelFlag = true;
 	}
-	
+
 	return;
 }
 
@@ -1254,7 +1254,7 @@ static bool CompareData(UINT32 DataLen, const UINT8* DataA,
 	UINT32 CurPos;
 	const UINT8* TempDA;
 	const UINT8* TempDB;
-	
+
 	TempDA = DataA;
 	TempDB = DataB;
 	for (CurPos = 0x00; CurPos < DataLen; CurPos ++, TempDA ++, TempDB ++)
@@ -1262,7 +1262,7 @@ static bool CompareData(UINT32 DataLen, const UINT8* DataA,
 		if (*TempDA != *TempDB)
 			return false;
 	}
-	
+
 	return true;
 }
 
@@ -1292,7 +1292,7 @@ static void RewriteVGMData(void)
 	RF_BLK_DATA* TempBlk;
 	IN_FILE_LIST* TempLst;
 	bool WriteCmd68;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	AllDelay = 0;
 	VGMPos = VGMHead.lngDataOffset;
@@ -1300,19 +1300,19 @@ static void RewriteVGMData(void)
 	VGMSmplPos = 0;
 	NewLoopS = 0x00;
 	memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 	// Write Blocks for PCM Data
 	for (CurType = 0x00; CurType < RFDATA_BLOCKS; CurType ++)
 	{
 		TempByt = DBBLK_TYPES[CurType];
-		
+
 		DataLen = 0x00;
 		for (CurBlk = 0x00; CurBlk < RFBlkCount; CurBlk ++)
 		{
 			TempBlk = &RFBlock[CurBlk];
 			if (TempBlk->Mode != CurType)
 				continue;
-			
+
 			TempBlk->DBPos = DataLen;
 			DataLen += TempBlk->DataSize;
 		}
@@ -1323,19 +1323,19 @@ static void RewriteVGMData(void)
 			DstData[DstPos + 0x02] = TempByt;
 			memcpy(&DstData[DstPos + 0x03], &DataLen, 0x04);
 			DstPos += 0x07;
-			
+
 			for (CurBlk = 0x00; CurBlk < RFBlkCount; CurBlk ++)
 			{
 				TempBlk = &RFBlock[CurBlk];
 				if (TempBlk->Mode != CurType)
 					continue;
-				
+
 				memcpy(&DstData[DstPos + 0x00], TempBlk->Data, TempBlk->DataSize);
 				DstPos += TempBlk->DataSize;
 			}
 		}
 	}
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -1348,7 +1348,7 @@ static void RewriteVGMData(void)
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		WriteEvent = true;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -1421,7 +1421,7 @@ static void RewriteVGMData(void)
 				TempByt = VGMData[VGMPos + 0x02];
 				memcpy(&TempLng, &VGMData[VGMPos + 0x03], 0x04);
 				TempLng &= 0x7FFFFFFF;
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -1456,15 +1456,15 @@ static void RewriteVGMData(void)
 								TempBlk = &RFBlock[TempLst->BlockID];
 								if (TempBlk->Mode & 0x80)
 									break;	// Single-Use Blocks are left
-								
-								CurEntry ++; 
+
+								CurEntry ++;
 								WriteEvent = false;
 								// writing the block here would cause some sort of bug, because
 								// I would miss the delay
 								WriteCmd68 = true;
 								break;
 							}
-							CurEntry ++; 
+							CurEntry ++;
 						}
 						break;
 					}
@@ -1520,7 +1520,7 @@ static void RewriteVGMData(void)
 				break;
 			}
 		}
-		
+
 		if (WriteEvent || WriteCmd68 || VGMPos == VGMHead.lngLoopOffset)
 		{
 			if (VGMPos != VGMHead.lngLoopOffset)
@@ -1537,12 +1537,12 @@ static void RewriteVGMData(void)
 					if (VGMPos == VGMHead.lngLoopOffset)
 						NewLoopS = DstPos;
 				}
-				
+
 				if (AllDelay <= 0xFFFF)
 					TempSht = (UINT16)AllDelay;
 				else
 					TempSht = 0xFFFF;
-				
+
 				if (! TempSht)
 				{
 					// don't do anything - I just want to be safe
@@ -1598,7 +1598,7 @@ static void RewriteVGMData(void)
 				}
 				AllDelay -= TempSht;
 			}
-			
+
 			if (WriteEvent)
 			{
 				if (VGMPos == VGMHead.lngLoopOffset)
@@ -1612,7 +1612,7 @@ static void RewriteVGMData(void)
 			AllDelay += CmdDelay;
 		}
 		VGMPos += CmdLen;
-		
+
 		if (WriteCmd68)
 		{
 			WriteCmd68 = false;
@@ -1626,7 +1626,7 @@ static void RewriteVGMData(void)
 		}
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -1651,7 +1651,7 @@ static void RewriteVGMData(void)
 			NewLoopS -= 0x1C;
 		memcpy(&DstData[0x1C], &NewLoopS, 0x04);
 	}
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		VGMPos = VGMHead.lngGD3Offset;
@@ -1660,7 +1660,7 @@ static void RewriteVGMData(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			VGMHead.lngGD3Offset = DstPos;
 			TempLng = VGMHead.lngGD3Offset - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
@@ -1672,12 +1672,12 @@ static void RewriteVGMData(void)
 	VGMHead.lngEOFOffset = DstDataLen;
 	TempLng = VGMHead.lngEOFOffset - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);
-	
+
 	if (VGMHead.lngVersion < 0x00000160)
 	{
 		VGMHead.lngVersion = 0x00000160;
 		memcpy(&DstData[0x08], &VGMHead.lngVersion, 0x04);
 	}
-	
+
 	return;
 }

--- a/stdbool.h
+++ b/stdbool.h
@@ -1,7 +1,7 @@
 // custom stdbool.h to for 1-byte bool types
 
 #ifndef _CSTM_STDBOOL_H_
-#define	_CSTM_STDBOOL_H_	
+#define	_CSTM_STDBOOL_H_
 
 #ifndef __cplusplus	// C++ already has the bool-type
 

--- a/vgm2txt.c
+++ b/vgm2txt.c
@@ -38,9 +38,9 @@ int main(int argc, char* argv[])
 	UINT32 TimeSec;
 	UINT32 TimeMS;
 	char FileName[0x100];
-	
+
 	printf("VGM Text Writer\n---------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	printf("File Name:\t");
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -63,7 +63,7 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	TimeMin = TimeSec = TimeMS = 0;
 	printf("Start Time:\t");
 	if (argc <= argbase + 1)
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
 		strcpy(FileName, argv[argbase + 1]);
 	sscanf(FileName, "%02u:%02u.%02u", &TimeMin, &TimeSec, &TimeMS);
 	VGMWriteFrom = (TimeMin * 6000 + TimeSec * 100 + TimeMS) * 441;
-	
+
 	TimeMin = TimeSec = TimeMS = 0;
 	printf("End Time:\t");
 	if (argc <= argbase + 2)
@@ -83,16 +83,16 @@ int main(int argc, char* argv[])
 	VGMWriteTo = (TimeMin * 6000 + TimeSec * 100 + TimeMS) * 441;
 	//if (! VGMWriteTo)
 	//	VGMWriteTo = VGMHead.lngTotalSamples;
-	
+
 	strcpy(FileName, FileBase);
 	strcat(FileName, ".txt");
 	WriteVGM2Txt(FileName);
-	
+
 	free(VGMData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -102,20 +102,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -149,7 +149,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -159,7 +159,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -167,14 +167,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -193,13 +193,13 @@ static void WriteVGM2Txt(const char* FileName)
 	char TempStr[0x80];
 	INT16 TempSSht;
 	double TempDbl;
-	
+
 	memset(TempStr, 0x00, 0x80);
-	
+
 	hFile = fopen(FileName, "wt");
 	if (hFile == NULL)
 		return;
-	
+
 	fprintf(hFile, "VGM Header:\n");
 	memcpy(TempStr, &VGMData[0x00], 0x04);
 	fprintf(hFile, "VGM Signature:\t\t\"%s\"\n", TempStr);
@@ -208,7 +208,7 @@ static void WriteVGM2Txt(const char* FileName)
 	fprintf(hFile, "EOF Offset:\t\t0x%08X (absolute)\n", VGMHead.lngEOFOffset);
 	fprintf(hFile, "GD3 Tag Offset:\t\t0x%08X (absolute)\n", VGMHead.lngGD3Offset);
 	fprintf(hFile, "Data Offset:\t\t0x%08X (absolute)\n", VGMHead.lngDataOffset);
-	
+
 	PrintMinSec(VGMHead.lngTotalSamples, TempStr);
 	fprintf(hFile, "Total Length:\t\t%u samples (%s s)\n", VGMHead.lngTotalSamples, TempStr);
 	fprintf(hFile, "Loop Point Offset:\t0x%08X (absolute)\n", VGMHead.lngLoopOffset);
@@ -221,7 +221,7 @@ static void WriteVGM2Txt(const char* FileName)
 	PrintMinSec(VGMHead.lngLoopSamples, TempStr);
 	fprintf(hFile, "Loop Length:\t\t%u samples (%s s)\n", VGMHead.lngLoopSamples, TempStr);
 	fprintf(hFile, "Recording Rate:\t\t%u Hz\n", VGMHead.lngRate);
-	
+
 	sprintf(TempStr, "%u Hz", VGMHead.lngHzPSG & 0x3FFFFFF);
 	if (VGMHead.lngHzPSG & 0x40000000)
 	{
@@ -238,31 +238,31 @@ static void WriteVGM2Txt(const char* FileName)
 	fprintf(hFile, "SN76496 Feedback:\t0x%02X\n", VGMHead.shtPSG_Feedback);
 	fprintf(hFile, "SN76496 ShiftRegWidth:\t%u bits\n", VGMHead.bytPSG_SRWidth);
 	fprintf(hFile, "SN76496 Flags:\t\t0x%02X\n", VGMHead.bytPSG_Flags);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM2413, "YM2413");
 	fprintf(hFile, "YM2413 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM2612, "YM2612");
 	fprintf(hFile, "YM2612 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM2151, "YM2151");
 	fprintf(hFile, "YM2151 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzSPCM, NULL);
 	fprintf(hFile, "SegaPCM Clock:\t\t%s\n", TempStr);
 	fprintf(hFile, "SegaPCM Interface:\t0x%08X\n", VGMHead.lngSPCMIntf);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzRF5C68 & ~0x40000000, NULL);
 	fprintf(hFile, "RF5C68 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM2203, "YM2203");
 	fprintf(hFile, "YM2203 Clock:\t\t%s\n", TempStr);
 	fprintf(hFile, "YM2203 AY8910 Flags:\t0x%02X\n", VGMHead.bytAYFlagYM2203);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM2608, "YM2608");
 	fprintf(hFile, "YM2608 Clock:\t\t%s\n", TempStr);
 	fprintf(hFile, "YM2608 AY8910 Flags:\t0x%02X\n", VGMHead.bytAYFlagYM2608);
-	
+
 	sprintf(TempStr, "%u Hz", VGMHead.lngHzYM2610 & ~0xC0000000);
 	if (VGMHead.lngHzYM2610 & 0x80000000)
 		sprintf(TempStr, "%s (YM2610B Mode)", TempStr);
@@ -271,34 +271,34 @@ static void WriteVGM2Txt(const char* FileName)
 	else if (! VGMHead.lngHzYM2610)
 		sprintf(TempStr, "%s - unused", TempStr);
 	fprintf(hFile, "YM2610 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM3812, "YM3812");
 	fprintf(hFile, "YM3812 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYM3526, "YM3526");
 	fprintf(hFile, "YM3526 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzY8950, "Y8950");
 	fprintf(hFile, "Y8950 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYMF262, "YMF262");
 	fprintf(hFile, "YMF262 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYMF278B, "YMF278B");
 	fprintf(hFile, "YMF278B Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYMF271, "YMF271");
 	fprintf(hFile, "YMF271 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzYMZ280B, "YMZ280B");
 	fprintf(hFile, "YMZ280B Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzRF5C164 & ~0x40000000, "RF5C164");
 	fprintf(hFile, "RF5C164 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzPWM & ~0x40000000, "PWM");
 	fprintf(hFile, "PWM Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzAY8910, "AY8910");
 	fprintf(hFile, "AY8910 Clock:\t\t%s\n", TempStr);
 	if (VGMHead.bytAYType & ~0x13)
@@ -307,7 +307,7 @@ static void WriteVGM2Txt(const char* FileName)
 		fprintf(hFile, "AY8910 Type:\t\t0x%02X - %s\n", VGMHead.bytAYType,
 				AY_NAMES[(VGMHead.bytAYType >> 2) | VGMHead.bytAYType]);
 	fprintf(hFile, "AY8910 Flags:\t\t0x%02X\n", VGMHead.bytAYFlag);
-	
+
 	if (VGMHead.bytVolumeModifier <= VOLUME_MODIF_WRAP)
 		TempSSht = VGMHead.bytVolumeModifier;
 	else if (VGMHead.bytVolumeModifier == (VOLUME_MODIF_WRAP + 0x01))
@@ -317,9 +317,9 @@ static void WriteVGM2Txt(const char* FileName)
 	TempDbl = pow(2.0, TempSSht / (double)0x20);
 	fprintf(hFile, "Volume Modifier:\t0x%02X (%d) = %.3f\n", VGMHead.bytVolumeModifier,
 			TempSSht, TempDbl);
-	
+
 	fprintf(hFile, "Reserved (0x7D):\t0x%02X\n", VGMHead.bytReserved2);
-	
+
 	if (VGMHead.bytLoopBase > 0)
 		strcpy(TempStr, "+");
 	else if (VGMHead.bytLoopBase < 0)
@@ -332,92 +332,92 @@ static void WriteVGM2Txt(const char* FileName)
 #endif
 	fprintf(hFile, "Loop Base:\t\t0x%02X = %s%d\n", VGMHead.bytLoopBase, TempStr,
 			VGMHead.bytLoopBase);
-	
+
 	TempDbl = TempSSht / 16.0;
 	fprintf(hFile, "Loop Modifier:\t\t0x%02X (MaxLoops * %.2f)\n", VGMHead.bytLoopModifier,
 			TempDbl);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzGBDMG, "GB DMG");
 	fprintf(hFile, "GB DMG Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzNESAPU, "NES APU");
 	if (VGMHead.lngHzNESAPU & 0x80000000)
 		sprintf(TempStr, "%s (with FDS channel)", TempStr);
 	fprintf(hFile, "NES APU Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzMultiPCM, "MultiPCM");
 	fprintf(hFile, "MultiPCM Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzUPD7759, "UPD7759");
 	fprintf(hFile, "UPD7759 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzOKIM6258, "OKIM6258");
 	fprintf(hFile, "OKIM6258 Clock:\t\t%s\n", TempStr);
 	fprintf(hFile, "OKIM6258 Flags:\t\t0x%02X\n", VGMHead.bytOKI6258Flags);
 	fprintf(hFile, "K054539 Flags:\t\t0x%02X\n", VGMHead.bytK054539Flags);
 	fprintf(hFile, "C140 Type:\t\t0x%02X\n", VGMHead.bytC140Type);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzOKIM6295, "OKIM6295");
 	fprintf(hFile, "OKIM6295 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzK051649, "K051649");
 	if (VGMHead.lngHzK051649 & 0x80000000)
 		sprintf(TempStr, "%s (SCC+ mode)", TempStr);
 	fprintf(hFile, "K051649 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzK054539, "K054539");
 	fprintf(hFile, "K054539 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzHuC6280, "HuC6280");
 	fprintf(hFile, "HuC6280 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzC140, "C140");
 	fprintf(hFile, "C140 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzK053260, "K053260");
 	fprintf(hFile, "K053260 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzPokey, "Pokey");
 	fprintf(hFile, "Pokey Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzQSound & ~0x40000000, "QSound");
 	fprintf(hFile, "QSound Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzSCSP, "SCSP");
 	fprintf(hFile, "SCSP Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzWSwan, "WSwan");
 	fprintf(hFile, "WonderSwan Clock:\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzVSU, "VSU");
 	fprintf(hFile, "VSU Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzSAA1099, "SAA1099");
 	fprintf(hFile, "SAA1099 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzES5503, "ES5503");
 	fprintf(hFile, "ES5503 Clock:\t\t%s\n", TempStr);
-	
+
 	if (VGMHead.lngHzNESAPU & 0x80000000)
 		WriteClockText(TempStr, VGMHead.lngHzES5506, "ES5506");
 	else
 		WriteClockText(TempStr, VGMHead.lngHzES5506, "ES5505");
 	fprintf(hFile, "ES5506 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzX1_010, "X1-010");
 	fprintf(hFile, "X1-010 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzC352, "C352");
 	fprintf(hFile, "C352 Clock:\t\t%s\n", TempStr);
-	
+
 	WriteClockText(TempStr, VGMHead.lngHzGA20, "GA20");
 	fprintf(hFile, "GA20 Clock:\t\t%s\n", TempStr);
-	
+
 	fprintf(hFile, "\n");
 	fprintf(hFile, "VGMData:\n");
 	VGMPos = VGMHead.lngDataOffset;
 	VGMSmplPos = 0;
-	
+
 #if ! defined(_DEBUG) && defined(_MSC_VER)
 	// Catch possible crashes (Windows non-debug only)
 	__try
@@ -431,11 +431,11 @@ static void WriteVGM2Txt(const char* FileName)
 #else
 	WriteVGMData2Txt(hFile);
 #endif
-	
+
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -446,7 +446,7 @@ static void WriteClockText(char* Buffer, UINT32 Clock, char* ChipName)
 		sprintf(Buffer, "%s - Dual %s", Buffer, ChipName);
 	else if (! Clock)
 		sprintf(Buffer, "%s - unused", Buffer);
-	
+
 	return;
 }
 
@@ -470,7 +470,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 	UINT32 ChipCounters[0x20];
 	UINT8 CurChip;
 	const UINT8* VGMPnt;
-	
+
 	for (TempByt = 0x00; TempByt < 0x20; TempByt ++)
 	{
 		switch(TempByt)
@@ -595,7 +595,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 			es5506_w(NULL, 0xFF, TempByt);
 		}
 	}
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -637,7 +637,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			CurChip = 0x00;
 			switch(Command)
@@ -739,7 +739,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 				break;
 			}
 			SetChip(CurChip);
-			
+
 			strcpy(TempStr, "unsupported chip");
 			switch(Command)
 			{
@@ -809,10 +809,10 @@ static void WriteVGMData2Txt(FILE* hFile)
 			case 0x67:	// Data Block (PCM Data Stream)
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				CurChip = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				if (WriteEvents)
 				{
 					switch(TempByt & 0xC0)
@@ -838,7 +838,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 							strcpy(MinSecStr, "Unknown Database Type");
 							break;
 						}
-						
+
 						if ((TempByt & 0xC0) == 0x40)
 							strcat(MinSecStr, " (compressed)");
 						break;
@@ -880,7 +880,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 							break;
 						case 0x8A:	// UPD7759 ROM Image
 							strcpy(MinSecStr, "UPD7759 ROM");
-							
+
 							SetChip(CurChip);
 							upd7759_write(NULL, 0xFF, 0x01);
 							break;
@@ -948,7 +948,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 						}
 						break;
 					}
-					
+
 					sprintf(TempStr, "Data Block - Type %02X: %s%s\n", TempByt, MinSecStr,
 									(CurChip ? " (2nd chip)" : "") );
 					sprintf(TempStr, "%s\t\t\tData Length: 0x%08X", TempStr, DataLen);
@@ -1334,7 +1334,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 				if (WriteEvents)
 				{
 					GetFullChipName(MinSecStr, VGMPnt[0x02]);	// Chip Type
-					
+
 					sprintf(TempStr, "DAC Ctrl:\tStream #%u - Setup Chip: %s Reg %02X %02X",
 							VGMPnt[0x01], MinSecStr, VGMPnt[0x03], VGMPnt[0x04]);
 				}
@@ -1365,7 +1365,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 					strcpy(MinSecStr, "Play");
 					if (VGMPnt[0x06] & 0x80)
 						strcat(MinSecStr, "/Loop");
-					
+
 					memcpy(&TempLng, &VGMPnt[0x02], 0x04);
 					sprintf(TempStr, "DAC Ctrl:\tStream #%u - %s from 0x%02X",
 							VGMPnt[0x01], MinSecStr, TempLng);
@@ -1407,7 +1407,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 					strcpy(MinSecStr, "Play");
 					if (VGMPnt[0x04] & 0x01)
 						strcat(MinSecStr, "/Loop");
-					
+
 					memcpy(&TempSht, &VGMPnt[0x02], 0x02);
 					sprintf(TempStr, "DAC Ctrl:\tStream #%u - %s: Block 0x%02X",
 							VGMPnt[0x01], MinSecStr, TempSht);
@@ -1419,7 +1419,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 				{
 					sprintf(TempStr, "Unknown command: %02X", Command);
 				}
-				
+
 				switch(Command & 0xF0)
 				{
 				case 0x30:
@@ -1447,7 +1447,7 @@ static void WriteVGMData2Txt(FILE* hFile)
 				break;
 			}
 		}
-		
+
 		if (WriteEvents)
 		{
 			if (VGMPos == VGMHead.lngLoopOffset)
@@ -1463,16 +1463,16 @@ static void WriteVGMData2Txt(FILE* hFile)
 			if (TempLng < 0x04)
 				memset(MinSecStr + TempLng * 0x03, ' ', (0x04 - TempLng) * 0x03);
 			MinSecStr[0x04 * 0x03 - 0x01] = 0x00;
-			
+
 			fprintf(hFile, "0x%08X: %s %s\n", VGMPos, MinSecStr, TempStr);
 		}
 		if (VGMWriteTo && VGMSmplPos > VGMWriteTo)
 			StopVGM = true;
-		
+
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -1493,6 +1493,6 @@ static void WriteVGMData2Txt(FILE* hFile)
 #endif
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	return;
 }

--- a/vgm_cmp.c
+++ b/vgm_cmp.c
@@ -87,13 +87,13 @@ int main(int argc, char* argv[])
 	char FileName[0x100];
 	UINT32 SrcDataSize;
 	UINT16 PassNo;
-	
+
 	printf("VGM Compressor\n--------------\n\n");
-	
+
 	ErrVal = 0;
 	JustTimerCmds = false;
 	DoOKI6258 = false;
-	
+
 	argbase = 1;
 	while(argbase < argc && argv[argbase][0] == '-')
 	{
@@ -112,7 +112,7 @@ int main(int argc, char* argv[])
 			break;
 		}
 	}
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	PassNo = 0x00;
 	do
 	{
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
 	} while(DataSizeB < DataSizeA);
 	printf("Data Compression Total: %u -> %u (%.1f %%)\n",
 			SrcDataSize, DataSizeB, 100.0 * DataSizeB / (float)SrcDataSize);
-	
+
 	if (DataSizeB < SrcDataSize)
 	{
 		if (argc > argbase + 1)
@@ -169,13 +169,13 @@ int main(int argc, char* argv[])
 		}
 		WriteVGMFile(FileName);
 	}
-	
+
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -185,20 +185,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -230,7 +230,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -240,7 +240,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -248,14 +248,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -267,13 +267,13 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -301,7 +301,7 @@ static void CompressVGMData(void)
 	UINT32 NewLoopS;
 	bool WroteCmd80;
 	const UINT8* VGMPnt;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	AllDelay = 0;
 	VGMPos = VGMHead.lngDataOffset;
@@ -309,7 +309,7 @@ static void CompressVGMData(void)
 	VGMSmplPos = 0;
 	NewLoopS = 0x00;
 	memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -326,7 +326,7 @@ static void CompressVGMData(void)
 	if (VGMHead.lngHzOKIM6295)
 	{
 		TempLng = VGMHead.lngHzOKIM6295 & 0x3FFFFFFF;
-		
+
 		SetChipSet(0x00);
 		okim6295_write(0x88, (TempLng >>  0) & 0xFF);
 		okim6295_write(0x89, (TempLng >>  8) & 0xFF);
@@ -363,7 +363,7 @@ static void CompressVGMData(void)
 			c140_write(0xFF, 0x00, VGMHead.bytC140Type);
 		}
 	}
-	
+
 	StopVGM = false;
 	WroteCmd80 = false;
 	while(VGMPos < VGMHead.lngEOFOffset)
@@ -374,7 +374,7 @@ static void CompressVGMData(void)
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		WriteEvent = true;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -395,7 +395,7 @@ static void CompressVGMData(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			ChipID = 0x00;
 			switch(Command)
@@ -497,7 +497,7 @@ static void CompressVGMData(void)
 				break;
 			}
 			SetChipSet(ChipID);
-			
+
 			NxtCmdPos = VGMPos;
 			NxtCmdCommand = Command;
 			switch(Command)
@@ -546,13 +546,13 @@ static void CompressVGMData(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
 				//if (TempByt == 0xC2)
 				//	WriteEvent = false;
 				/*SetChipSet(ChipID);
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -569,7 +569,7 @@ static void CompressVGMData(void)
 					DataLen = TempLng - 0x02;
 					break;
 				}*/
-				
+
 				CmdLen = 0x07 + TempLng;
 				break;
 			case 0xE0:	// Seek to PCM Data Bank Pos
@@ -828,7 +828,7 @@ static void CompressVGMData(void)
 				break;
 			}
 		}
-		
+
 		if (WriteEvent || VGMPos == VGMHead.lngLoopOffset)
 		{
 			if (VGMPos == VGMHead.lngLoopOffset)
@@ -842,7 +842,7 @@ static void CompressVGMData(void)
 				AllDelay = 0x00;
 			}
 			CmdDelay = 0x00;
-			
+
 			/*if (VGMPos != VGMHead.lngLoopOffset)
 			{
 				AllDelay += CmdDelay;
@@ -851,10 +851,10 @@ static void CompressVGMData(void)
 			VGMLib_WriteDelay(DstData, &DstPos, AllDelay, &WroteCmd80);
 			AllDelay = CmdDelay;
 			CmdDelay = 0x00;*/
-			
+
 			if (VGMPos == VGMHead.lngLoopOffset)
 				NewLoopS = DstPos;
-			
+
 			if (WriteEvent)
 			{
 				// Write Event
@@ -878,7 +878,7 @@ static void CompressVGMData(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -904,7 +904,7 @@ static void CompressVGMData(void)
 		memcpy(&DstData[0x1C], &NewLoopS, 0x04);
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (VGMHead.lngGD3Offset && VGMHead.lngGD3Offset + 0x0B < VGMHead.lngEOFOffset)
 	{
 		VGMPos = VGMHead.lngGD3Offset;
@@ -913,7 +913,7 @@ static void CompressVGMData(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			VGMHead.lngGD3Offset = DstPos;
 			TempLng = DstPos - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
@@ -924,9 +924,9 @@ static void CompressVGMData(void)
 	DstDataLen = DstPos;
 	TempLng = DstDataLen - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);
-	
+
 	FreeAllChips();
-	
+
 	return;
 }
 
@@ -941,14 +941,14 @@ bool GetNextChipCommand(void)
 	bool ReturnData;
 	bool CmdIsPort;
 	bool FirstCmd;
-	
+
 	CurPos = NxtCmdPos;
 	FirstCmd = true;
 	while(CurPos < VGMHead.lngEOFOffset)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[CurPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			CmdLen = 0x01;
@@ -1193,9 +1193,9 @@ bool GetNextChipCommand(void)
 			NxtCmdPos = CurPos;	// support consecutive searches
 			return true;
 		}
-		
+
 		CurPos += CmdLen;
 	}
-	
+
 	return false;
 }

--- a/vgm_cnt.c
+++ b/vgm_cnt.c
@@ -45,9 +45,9 @@ int main(int argc, char* argv[])
 	int argbase;
 	int ErrVal;
 	char FileName[0x100];
-	
+
 	printf("VGM Command Counter\n-------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	printf("File Name:\t");
@@ -62,7 +62,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -70,14 +70,14 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	CountVGMData();
-	
+
 	free(VGMData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -86,20 +86,20 @@ static bool OpenVGMFile(const char* FileName)
 	gzFile hFile;
 	UINT32 CurPos;
 	UINT32 TempLng;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -133,7 +133,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -143,7 +143,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -151,9 +151,9 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	return true;
 
 OpenErr:
@@ -164,12 +164,12 @@ OpenErr:
 
 static void CountVGMData()
 {
-	const char* CHIP_STRS[CHIP_COUNT] = 
+	const char* CHIP_STRS[CHIP_COUNT] =
 	{	"SN76496", "YM2413", "YM2612", "YM2151", "SegaPCM", "RF5C68", "YM2203", "YM2608",
 		"YM2610", "YM3812", "YM3526", "Y8950", "YMF262", "YMF278B", "YMF271", "YMZ280B",
 		"RF5C164", "PWM", "AY8910", "GameBoy", "NES APU", "MultiPCM", "uPD7759", "OKIM6258",
 		"OKIM6295", "K051649", "K054539", "HuC6280", "C140", "K053260", "Pokey", "QSound"};
-	
+
 	UINT8 Command;
 	UINT8 TempByt;
 	UINT16 TempSht;
@@ -182,7 +182,7 @@ static void CountVGMData()
 	UINT32 ChipCounters[CHIP_COUNT];
 	UINT8 CurChip;
 	const UINT8* VGMPnt;
-	
+
 	memset(ChipState, 0x00, sizeof(CHIP_STATE) * 0x02 * CHIP_COUNT);
 	for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++)
 	{
@@ -300,7 +300,7 @@ static void CountVGMData()
 		}
 		ChipCounters[CurChip] = TempLng;
 	}
-	
+
 	StopVGM = false;
 	VGMPos = VGMHead.lngDataOffset;
 	while(VGMPos < VGMHead.lngEOFOffset)
@@ -325,7 +325,7 @@ static void CountVGMData()
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			CurChip = 0x00;
 			switch(Command)
@@ -426,7 +426,7 @@ static void CountVGMData()
 				}
 				break;
 			}
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -464,10 +464,10 @@ static void CountVGMData()
 			case 0x67:	// Data Block (PCM Data Stream)
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				CurChip = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -803,7 +803,7 @@ static void CountVGMData()
 		for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++)
 		{
 			CHIP_STATE* TempChp = &ChipState[TempByt][CurChip];
-			
+
 			if (TempChp->Used || TempChp->CmdCount)
 			{
 				printf("%s #%u: ", CHIP_STRS[CurChip], TempByt);
@@ -816,7 +816,7 @@ static void CountVGMData()
 			}
 		}
 	}
-	
+
 	return;
 }
 
@@ -828,7 +828,7 @@ static void print_wordnum(const char* Word, INT32 Number)
 		printf("%d %s", Number, Word);
 	else
 		printf("%d %ss", Number, Word);
-	
+
 	return;
 }
 
@@ -836,11 +836,11 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 {
 	CHIP_STATE* TempChp = &ChipState[ChipSet][ChipID];
 	UINT8 CurChn;
-	
+
 	TempChp->CmdCount ++;
 	if (Reg & 0x8000)
 		return;
-	
+
 	switch(ChipID)
 	{
 	case 0x00:	// SN76496
@@ -1030,7 +1030,7 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 					if (Data & (0x10 << CurChn))
 						DoKeyOnOff(TempChp, CurChn, 0x00, 0x00);
 				}
-				
+
 				TempChp->ChnReg = 0xFF;
 			}
 			else if (Data & 0x80)
@@ -1101,7 +1101,7 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 		}
 		break;
 	}
-	
+
 	return;
 }
 

--- a/vgm_dso.c
+++ b/vgm_dso.c
@@ -84,9 +84,9 @@ int main(int argc, char* argv[])
 	char FileName[0x100];
 	UINT8 curBank;
 	UINT8 smplOverlap;
-	
+
 	printf("VGM DAC Stream Optimizer\n------------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	printf("File Name:\t");
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 1;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -109,11 +109,11 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	DstData = NULL;
 	memset(PCMBank, 0x00, sizeof(VGM_PCM_BANK) * PCM_BANK_COUNT);
 	memset(Bank93, 0x00, sizeof(SAMPLE_LIST) * PCM_BANK_COUNT);
-	
+
 	CancelFlag = false;
 	FindUsedROMData();
 	if (CancelFlag)
@@ -126,14 +126,14 @@ int main(int argc, char* argv[])
 		UINT32 curSmpl;
 		SAMPLE_LIST* tempBnk;
 		SAMPLE_INF* tempSmpl;
-		
+
 		printf("Data Block Usage\n---------------\n");
 		for (curBank = 0x00; curBank < PCM_BANK_COUNT; curBank ++)
 		{
 			tempBnk = &Bank93[curBank];
 			if (tempBnk->smplCnt == 0)
 				continue;
-			
+
 			printf("Start   End     Size  -- Datablock Type 0x%02X\n", curBank);
 			for (curSmpl = 0; curSmpl < tempBnk->smplCnt; curSmpl ++)
 			{
@@ -148,11 +148,11 @@ int main(int argc, char* argv[])
 		SAMPLE_LIST* tempBnk;
 		SAMPLE_INF* tempSmpl;
 		UINT32 smplPos;
-		
+
 		for (curBank = 0x00; curBank < PCM_BANK_COUNT; curBank ++)
 		{
 			tempBnk = &Bank93[curBank];
-			
+
 			smplPos = 0;
 			for (curSmpl = 0; curSmpl < tempBnk->smplCnt; curSmpl ++)
 			{
@@ -172,9 +172,9 @@ int main(int argc, char* argv[])
 		ErrVal = 0;
 		goto BreakProgress;
 	}
-	
+
 	OptimizeVGMSampleROM();
-	
+
 	if (argc > argbase + 1)
 		strcpy(FileName, argv[argbase + 1]);
 	else
@@ -184,8 +184,8 @@ int main(int argc, char* argv[])
 		strcpy(FileName, FileBase);
 		strcat(FileName, "_optimized.vgm");
 	}
-	WriteVGMFile(FileName); 
-	
+	WriteVGMFile(FileName);
+
 BreakProgress:
 	free(VGMData);
 	free(DstData);
@@ -195,10 +195,10 @@ BreakProgress:
 		free(PCMBank[curBank].Data);
 		free(Bank93[curBank].samples);
 	}
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -208,20 +208,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -242,7 +242,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -252,7 +252,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -260,14 +260,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -279,13 +279,13 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -305,21 +305,21 @@ static void FindUsedROMData(void)
 	bool StopVGM;
 	const UINT8* VGMPnt;
 	STREAM_INF* tempSInf;
-	
+
 	printf("Creating ROM-Usage Mask ...\n");
 	VGMPos = VGMHead.lngDataOffset;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
 	memset(StreamInfo, 0x00, sizeof(STREAM_INF) * 0x100);
-	
+
 	StopVGM = false;
 	while(VGMPos < VGMHead.lngEOFOffset)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -338,7 +338,7 @@ static void FindUsedROMData(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -366,10 +366,10 @@ static void FindUsedROMData(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -425,7 +425,7 @@ static void FindUsedROMData(void)
 				{
 					UINT32 dStart;
 					UINT32 dLen;
-					
+
 					dStart = ReadLE32(&VGMPnt[0x02]);
 					dLen = ReadLE32(&VGMPnt[0x07]);
 					AddSampleToList(tempSInf->bankID, dStart, dLen);
@@ -470,11 +470,11 @@ static void FindUsedROMData(void)
 				break;
 			}
 		}
-		
+
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -489,7 +489,7 @@ static void FindUsedROMData(void)
 #endif
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-		
+
 	return;
 }
 
@@ -517,13 +517,13 @@ static void OptimizeVGMSampleROM(void)
 	SAMPLE_LIST* tempBnk;
 	SAMPLE_INF* tempSmpl;
 	STREAM_INF* tempSInf;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	VGMPos = VGMHead.lngDataOffset;
 	DstPos = VGMHead.lngDataOffset;
 	NewLoopS = 0x00;
 	memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -533,19 +533,19 @@ static void OptimizeVGMSampleROM(void)
 		tempBnk = &Bank93[curBank];
 		if (tempPCM->DataSize == 0 || tempBnk->smplCnt == 0)
 			continue;
-		
+
 		TempLng = 0;
 		TempSht = 0x0000;
 		for (curSmpl = 0; curSmpl < tempBnk->smplCnt; curSmpl ++)
 		{
 			tempSmpl = &tempBnk->samples[curSmpl];
-			
+
 			if (TempLng < tempSmpl->startOfs)
 			{
 				WriteDataBlock(&DstPos, curBank, tempSmpl->startOfs - TempLng, &tempPCM->Data[TempLng]);
 				TempSht ++;
 			}
-			
+
 			tempSmpl->smplID = TempSht;
 			WriteDataBlock(&DstPos, curBank, tempSmpl->dataSize, &tempPCM->Data[tempSmpl->startOfs]);
 			TempSht ++;
@@ -568,26 +568,26 @@ static void OptimizeVGMSampleROM(void)
 			tempSInf->posCmd[0x01] = 0x00;
 			tempSInf->posCmd[0x02] = 0x00;
 		}
-		
+
 		for (Command = 0x00; Command < 0x03; Command ++)
 		{
 			if (! tempSInf->posCmd[Command])
 				continue;
-			
+
 			CmdLen = (Command == 0x02) ? 0x06 : 0x05;
 			printf("Copying data from for command %02X 0x%06X -> 0x%06X\n", 0x90 + Command, tempSInf->posCmd[Command], DstPos);
 			memcpy(&DstData[DstPos], &VGMData[tempSInf->posCmd[Command]], CmdLen);
 			DstPos += CmdLen;
 		}
 	}
-	
+
 	StopVGM = false;
 	while(VGMPos < VGMHead.lngEOFOffset)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		WriteEvent = true;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -606,7 +606,7 @@ static void OptimizeVGMSampleROM(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -634,10 +634,10 @@ static void OptimizeVGMSampleROM(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -683,7 +683,7 @@ static void OptimizeVGMSampleROM(void)
 				{
 					UINT32 dStart;
 					UINT32 dLen;
-					
+
 					tempBnk = &Bank93[tempSInf->bankID];
 					dStart = ReadLE32(&VGMPnt[0x02]);
 					dLen = ReadLE32(&VGMPnt[0x07]);
@@ -739,7 +739,7 @@ static void OptimizeVGMSampleROM(void)
 				break;
 			}
 		}
-		
+
 		// Note: In the case that the loop offset points to a Data Block,
 		//       it gets moved to the first command after it.
 		if (VGMPos == VGMHead.lngLoopOffset)
@@ -752,7 +752,7 @@ static void OptimizeVGMSampleROM(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -774,7 +774,7 @@ static void OptimizeVGMSampleROM(void)
 		memcpy(&DstData[0x1C], &TempLng, 0x04);
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (VGMHead.lngGD3Offset && VGMHead.lngGD3Offset + 0x0B < VGMHead.lngEOFOffset)
 	{
 		VGMPos = VGMHead.lngGD3Offset;
@@ -783,7 +783,7 @@ static void OptimizeVGMSampleROM(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			TempLng = DstPos - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
 			memcpy(&DstData[DstPos], &VGMData[VGMPos], CmdLen);
@@ -793,7 +793,7 @@ static void OptimizeVGMSampleROM(void)
 	DstDataLen = DstPos;
 	TempLng = DstDataLen - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);
-	
+
 	return;
 }
 
@@ -805,7 +805,7 @@ static void WriteDataBlock(UINT32* DstPos, UINT8 blkType, UINT32 dataSize, const
 	WriteLE32(&DstData[*DstPos + 0x03], dataSize);
 	memcpy(&DstData[*DstPos + 0x07], data, dataSize);
 	(*DstPos) += 0x07 + dataSize;
-	
+
 	return;
 }
 
@@ -815,27 +815,27 @@ static void AddPCMData(UINT8 Type, UINT32 DataSize, const UINT8* Data)
 	VGM_PCM_BANK* tempPCM;
 	VGM_PCM_DATA* tempBnk;
 	UINT8 BnkType;
-	
+
 	BnkType = Type & 0x3F;
 	if (BnkType >= PCM_BANK_COUNT)
 		return;
 	if (Type == 0x7F)
 		return;
-	
+
 	tempPCM = &PCMBank[BnkType];
 	CurBnk = tempPCM->BankCount;
 	tempPCM->BankCount ++;
 	tempPCM->Bank = (VGM_PCM_DATA*)realloc(tempPCM->Bank, sizeof(VGM_PCM_DATA) * tempPCM->BankCount);
-	
+
 	tempPCM->Data = realloc(tempPCM->Data, tempPCM->DataSize + DataSize);
 	tempBnk = &tempPCM->Bank[CurBnk];
 	tempBnk->DataStart = tempPCM->DataSize;
-	
+
 	tempBnk->DataSize = DataSize;
 	tempBnk->Data = tempPCM->Data + tempBnk->DataStart;
 	memcpy(tempBnk->Data, Data, DataSize);
 	tempPCM->DataSize += DataSize;
-	
+
 	return;
 }
 
@@ -845,11 +845,11 @@ static void AddSampleToList(UINT8 Type, UINT32 startOfs, UINT32 length)
 	UINT32 curSmpl;
 	SAMPLE_LIST* tempBnk;
 	SAMPLE_INF* tempSmpl;
-	
+
 	BnkType = Type & 0x3F;
 	if (BnkType >= PCM_BANK_COUNT)
 		return;
-	
+
 	tempBnk = &Bank93[BnkType];
 	for (curSmpl = 0; curSmpl < tempBnk->smplCnt; curSmpl ++)
 	{
@@ -860,11 +860,11 @@ static void AddSampleToList(UINT8 Type, UINT32 startOfs, UINT32 length)
 	curSmpl = tempBnk->smplCnt;
 	tempBnk->smplCnt ++;
 	tempBnk->samples = (SAMPLE_INF*)realloc(tempBnk->samples, sizeof(SAMPLE_INF) * tempBnk->smplCnt);
-	
+
 	tempSmpl = &tempBnk->samples[curSmpl];
 	tempSmpl->startOfs = startOfs;
 	tempSmpl->dataSize = length;
-	
+
 	return;
 }
 
@@ -877,13 +877,13 @@ static void SortSampleLists(void)
 {
 	UINT8 curBank;
 	SAMPLE_LIST* tempBnk;
-	
+
 	for (curBank = 0x00; curBank < PCM_BANK_COUNT; curBank ++)
 	{
 		tempBnk = &Bank93[curBank];
 		qsort(tempBnk->samples, tempBnk->smplCnt, sizeof(SAMPLE_INF), &SampleCompare);
 	}
-	
+
 	return;
 }
 

--- a/vgm_facc.c
+++ b/vgm_facc.c
@@ -40,12 +40,12 @@ int main(int argc, char* argv[])
 	int ErrVal;
 	int argbase;
 	char FileName[0x100];
-	
+
 	printf("Make VGM Frame Accurate\n-----------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -58,7 +58,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -66,9 +66,9 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	RoundVGMData();
-	
+
 	if (argc > argbase + 1)
 		strcpy(FileName, argv[argbase + 1]);
 	else
@@ -79,13 +79,13 @@ int main(int argc, char* argv[])
 		strcat(FileName, "_frame.vgm");
 	}
 	WriteVGMFile(FileName);
-	
+
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -95,20 +95,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -129,7 +129,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -139,7 +139,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -147,14 +147,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -167,25 +167,25 @@ static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
 	const char* FileTitle;
-	
+
 	printf("\t\t\t\t\t\t\t\t\r");
 	FileTitle = strrchr(FileName, '\\');
 	if (FileTitle == NULL)
 		FileTitle = FileName;
 	else
 		FileTitle ++;
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
 		printf("Error writing %s!\n", FileTitle);
 		return;
 	}
-	
+
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
 	printf("%s written.\n", FileTitle);
-	
+
 	return;
 }
 
@@ -219,11 +219,11 @@ static void RoundVGMData(void)
 	INT32 RndPosMin;
 	INT32 RndPosMax;
 	INT32 RndPosMax1;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen);
 	VGMPos = VGMHead.lngDataOffset;
 	DstPos = VGMHead.lngDataOffset;
-	
+
 	switch(VGMHead.lngRate)
 	{
 	case 0:
@@ -252,14 +252,14 @@ static void RoundVGMData(void)
 	MaxDelay = (UINT16)(0xFFFF / RoundTo * RoundTo);
 	SampleCount = RoundU(VGMHead.lngTotalSamples);
 	LoopSmpl = RoundU(VGMHead.lngTotalSamples - VGMHead.lngLoopSamples);
-	
+
 	RndErrMin = 0;
 	RndErrMax = 0;
 	RndErrMax1 = 0;
 	RndPosMin = 0;
 	RndPosMax = 0;
 	RndPosMax1 = 0;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -273,7 +273,7 @@ static void RoundVGMData(void)
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		IsDelay = false;
-		
+
 		CmdDelay = 0x00;
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
@@ -373,7 +373,7 @@ static void RoundVGMData(void)
 				}
 				break;
 			}
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -512,7 +512,7 @@ static void RoundVGMData(void)
 				break;
 			}
 		}
-		
+
 		if (VGMHead.lngLoopOffset && VGMPos == VGMHead.lngLoopOffset)
 			LoopPos = DstPos;
 		if (IsDelay)
@@ -547,12 +547,12 @@ static void RoundVGMData(void)
 						TempSht = (UINT16)TempLng;
 					else
 						TempSht = MaxDelay;
-					
+
 					DstData[DstPos + 0x00] = 0x61;
 					memcpy(&DstData[DstPos + 0x01], &TempSht, 0x02);
 					DstPos += 0x03;
 				}
-				
+
 				VGMSmplLast += TempSht;
 			}
 		}
@@ -564,7 +564,7 @@ static void RoundVGMData(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -578,19 +578,19 @@ static void RoundVGMData(void)
 		}
 #endif
 	}
-	
+
 	if (VGMHead.lngLoopOffset && ! LoopPos)
 		printf("Warning! Failed to relocate Loop Point!\n");
-	
+
 	WriteVGMHeader(DstData, VGMData, DstPos, SampleCount,
 					LoopPos, SampleCount - LoopSmpl);
 	/*sprintf(TempStr, "%s_frame.vgm", FileBase);
 	WriteVGMFile(TempStr);*/
-	
+
 	printf("Maximum Rounding Difference:\n");
 	printf("\t%d at %06X\n\t%d at %06X\n\t%d at %06X (first frame only)\n",
 			RndErrMin, RndPosMin, RndErrMax, RndPosMax, RndErrMax1, RndPosMax1);
-	
+
 	return;
 }
 
@@ -602,7 +602,7 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 	UINT32 DstPos;
 	UINT32 CmdLen;
 	UINT32 TempLng;
-	
+
 	memcpy(DstData, VGMData, VGMHead.lngDataOffset);	// Copy Header
 	memcpy(&DstData[0x18], &SampleCount, 0x04);
 	TempLng = LoopPos;
@@ -610,7 +610,7 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 		TempLng -= 0x1C;
 	memcpy(&DstData[0x1C], &TempLng, 0x04);
 	memcpy(&DstData[0x20], &LoopSmpls, 0x04);
-	
+
 	DstPos = EOFPos;
 	if (VGMHead.lngGD3Offset && VGMHead.lngGD3Offset + 0x0B < VGMHead.lngEOFOffset)
 	{
@@ -620,18 +620,18 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 		{
 			memcpy(&CmdLen, &VGMData[CurPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			TempLng = DstPos - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
 			memcpy(&DstData[DstPos], &VGMData[CurPos], CmdLen);	// Copy GD3 Tag
 			DstPos += CmdLen;
 		}
 	}
-	
+
 	DstDataLen = DstPos;
 	TempLng = DstDataLen - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);	// Write EOF Position
-	
+
 	return;
 }
 
@@ -654,7 +654,7 @@ static void SetRoundError(UINT32 SrcVal, UINT32 RndVal, INT32* ErrMin, INT32* Er
 						  INT32* PosMin, INT32* PosMax)
 {
 	INT32 TempLng;
-	
+
 	TempLng = SrcVal - RndVal;
 	if (TempLng < 0)
 	{
@@ -672,6 +672,6 @@ static void SetRoundError(UINT32 SrcVal, UINT32 RndVal, INT32* ErrMin, INT32* Er
 			*PosMax = VGMPos;
 		}
 	}
-	
+
 	return;
 }

--- a/vgm_lib.h
+++ b/vgm_lib.h
@@ -10,17 +10,17 @@ void VGMLib_WriteDelay(UINT8* DstData, UINT32* Pos, UINT32 Delay, bool* WroteCmd
 	UINT16 CurDly;
 	UINT32 TempLng;
 	bool WrtCmdPCM;
-	
+
 	DstPos = *Pos;
 	WrtCmdPCM = (WroteCmd80 == NULL) ? false : *WroteCmd80;
-	
+
 	while(Delay)
 	{
 		if (Delay <= 0xFFFF)
 			CurDly = (UINT16)Delay;
 		else
 			CurDly = 0xFFFF;
-		
+
 		if (WrtCmdPCM)
 		{
 			// highest delay compression - Example:
@@ -40,7 +40,7 @@ void VGMLib_WriteDelay(UINT8* DstData, UINT32* Pos, UINT32 Delay, bool* WroteCmd
 			else if (DELAY_CHECK(CurDly,						// 8F 62 63
 								DELAY_60HZ + DELAY_50HZ, 0x0F))
 				CurDly -= DELAY_60HZ + DELAY_50HZ;
-			
+
 			/*if (CurDly >= 0x10 && CurDly <= 0x1F)
 				CurDly = 0x0F;
 			else if (CurDly >= 0x20)
@@ -109,7 +109,7 @@ void VGMLib_WriteDelay(UINT8* DstData, UINT32* Pos, UINT32 Delay, bool* WroteCmd
 		}
 		Delay -= CurDly;
 	}
-	
+
 	*Pos = DstPos;
 	return;
 }

--- a/vgm_mono.c
+++ b/vgm_mono.c
@@ -62,9 +62,9 @@ int main(int argc, char* argv[])
 	int argbase;
 	int ErrVal;
 	char FileName[0x100];
-	
+
 	printf("VGM Mono\n--------\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	/*while(argbase < argc && argv[argbase][0] == '-')
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
 			break;
 		}
 	}*/
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	/*PassNo = 0x00;
 	do
 	{
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
 	} while(DataSizeB < DataSizeA);
 	printf("Data Compression Total: %u -> %u (%.1f %%)\n",
 			SrcDataSize, DataSizeB, 100.0 * DataSizeB / (float)SrcDataSize);
-	
+
 	if (DataSizeB < SrcDataSize)*/
 	{
 		if (argc > argbase + 1)
@@ -136,13 +136,13 @@ int main(int argc, char* argv[])
 		}
 		WriteVGMFile(FileName);
 	}
-	
+
 	free(VGMData);
 	//free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -152,20 +152,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -197,7 +197,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -207,7 +207,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -215,14 +215,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -234,14 +234,14 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	//fwrite(DstData, 0x01, DstDataLen, hFile);
 	fwrite(VGMData, 0x01, VGMDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -271,13 +271,13 @@ static void CompressVGMData(void)
 	UINT8 X1Channel;
 	UINT8 X1Flags[0x10];
 	UINT8* X1VolWrites[0x10];	// need to cache because sample volume register has another purpose in wavetable mode
-	
+
 	//DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	VGMPos = VGMHead.lngDataOffset;
 	//DstPos = VGMHead.lngDataOffset;
 	VGMSmplPos = 0;
 	//memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -302,17 +302,17 @@ static void CompressVGMData(void)
 			c140_write(0xFF, 0x00, VGMHead.bytC140Type);
 		}
 	}*/
-	
+
 	memset(ChnBoth, 0x00, sizeof(UINT32) * 0x20);
 	LastMBnkWrtOfs = 0x00;
 	MPCMBank = MPCMAddr = MPCMSlot = 0x00;
-	
+
 	StopVGM = false;
 	while(VGMPos < VGMHead.lngEOFOffset)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -331,7 +331,7 @@ static void CompressVGMData(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			ChipID = 0x00;
 			switch(Command)
@@ -433,7 +433,7 @@ static void CompressVGMData(void)
 				break;
 			}
 			//SetChipSet(ChipID);
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -470,11 +470,11 @@ static void CompressVGMData(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
 				/*SetChipSet(ChipID);
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -491,7 +491,7 @@ static void CompressVGMData(void)
 					DataLen = TempLng - 0x02;
 					break;
 				}*/
-				
+
 				CmdLen = 0x07 + TempLng;
 				break;
 			case 0xE0:	// Seek to PCM Data Bank Pos
@@ -507,7 +507,7 @@ static void CompressVGMData(void)
 				if ((TempSht & 0xF8) == 0x20)
 				{
 					TempByt = TempSht & 0x07;
-					
+
 					if ((VGMPnt[0x02] & 0xC0) == 0xC0)
 					{
 						ChnBoth[TempByt] = VGMPos;
@@ -562,7 +562,7 @@ static void CompressVGMData(void)
 			case 0x59:	// YM2610 write port 1
 				TempByt = Command & 0x01;
 				//WriteEvent = ym2610_write(TempByt, VGMPnt[0x01], VGMPnt[0x02]);
-				
+
 				TempSht = (TempByt << 8) | (VGMPnt[0x01] << 0);
 				//		FM Stereo			or		ADPCM Stereo		or		Delta-T Stereo
 				if ((TempSht & 0xFC) == 0xB4 || (TempSht & 0x1F8) == 0x108 || TempSht == 0x011)
@@ -573,7 +573,7 @@ static void CompressVGMData(void)
 						TempByt = 12;
 					else
 						TempByt = 6 + (TempSht & 0x07);
-					
+
 					if ((VGMPnt[0x02] & 0xC0) == 0xC0)
 					{
 						ChnBoth[TempByt] = VGMPos;
@@ -809,7 +809,7 @@ static void CompressVGMData(void)
 			case 0xc8:	// X1-010 write
 				TempSht = VGMPnt[0x01]<<8 | VGMPnt[0x02]<<0;
 				TempByt = VGMPnt[0x03];
-				
+
 				// register write
 				if(TempSht < 0x80)
 				{
@@ -850,7 +850,7 @@ static void CompressVGMData(void)
 					TempByt = (TempByt>>4) > (TempByt&0x0f) ? ((TempByt&0xf0) | (TempByt>>4)) : ((TempByt&0x0f) | (TempByt<<4));
 					VGMPnt[0x03] = TempByt;
 				}
-				
+
 				CmdLen = 0x04;
 				break;
 			default:
@@ -882,11 +882,11 @@ static void CompressVGMData(void)
 				break;
 			}
 		}
-		
+
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -901,6 +901,6 @@ static void CompressVGMData(void)
 #endif
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	return;
 }

--- a/vgm_ndlz.c
+++ b/vgm_ndlz.c
@@ -48,9 +48,9 @@ int main(int argc, char* argv[])
 	int ErrVal;
 	char FileName[0x100];
 	UINT8 FileID;
-	
+
 	printf("VGM Undualizer\n--------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	printf("File Name:\t");
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -73,20 +73,20 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	SplitVGMData();
 	free(SrcData);
-	
+
 	for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 	{
 		sprintf(FileName, "%s_%u.vgm", FileBase, FileID);
 		WriteVGMFile(FileName, &DstVGM[FileID]);
 		free(DstVGM[FileID].Data);
 	}
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -96,20 +96,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &SrcHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(SrcHead);
-	
+
 	// Header preperations
 	if (SrcHead.lngVersion < 0x00000150)
 	{
@@ -130,7 +130,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! SrcHead.lngDataOffset)
 		SrcHead.lngDataOffset = 0x0000000C;
 	SrcHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = SrcHead.lngDataOffset;
 	if (SrcHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -140,7 +140,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&SrcHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	SrcDataLen = SrcHead.lngEOFOffset;
 	SrcData = (UINT8*)malloc(SrcDataLen);
@@ -148,14 +148,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, SrcData, SrcDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -168,7 +168,7 @@ static void WriteVGMFile(const char* FileName, VGM_INF* VGMInf)
 {
 	FILE* hFile;
 	const char* FileTitle;
-	
+
 	//printf("                                                                \r");
 	printf("\t\t\t\t\t\t\t\t\r");
 	FileTitle = strrchr(FileName, '\\');
@@ -176,24 +176,24 @@ static void WriteVGMFile(const char* FileName, VGM_INF* VGMInf)
 		FileTitle = FileName;
 	else
 		FileTitle ++;
-	
+
 	if (! VGMInf->HadWrt)
 	{
 		printf("%s skipped (empty).\n", FileTitle);
 		return;
 	}
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
 		printf("Error writing %s!\n", FileTitle);
 		return;
 	}
-	
+
 	fwrite(VGMInf->Data, 0x01, VGMInf->DataLen, hFile);
 	fclose(hFile);
 	printf("%s written.\n", FileTitle);
-	
+
 	return;
 }
 
@@ -202,7 +202,7 @@ static void CopyHeader(VGM_HEADER* SrcHead, VGM_HEADER* DstHead, bool IsChip2)
 	UINT8 CurChip;
 	UINT32* SrcClock;
 	UINT32* DstClock;
-	
+
 	*DstHead = *SrcHead;
 	for (CurChip = 0x00; CurChip < 0x20; CurChip ++)
 	{
@@ -234,7 +234,7 @@ static void CopyHeader(VGM_HEADER* SrcHead, VGM_HEADER* DstHead, bool IsChip2)
 			DstClock = &DstHead->lngHzOKIM6295;
 			break;
 		}
-		
+
 		if (! IsChip2 || (*SrcClock & 0x40000000))
 		{
 			*DstClock = *SrcClock & 0xBFFFFFFF;
@@ -270,12 +270,12 @@ static void CopyHeader(VGM_HEADER* SrcHead, VGM_HEADER* DstHead, bool IsChip2)
 				break;
 			}
 		}
-		
+
 		// move to next chip clock
 		SrcClock ++;
 		DstClock ++;
 	}
-	
+
 	return;
 }
 
@@ -298,11 +298,11 @@ static void SplitVGMData(void)
 	bool WriteEvent;
 	UINT32 FixOfs;
 	UINT8 FixByt;
-	
+
 	for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 	{
 		TempVGM = &DstVGM[FileID];
-		
+
 		CopyHeader(&SrcHead, &TempVGM->Head, (FileID > 0x00));
 		TempVGM->Pos = TempVGM->Head.lngDataOffset;
 		TempVGM->DataLen = SrcDataLen;
@@ -311,7 +311,7 @@ static void SplitVGMData(void)
 		TempVGM->WroteCmd80 = false;
 		TempVGM->HadWrt = false;
 	}
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -327,14 +327,14 @@ static void SplitVGMData(void)
 			for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 			{
 				TempVGM = &DstVGM[FileID];
-				
+
 				TempLng = SrcSmplPos - TempVGM->SmplPos;
 				VGMLib_WriteDelay(TempVGM->Data, &TempVGM->Pos, TempLng, &TempVGM->WroteCmd80);
 				TempVGM->Head.lngLoopOffset = TempVGM->Pos;
 				TempVGM->SmplPos = SrcSmplPos;
 			}
 		}
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -358,28 +358,28 @@ static void SplitVGMData(void)
 			{
 			case 0x66:	// End Of File
 				StopVGM = true;
-				
+
 				WriteEvent = false;
 				CmdLen = 0x01;
 				break;
 			case 0x62:	// 1/60s delay
 				TempSht = 735;
 				CmdDelay = TempSht;
-				
+
 				WriteEvent = false;
 				CmdLen = 0x01;
 				break;
 			case 0x63:	// 1/50s delay
 				TempSht = 882;
 				CmdDelay = TempSht;
-				
+
 				WriteEvent = false;
 				CmdLen = 0x01;
 				break;
 			case 0x61:	// xx Sample Delay
 				memcpy(&TempSht, &SrcData[SrcPos + 0x01], 0x02);
 				CmdDelay = TempSht;
-				
+
 				WriteEvent = false;
 				CmdLen = 0x03;
 				break;
@@ -388,10 +388,10 @@ static void SplitVGMData(void)
 				memcpy(&TempLng, &SrcData[SrcPos + 0x03], 0x04);
 				FileID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				FixOfs = 0x06;
 				FixByt = SrcData[SrcPos + 0x06] & 0x7F;
-				
+
 				CmdLen = 0x07 + TempLng;
 				break;
 			case 0x68:	// PCM RAM write
@@ -423,14 +423,14 @@ static void SplitVGMData(void)
 				FileID = 0x01;
 				FixOfs = 0x00;
 				FixByt = 0x50;
-				
+
 				CmdLen = 0x02;
 				break;
 			case 0x3F:
 				FileID = 0x01;
 				FixOfs = 0x00;
 				FixByt = 0x4F;
-				
+
 				CmdLen = 0x02;
 				break;
 			default:
@@ -456,14 +456,14 @@ static void SplitVGMData(void)
 						FixOfs = 0x00;
 						FixByt = Command - 0x50;
 					}
-					
+
 					CmdLen = 0x03;
 					break;
 				case 0xB0:
 					FileID = (SrcData[SrcPos + 0x01] & 0x80) >> 7;
 					FixOfs = 0x01;
 					FixByt = SrcData[SrcPos + 0x01] & 0x7F;
-					
+
 					CmdLen = 0x03;
 					break;
 				case 0xC0:
@@ -471,7 +471,7 @@ static void SplitVGMData(void)
 					FileID = (SrcData[SrcPos + 0x01] & 0x80) >> 7;
 					FixOfs = 0x01;
 					FixByt = SrcData[SrcPos + 0x01] & 0x7F;
-					
+
 					CmdLen = 0x04;
 					break;
 				case 0xE0:
@@ -486,16 +486,16 @@ static void SplitVGMData(void)
 				}	// end switch(Command & 0xF0)
 			}	// end switch(Command)
 		}
-		
+
 		SrcSmplPos += CmdDelay;
 		if (WriteEvent)
 		{
 			TempVGM = &DstVGM[FileID];
-			
+
 			TempLng = SrcSmplPos - TempVGM->SmplPos;
 			VGMLib_WriteDelay(TempVGM->Data, &TempVGM->Pos, TempLng, &TempVGM->WroteCmd80);
 			TempVGM->SmplPos = SrcSmplPos;
-			
+
 			// Write Event
 			TempVGM->HadWrt = true;
 			TempVGM->WroteCmd80 = ((Command & 0xF0) == 0x80);
@@ -504,12 +504,12 @@ static void SplitVGMData(void)
 				CmdDelay = Command & 0x0F;
 				Command &= 0x80;
 			}
-			
+
 			if (CmdLen > 0x01)
 				memcpy(&TempVGM->Data[TempVGM->Pos], &SrcData[SrcPos], CmdLen);
 			else
 				TempVGM->Data[TempVGM->Pos] = Command;	// write the 0x80-command correctly
-			
+
 			// now fix the 2nd-chip commands
 			if (FileID)
 				TempVGM->Data[TempVGM->Pos + FixOfs] = FixByt;
@@ -518,7 +518,7 @@ static void SplitVGMData(void)
 		SrcPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -535,7 +535,7 @@ static void SplitVGMData(void)
 		TempVGM = &DstVGM[FileID];
 		if (! TempVGM->HadWrt)
 			continue;
-		
+
 		// write EOF
 		TempLng = SrcSmplPos - TempVGM->SmplPos;
 		VGMLib_WriteDelay(TempVGM->Data, &TempVGM->Pos, TempLng, &TempVGM->WroteCmd80);
@@ -543,7 +543,7 @@ static void SplitVGMData(void)
 		TempVGM->Pos ++;
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (SrcHead.lngGD3Offset && SrcHead.lngGD3Offset + 0x0B < SrcHead.lngEOFOffset)
 	{
 		SrcPos = SrcHead.lngGD3Offset;
@@ -552,26 +552,26 @@ static void SplitVGMData(void)
 		{
 			memcpy(&CmdLen, &SrcData[SrcPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 			{
 				TempVGM = &DstVGM[FileID];
 				if (! TempVGM->HadWrt)
 					continue;
-				
+
 				TempVGM->Head.lngGD3Offset = TempVGM->Pos;
 				memcpy(&TempVGM->Data[TempVGM->Pos], &SrcData[SrcPos], CmdLen);
 				TempVGM->Pos += CmdLen;
 			}
 		}
 	}
-	
+
 	for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 	{
 		TempVGM = &DstVGM[FileID];
 		if (! TempVGM->HadWrt)
 			continue;
-		
+
 		TempVGM->DataLen = TempVGM->Pos;
 		TempVGM->Head.lngEOFOffset = TempVGM->DataLen - 0x04;
 		if (TempVGM->Head.lngGD3Offset)
@@ -580,7 +580,7 @@ static void SplitVGMData(void)
 			TempVGM->Head.lngLoopOffset -= 0x1C;
 		TempLng = TempVGM->Head.lngDataOffset;
 		TempVGM->Head.lngDataOffset -= 0x34;
-		
+
 		// Copy Header
 		if (sizeof(VGM_HEADER) < TempLng)
 		{
@@ -593,6 +593,6 @@ static void SplitVGMData(void)
 			memcpy(&TempVGM->Data[0x00], &TempVGM->Head, TempLng);
 		}
 	}
-	
+
 	return;
 }

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -62,9 +62,9 @@ int main(int argc, char* argv[])
 	bool FileCompr;
 	int ErrVal;
 	UINT8 RetVal;
-	
+
 	printf("VGM Patcher\n-----------\n");
-	
+
 	ErrVal = 0;
 	if (argc <= 1)
 	{
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
 		printf("    -SetVolMod    Set the Volume Modifier (Format: 1.0, 0x00)\n");
 		printf("\n");
 		_getch();
-		
+
 		printf("Commands to check the lengths (total, loop) and offsets (EOF, loop, GD3):\n");
 		printf("    -Check        asks for correction\n");
 		printf("    -CheckR       read only mode\n");
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
 		printf("\n");
 		printf("                   Tip: Stripping without commands optimizes the delays.\n");
 		printf("\n");
-		
+
 		printf("Command names are case insensitive.\n");
 		goto EndProgram;
 	}
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
 		printf("    -SetHzYMF271   Sets the YMF271 (OPLX) chip clock\n");
 		printf("    -SetHzYMZ280B  Sets the YMZ280B chip clock\n");
 		_getch();
-		
+
 		printf("    -SetHzRF5C164  Sets the RF5C164 (Sega MegaCD PCM) chip clock\n");
 		printf("    -SetHzPWM      Sets the PWM chip clock\n");
 		printf("    -SetHzAY8910   Sets the AY8910 chip clock\n");
@@ -195,7 +195,7 @@ int main(int argc, char* argv[])
 		printf("    PWM            -\n");
 		printf("    AY8910        *0..5\n");
 		_getch();
-		
+
 		printf("    GBDMG         *0..3\n");
 		printf("    NESAPU        *0..4\n");
 		printf("    MultiPCM      *0..27\n");
@@ -214,7 +214,7 @@ int main(int argc, char* argv[])
 		printf("\n");
 		goto EndProgram;
 	}
-	
+
 	for (CmdCnt = 1; CmdCnt < argc; CmdCnt ++)
 	{
 		if (*argv[CmdCnt] != '-')
@@ -230,7 +230,7 @@ int main(int argc, char* argv[])
 		printf("Error: No files specified!\n");
 		goto EndProgram;
 	}
-	
+
 	PreparseCommands(CmdCnt - 1, argv + 1);
 	for (CurArg = CmdCnt; CurArg < argc; CurArg ++)
 	{
@@ -242,7 +242,7 @@ int main(int argc, char* argv[])
 			ErrVal |= 1;	// There was at least 1 opening-error.
 			continue;
 		}
-		
+
 		RetVal = PatchVGM(CmdCnt - 1, argv + 1);
 		if (RetVal & 0x80)
 		{
@@ -267,10 +267,10 @@ int main(int argc, char* argv[])
 		}*/
 		printf("\n");
 	}
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -279,13 +279,13 @@ static UINT32 GetGZFileLength(const char* FileName)
 	FILE* hFile;
 	UINT32 FileSize;
 	UINT16 gzHead;
-	
+
 	hFile = fopen(FileName, "rb");
 	if (hFile == NULL)
 		return 0xFFFFFFFF;
-	
+
 	fread(&gzHead, 0x02, 0x01, hFile);
-	
+
 	if (gzHead != 0x8B1F)
 	{
 		// normal file
@@ -298,9 +298,9 @@ static UINT32 GetGZFileLength(const char* FileName)
 		fseek(hFile, -4, SEEK_END);
 		fread(&FileSize, 0x04, 0x01, hFile);
 	}
-	
+
 	fclose(hFile);
-	
+
 	return FileSize;
 }
 
@@ -313,7 +313,7 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 	UINT32 FileSize;
 	UINT32 CurPos;
 	UINT32 TempLng;
-	
+
 #ifdef WIN32
 	hFileWin = CreateFile(FileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL,
 							OPEN_EXISTING, 0, NULL);
@@ -324,26 +324,26 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 	}
 #endif
 	KeepDate = true;
-	
+
 	FileSize = GetGZFileLength(FileName);
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	*Compressed = ! gzdirect(hFile);
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// I skip the Header preperations. I'll deal with that later
-	
+
 	if (VGMHead.lngVersion < 0x150)
 		RealHdrSize = 0x40;
 	else
@@ -351,10 +351,10 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 	TempLng = sizeof(VGM_HEADER);
 	if (TempLng > RealHdrSize)
 		memset((UINT8*)&VGMHead + RealHdrSize, 0x00, TempLng - RealHdrSize);
-	
+
 	memset(&VGMHeadX, 0x00, sizeof(VGM_HDR_EXTRA));
 	memset(&VGMH_Extra, 0x00, sizeof(VGM_EXTRA));
-	
+
 	if (VGMHead.lngExtraOffset)
 	{
 		CurPos = 0xBC + VGMHead.lngExtraOffset;
@@ -367,7 +367,7 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 	}
 	// never copy more bytes than the structure has
 	RealCpySize = (RealHdrSize <= TempLng) ? RealHdrSize : TempLng;
-	
+
 	// Read Data
 	if (*Compressed)
 		VGMDataLen = 0x04 + VGMHead.lngEOFOffset;	// size from EOF offset
@@ -378,9 +378,9 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	// Read Extra Header Data
 	if (VGMHead.lngExtraOffset)
 	{
@@ -388,16 +388,16 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 		memcpy(&TempLng,	&VGMData[CurPos], 0x04);
 		memcpy(&VGMHeadX,	&VGMData[CurPos], TempLng);
 		CurPos += 0x04;
-		
+
 		if (VGMHeadX.Chp2ClkOffset)
 			ReadChipExtraData32(CurPos + VGMHeadX.Chp2ClkOffset, &VGMH_Extra.Clocks);
 		CurPos += 0x04;
-		
+
 		if (VGMHeadX.ChpVolOffset)
 			ReadChipExtraData16(CurPos + VGMHeadX.ChpVolOffset, &VGMH_Extra.Volumes);
 		CurPos += 0x04;
 	}
-	
+
 	return true;
 
 OpenErr:
@@ -411,14 +411,14 @@ static void ReadChipExtraData32(UINT32 StartOffset, VGMX_CHP_EXTRA32* ChpExtra)
 	UINT32 CurPos;
 	UINT8 CurChp;
 	VGMX_CHIP_DATA32* TempCD;
-	
+
 	if (! StartOffset)
 	{
 		ChpExtra->ChipCnt = 0x00;
 		ChpExtra->CCData = NULL;
 		return;
 	}
-	
+
 	CurPos = StartOffset;
 	ChpExtra->ChipCnt = VGMData[CurPos];
 	if (ChpExtra->ChipCnt)
@@ -427,7 +427,7 @@ static void ReadChipExtraData32(UINT32 StartOffset, VGMX_CHP_EXTRA32* ChpExtra)
 	else
 		ChpExtra->CCData = NULL;
 	CurPos ++;
-	
+
 	for (CurChp = 0x00; CurChp < ChpExtra->ChipCnt; CurChp ++)
 	{
 		TempCD = &ChpExtra->CCData[CurChp];
@@ -435,7 +435,7 @@ static void ReadChipExtraData32(UINT32 StartOffset, VGMX_CHP_EXTRA32* ChpExtra)
 		memcpy(&TempCD->Data, &VGMData[CurPos + 0x01], 0x04);
 		CurPos += 0x05;
 	}
-	
+
 	return;
 }
 
@@ -444,14 +444,14 @@ static void ReadChipExtraData16(UINT32 StartOffset, VGMX_CHP_EXTRA16* ChpExtra)
 	UINT32 CurPos;
 	UINT8 CurChp;
 	VGMX_CHIP_DATA16* TempCD;
-	
+
 	if (! StartOffset)
 	{
 		ChpExtra->ChipCnt = 0x00;
 		ChpExtra->CCData = NULL;
 		return;
 	}
-	
+
 	CurPos = StartOffset;
 	ChpExtra->ChipCnt = VGMData[CurPos];
 	if (ChpExtra->ChipCnt)
@@ -460,7 +460,7 @@ static void ReadChipExtraData16(UINT32 StartOffset, VGMX_CHP_EXTRA16* ChpExtra)
 	else
 		ChpExtra->CCData = NULL;
 	CurPos ++;
-	
+
 	for (CurChp = 0x00; CurChp < ChpExtra->ChipCnt; CurChp ++)
 	{
 		TempCD = &ChpExtra->CCData[CurChp];
@@ -469,7 +469,7 @@ static void ReadChipExtraData16(UINT32 StartOffset, VGMX_CHP_EXTRA16* ChpExtra)
 		memcpy(&TempCD->Data, &VGMData[CurPos + 0x02], 0x02);
 		CurPos += 0x04;
 	}
-	
+
 	return;
 }
 
@@ -482,14 +482,14 @@ static bool WriteVGMFile(const char* FileName, bool Compress)
 #ifdef WIN32
 	HANDLE hFileWin;
 #endif
-	
+
 	if (! Compress)
 		hFile.f = fopen(FileName, "wb");
 	else
 		hFile.gz = gzopen(FileName, "wb9");
 	if (hFile.f == NULL)
 		return false;
-	
+
 	// Write VGM Data (including GD3 Tag)
 	if (! Compress)
 	{
@@ -501,12 +501,12 @@ static bool WriteVGMFile(const char* FileName, bool Compress)
 		gzseek(hFile.gz, 0x00, SEEK_SET);
 		gzwrite(hFile.gz, VGMData, VGMDataLen);
 	}
-	
+
 	if (! Compress)
 		fclose(hFile.f);
 	else
 		gzclose(hFile.gz);
-	
+
 	if (KeepDate)
 	{
 #ifdef WIN32
@@ -519,9 +519,9 @@ static bool WriteVGMFile(const char* FileName, bool Compress)
 		}
 #endif
 	}
-	
+
 	printf("File written.\n");
-	
+
 	return true;
 }
 
@@ -535,12 +535,12 @@ static UINT8 PreparseCommands(int ArgCount, char* ArgList[])
 	//UINT8 TempByt;
 	//UINT16 TempSht;
 	//UINT32 TempLng;
-	
+
 	memset(&StripVGM, 0x00, sizeof(STRIP_DATA) * 2);
 	for (CurArg = 0; CurArg < ArgCount; CurArg ++)
 	{
 		CmdStr = ArgList[CurArg] + 1;	// Skip the '-' at the beginning
-		
+
 		CmdData = strchr(CmdStr, ':');
 		if (CmdData != NULL)
 		{
@@ -549,7 +549,7 @@ static UINT8 PreparseCommands(int ArgCount, char* ArgList[])
 			*CmdData = 0x00;
 			CmdData ++;
 		}
-		
+
 		/*if (CmdData != NULL)
 			printf("%s: %s\n", CmdStr, CmdData);
 		else
@@ -570,7 +570,7 @@ static UINT8 PreparseCommands(int ArgCount, char* ArgList[])
 			*CmdData = ChrBak;
 		}
 	}
-	
+
 	return 0x00;
 }
 
@@ -593,10 +593,10 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 	UINT8 ChnNum;
 	UINT8 ChipMask;
 	UINT8 CurCSet;
-	
+
 	if (StripCmd == NULL)
 		return 0x00;	// Passing no argument is valid
-	
+
 	// Format: "ChipA:Chn1,Chn2,Chn3;ChipB-#;ChipC"
 	StripTmp = strdup(StripCmd);
 	ChipPos = StripTmp;
@@ -620,7 +620,7 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 		{
 			StripMode = 0x01;	// Last Entry - Strip Channels
 		}
-		
+
 		switch(StripMode)
 		{
 		case 0x00:	// 00 - Strip All
@@ -636,10 +636,10 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			*NxtChip = '\0';
 			NxtChip ++;
 		}
-		
+
 		// Detect the chip IDs to strip
 		ChipMask = 0x03;
-		
+
 		CpNumPos = strchr(ChipPos, '-');
 		if (CpNumPos != NULL)
 		{
@@ -649,7 +649,7 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			if (CurChip < 2)
 				ChipMask = 1 << CurChip;
 		}
-		
+
 		// I can compare ChipPos, because I zeroed the split-char
 		if (! stricmp(ChipPos, "PSG") || ! stricmp(ChipPos, "SN76496"))
 		{
@@ -840,7 +840,7 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			printf("Strip Error - Unknown Chip: %s\n", ChipPos);
 			return 0x80;
 		}
-		
+
 		for (CurCSet = 0; CurCSet < 2; CurCSet ++)
 		{
 			if (! (ChipMask & (1 << CurCSet)))
@@ -848,7 +848,7 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 				TempChip = (STRIP_GENERIC*)( (STRIP_DATA*)TempChip + 1 );
 				continue;	// bit not set - skip
 			}
-			
+
 			switch(StripMode)
 			{
 			case 0x00:	// 00 - Strip All
@@ -868,7 +868,7 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 						*ChnPos = '\0';
 						ChnPos ++;
 					}
-					
+
 					ChnNum = (UINT8)strtoul(ChipPos, &StopPos, 0);
 					if (StopPos != ChipPos)
 					{
@@ -901,20 +901,20 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 							printf("Unknown channel: %s\n", ChipPos);
 						}
 					}
-					
+
 					ChipPos = ChnPos;
 				}
 				break;
 			}
-			
+
 			// advance by one STRIP_DATA
 			TempChip = (STRIP_GENERIC*)( (STRIP_DATA*)TempChip + 1 );
 		}
-		
+
 		ChipPos = NxtChip;
 	}
 	free(StripTmp);
-	
+
 	return 0x00;
 }
 
@@ -937,7 +937,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 	UINT32 NewVal;
 	UINT32* ChipHzPnt;
 	bool LightChange;
-	
+
 	// Execute Commands
 	ResVal = 0x00;	// nothing done - skip writing
 	//if (! ArgCount)
@@ -945,7 +945,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 	for (CurArg = 0; CurArg < ArgCount; CurArg ++)
 	{
 		CmdStr = ArgList[CurArg] + 1;	// Skip the '-' at the beginning
-		
+
 		CmdData = strchr(CmdStr, ':');
 		if (CmdData != NULL)
 		{
@@ -954,7 +954,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 			*CmdData = 0x00;
 			CmdData ++;
 		}
-		
+
 		RetVal = 0x00;
 		LightChange = false;
 		if (CmdData != NULL)
@@ -965,9 +965,9 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			OldVal = VGMHead.lngVersion;
-			
+
 			TempPnt  = strchr(CmdData, '.');
 			TempLng = strtoul(CmdData, NULL, 0x10);	// Version Major
 			if (TempPnt)
@@ -983,7 +983,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				TempByt = 0x00;
 			}
 			NewVal = (TempLng << 8) | (TempByt << 0);
-			
+
 			if (OldVal != NewVal)
 			{
 				if (! stricmp(CmdStr, "UpdateVer"))
@@ -1055,7 +1055,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 							VGMHead.lngRate = 0;
 						}
 					}
-					
+
 					VGMHead.lngVersion = NewVal;
 					RetVal |= 0x10;
 				}
@@ -1072,7 +1072,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 						printf("The VGM has a data offset set, but you're changing the Version to < 1.50.\n");
 						printf("This will create bad VGMs. Please use -UpdateVer instead!\n");
 					}
-					
+
 					if (RetVal & 0x10)
 						VGMHead.lngVersion = NewVal;
 				}
@@ -1104,13 +1104,13 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				}
 #endif
 				NewVal = (NewVal + 0x3F) >> 6 << 6;	// round up to 0x40 bytes;
-				
+
 				//OldVal = 0x34 + VGMHead.lngDataOffset;
 				OldVal = RealHdrSize;
 				if (NewVal < OldVal)
 				{
 					ResizeVGMHeader(NewVal);
-					
+
 					printf("Header Size Old: 0x%02X bytes, New: 0x%02X bytes\n", OldVal, NewVal);
 					RetVal |= 0x10;
 				}
@@ -1129,7 +1129,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				if (NewVal < OldVal)
 				{
 					VGMHead.lngVersion = NewVal;
-					
+
 					printf("VGM Version Old: %u.%02X, New: %u.%02X\n",
 							OldVal >> 8, OldVal & 0xFF, NewVal >> 8, NewVal & 0xFF);
 					RetVal |= 0x10;
@@ -1171,7 +1171,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			NewVal = strtoul(CmdData, NULL, 0);
 			if (NewVal != VGMHead.lngRate)
 			{
@@ -1183,7 +1183,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			CmdStr += 5;
 			ChipHzPnt = NULL;
 			if (! stricmp(CmdStr, "PSG"))
@@ -1351,7 +1351,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				printf("Error - Unknown Chip: %s\n", CmdStr);
 				return 0x80;
 			}
-			
+
 			if (VGMHead.lngVersion >= OldVal)
 			{
 				NewVal = strtoul(CmdData, NULL, 0);
@@ -1374,7 +1374,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			CmdStr += 7;
 			if (! stricmp(CmdStr, "FdB"))
 			{
@@ -1436,7 +1436,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x151)
 			{
 				NewVal = strtoul(CmdData, NULL, 0);
@@ -1455,7 +1455,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x151)
 			{
 				TempByt = (UINT8)strtoul(CmdData, NULL, 0);
@@ -1474,7 +1474,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x151)
 			{
 				TempByt = (UINT8)strtoul(CmdData, NULL, 0);
@@ -1493,7 +1493,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x150)
 			{
 				TempByt = GetLoopModVal(CmdData);
@@ -1523,7 +1523,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x150)
 			{
 				TempSLng = strtol(CmdData, NULL, 0);
@@ -1553,7 +1553,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x150)
 			{
 				TempByt = GetVolModVal(CmdData);
@@ -1583,7 +1583,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x161)
 			{
 				TempByt = (UINT8)strtoul(CmdData, NULL, 0);
@@ -1602,7 +1602,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x161)
 			{
 				TempByt = (UINT8)strtoul(CmdData, NULL, 0);
@@ -1621,7 +1621,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		{
 			if (CmdData == NULL)
 				goto IncompleteArg;
-			
+
 			if (VGMHead.lngVersion >= 0x161)
 			{
 				TempByt = (UINT8)strtoul(CmdData, NULL, 0);
@@ -1669,7 +1669,7 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				printf("Error - Unknown Command: -%s\n", CmdStr - 5);
 				return 0x80;
 			}
-			
+
 			TempByt = CheckVGMFile(TempByt);
 			if (TempByt == 0xFF)
 			{
@@ -1703,14 +1703,14 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				KeepDate = false;
 		}
 		ResVal |= RetVal;
-		
+
 		if (CmdData != NULL)
 		{
 			CmdData --;
 			*CmdData = ChrBak;
 		}
 	}
-	
+
 	if (ResVal & 0x10)
 	{
 		// Write VGM Header
@@ -1721,13 +1721,13 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 		memcpy(&VGMData[0x00], &VGMHead, TempLng);*/
 		memcpy(&VGMData[0x00], &VGMHead, RealCpySize);
 	}
-	
+
 	return ResVal;
 
 IncompleteArg:
 
 	printf("Error! Argument incomplete!\n");
-	
+
 	return 0x80;
 }
 
@@ -1735,7 +1735,7 @@ static UINT8 GetLoopModVal(char* CmdData)
 {
 	double LoopDbl;
 	INT32 LoopLng;
-	
+
 	switch(CmdData[0x00])
 	{
 	case '*':
@@ -1759,13 +1759,13 @@ static UINT8 GetLoopModVal(char* CmdData)
 		LoopLng = strtol(CmdData, NULL, 0);
 		break;
 	}
-	
+
 	// Note 0x00 is valid, but equal to 0x10, so minimum is 0x01
 	if (LoopLng < 0x00)
 		LoopLng = 0x01;
 	else if (LoopLng > 0xFF)
 		LoopLng = 0xFF;
-	
+
 	return (UINT8)LoopLng;
 }
 
@@ -1774,7 +1774,7 @@ static UINT8 GetVolModVal(char* CmdData)
 	char* EndStr;
 	double VolDbl;
 	INT32 VolLng;
-	
+
 	VolLng = strtol(CmdData, &EndStr, 0);
 	if (*EndStr == '.')
 	{
@@ -1786,7 +1786,7 @@ static UINT8 GetVolModVal(char* CmdData)
 			VolDbl = 64.0;
 		VolLng = (INT32)floor(log(VolDbl) / log(2.0) * 0x20 + 0.5);
 	}
-	
+
 	if (VolLng < 0x00)
 	{
 		if (VolLng < -0x3F)
@@ -1797,7 +1797,7 @@ static UINT8 GetVolModVal(char* CmdData)
 	{
 		VolLng = 0x00;
 	}
-	
+
 	return (UINT8)VolLng;
 }
 
@@ -1805,20 +1805,20 @@ static bool ResizeVGMHeader(UINT32 NewSize)
 {
 	UINT32 OldSize;
 	INT32 PosMove;
-	
+
 	// for now I want the complete header (incl. extentions)
 	/*if (! VGMHead.lngDataOffset)
 		OldSize = 0x40;
 	else
 		OldSize = 0x34 + VGMHead.lngDataOffset;*/
 	OldSize = RealHdrSize;
-	
+
 	if (OldSize == NewSize)
 		return false;
-	
+
 	if (NewSize < 0xC0 && OldSize >= 0xC0)
 		OldSize = 0x34 + VGMHead.lngDataOffset;
-	
+
 	PosMove = NewSize - OldSize;
 	VGMHead.lngEOFOffset += PosMove;
 	if (VGMHead.lngGD3Offset)
@@ -1829,22 +1829,22 @@ static bool ResizeVGMHeader(UINT32 NewSize)
 		VGMHead.lngExtraOffset += PosMove;
 	VGMHead.lngDataOffset += PosMove;	// can't use (NewSize - 0x34), if I have extra headers
 	RealHdrSize = NewSize;
-	
+
 	if (PosMove > 0)
 	{
 		VGMData = (UINT8*)realloc(VGMData, VGMDataLen + PosMove);
 		memmove(&VGMData[NewSize], &VGMData[OldSize], VGMDataLen - OldSize);
-		memset(&VGMData[OldSize], 0x00, PosMove); 
+		memset(&VGMData[OldSize], 0x00, PosMove);
 	}
 	else
 	{
 		memmove(&VGMData[NewSize], &VGMData[OldSize], VGMDataLen - OldSize);
 	}
 	VGMDataLen += PosMove;
-	
+
 	OldSize = sizeof(VGM_HEADER);
 	RealCpySize = (RealHdrSize <= OldSize) ? RealHdrSize : OldSize;
-	
+
 	return true;
 }
 
@@ -1859,7 +1859,7 @@ static UINT32 CheckForMinVersion(void)
 	bool StopVGM;
 	UINT32 MinVer;
 	UINT32* ChipHzPnt;
-	
+
 	TempLng = sizeof(VGM_HEADER);
 	ChipHzPnt = (UINT32*)((UINT8*)&VGMHead + TempLng);
 	while(ChipHzPnt > &VGMHead.lngDataOffset)
@@ -1881,7 +1881,7 @@ static UINT32 CheckForMinVersion(void)
 		MinVer = 0x171;
 	if (VGMHead.lngVersion > 0x171)
 		return VGMHead.lngVersion;
-	
+
 	if (MinVer == 0x150)
 	{
 		// check for dual chip usage of <1.51 chips
@@ -1891,7 +1891,7 @@ static UINT32 CheckForMinVersion(void)
 			(VGMHead.lngHzYM2151 & 0xC0000000))
 			MinVer = 0x151;
 	}
-	
+
 	StopVGM = false;
 	if (VGMHead.lngVersion < 0x150)
 		CurPos = 0x40;
@@ -2007,11 +2007,11 @@ static UINT32 CheckForMinVersion(void)
 			}
 		}
 		CurPos += CmdLen;
-		
+
 		if (StopVGM)
 			break;
 	}
-	
+
 	return MinVer;
 }
 
@@ -2042,7 +2042,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 	UINT32 NewDataPos;
 	bool GD3Fix;
 	bool CmdWarning[0x100];
-	
+
 	HasLoop = VGMHead.lngLoopOffset ? true : false;
 	if (! HasLoop && VGMHead.lngLoopSamples)
 	{
@@ -2058,7 +2058,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		LoopPos = 0x00;
 	CountLen = 0x00;
 	CountLoop = 0x00;
-	
+
 	VGMErr = 0x00;
 	InLoop = false;
 	if (VGMHead.lngVersion < 0x150)
@@ -2076,7 +2076,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		{
 			VGMErr |= 0x04;
 			printf("Bad Data Offset!");
-			
+
 			StopVGM = false;
 			while(CurPos < VGMDataLen)
 			{
@@ -2111,7 +2111,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 						memcpy(&TempLng, &VGMData[CurPos + 0x03], 0x04);
 						TempLng &= 0x7FFFFFFF;
 						CmdLen = 0x07 + TempLng;
-						
+
 						if (TempByt == 0x66 && CurPos + CmdLen <= VGMDataLen)
 							StopVGM = true;
 						else
@@ -2166,17 +2166,17 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 				}
 				if (StopVGM)
 					break;
-				
+
 				CurPos += CmdLen;
 			}
 			NewDataPos = CurPos;
 			printf("  New Offset is: 0x%X\n", NewDataPos);
 		}
-		
+
 		if (VGMHead.lngDataOffset)
 			CurPos = 0x34 + VGMHead.lngDataOffset;
 	}
-	
+
 	memset(CmdWarning, 0x00, 0x100);
 	StopVGM = false;
 	BadCmdFound = false;
@@ -2187,7 +2187,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 			if (CurPos == LoopPos)
 				InLoop = true;
 		}
-		
+
 		CmdLen = 0x00;
 		CmdDelay = 0x00;
 		Command = VGMData[CurPos + 0x00];
@@ -2334,12 +2334,12 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		CountLen += CmdDelay;
 		if (InLoop)
 			CountLoop += CmdDelay;
-		
+
 		if (StopVGM)
 			break;
 	}
 	VGMEoDPos = CurPos;
-	
+
 	// VGMErr Bits:
 	//	Bit	Val	Error Description
 	//	 0	 01	Total Samples
@@ -2354,8 +2354,8 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 	//	4-7	 F0	In Header
 	//	 0	 11	GD3 found
 	//	 1	 02	GD3 Offset wrong
-	//	 3	 04	
-	//	 4	 08	
+	//	 3	 04
+	//	 4	 08
 	//VGMErr = 0x00;
 	GD3Flags = 0x00;
 	GD3Fix = false;
@@ -2363,14 +2363,14 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		VGMErr |= 0x01;
 	if (CountLoop != VGMHead.lngLoopSamples)
 		VGMErr |= 0x02;
-	
+
 	if (CurPos > 0x04 + VGMHead.lngEOFOffset)
 		printf("Warning! EOF Offset before EOF command!\n");
 	if (! StopVGM)
 		printf("Warning! File end before EOF command!\n");
 	if (HasLoop && ! InLoop)
 		printf("Warning! Loop offset between commands!\n");
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		// Check for GD3 Tag at GD3 Offset
@@ -2430,11 +2430,11 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 			VGMErr |= 0x10;
 			GD3Flags |= 0x02;	// GD3 Offset - wrong
 		}
-		
+
 		memcpy(&GD3Ver, &VGMData[CurPos + 0x04], 0x04);
 		if (GD3Ver > 0x100)
 			printf("GD3 Tag version newer than supported - correction may be skipped!\n");
-		
+
 		memcpy(&CmdLen, &VGMData[CurPos + 0x08], 0x04);
 		TempLng = CalcGD3Length(CurPos + 0x0C, GD3T_ENT_V100);
 		if (TempLng != CmdLen)
@@ -2453,7 +2453,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 				// unknown GD3 version - don't fix length
 			}
 		}
-		
+
 		//TempLng += 0x0C;	// calculate EOF based on calculated GD3 length
 		TempLng = 0x0C + CmdLen;	// calculate EOF based on current GD3 length
 		if (CurPos + TempLng != 0x04 + VGMHead.lngEOFOffset)	// Check EOF Offset
@@ -2472,7 +2472,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 			VGMErr |= 0x20;
 		}
 	}
-	
+
 	if (VGMHead.lngVersion >= 0x0150)
 	{
 		VGMVer = CheckForMinVersion();
@@ -2483,7 +2483,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 			VGMErr |= 0x80;
 		}
 	}
-	
+
 	printf("\t%9s  %9s\n", "Header", "Counted");
 	printf("Length\t%9u  %9u", VGMHead.lngTotalSamples, CountLen);
 	if (VGMHead.lngTotalSamples != CountLen)
@@ -2493,10 +2493,10 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 	if (VGMHead.lngLoopSamples != CountLoop)
 		printf(" !");
 	printf("\n");
-	
+
 	if (! VGMErr && ! BadCmdFound)
 		return 0x00;	// No errors - It's all okay
-	
+
 	if (BadCmdFound)
 	{
 		Mode |= 0x10;
@@ -2509,7 +2509,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		if (! VGMErr)
 			Mode &= ~0x03;	// If there are no fixable errors, we don't need to ask.
 	}
-	
+
 	printf("There are some errors. ");
 	if ((Mode & 0x13) == 0x00)
 	{
@@ -2546,10 +2546,10 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 	{
 		printf("\n");
 	}
-	
+
 	if (! (Mode & 0x03))
 		return 0x00;
-	
+
 	RetVal = 0x00;
 	if (VGMErr & 0x01)
 	{
@@ -2591,7 +2591,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		VGMHead.lngDataOffset = NewDataPos - 0x34;
 		RetVal |= 0x01;
 	}
-	
+
 	//	 4	 10	GD3 Tag Offset
 	//	 5	 20	GD3 Tag Length / EOF Offset
 	if (VGMErr & 0x10)
@@ -2608,7 +2608,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 		case 0x11:	// GD3 found, offset is good
 			break;
 		}
-		
+
 		if (GD3Flags & 0x02)	// GD3 Offset wrong
 		{
 			VGMHead.lngGD3Offset = VGMGD3Pos - 0x14;
@@ -2632,7 +2632,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 				memcpy(&VGMData[CurPos + 0x08], &TempLng, 0x04);	// rewrite GD3 length
 				GD3Fix = true;
 			}
-			
+
 			TempLng += 0x0C;
 			VGMEoDPos = CurPos + TempLng;
 		}
@@ -2647,7 +2647,7 @@ static UINT8 CheckVGMFile(UINT8 Mode)
 	}
 	if ((VGMErr & ~0x20) || ! GD3Fix)
 		KeepDate = false;
-	
+
 	return RetVal;
 }
 
@@ -2663,7 +2663,7 @@ static bool ChipCommandIsValid(UINT8 Command)
 {
 	if (ChipCommandIsUnknown(Command))
 		return false;
-	
+
 	if (Command >= 0x61 && Command <= 0x63)
 		return true;
 	if ((Command & 0xF0) == 0x70)
@@ -2750,7 +2750,7 @@ static bool ChipCommandIsValid(UINT8 Command)
 		return true;
 	if (Command == 0xC4 && VGMHead.lngHzQSound)
 		return true;
-	
+
 	return false;
 }
 
@@ -2766,10 +2766,10 @@ static UINT32 RelocateVGMLoop(void)
 	UINT32 VGMSmplPos;
 	UINT32 VGMLoop;
 	UINT16 CmdDelay;
-	
+
 	VGMLoop = VGMHead.lngTotalSamples - VGMHead.lngLoopSamples;
 	VGMSmplPos = 0x00;
-	
+
 	StopVGM = false;
 	if (VGMHead.lngVersion < 0x150)
 		CurPos = 0x40;
@@ -2875,11 +2875,11 @@ static UINT32 RelocateVGMLoop(void)
 		VGMSmplPos += CmdDelay;
 		if (VGMSmplPos == VGMLoop)
 			return CurPos;
-		
+
 		if (StopVGM)
 			break;
 	}
-	
+
 	return 0x00;
 }
 
@@ -2888,7 +2888,7 @@ static UINT32 CalcGD3Length(UINT32 DataPos, UINT16 TagEntries)
 	UINT32 CurPos;
 	UINT16* CurChr;
 	UINT16 CurEnt;
-	
+
 	CurPos = DataPos;
 	for (CurEnt = 0x00; CurEnt < TagEntries; CurEnt ++)
 	{
@@ -2898,7 +2898,7 @@ static UINT32 CalcGD3Length(UINT32 DataPos, UINT16 TagEntries)
 			CurPos += 0x02;
 		} while(*CurChr);
 	}
-	
+
 	return CurPos - DataPos;
 }
 
@@ -2927,7 +2927,7 @@ static void StripVGMData(void)
 	UINT32 NewLoopS;
 	bool WroteCmd80;
 	UINT8* VGMPnt;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	AllDelay = 0;
 	if (VGMHead.lngDataOffset)
@@ -2960,7 +2960,7 @@ static void StripVGMData(void)
 			c140_write(0xFF, 0x00, VGMHead.bytC140Type);
 		}
 	}
-	
+
 	StopVGM = false;
 	WroteCmd80 = false;
 	while(VGMPos < VGMDataLen)
@@ -2969,7 +2969,7 @@ static void StripVGMData(void)
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		WriteEvent = true;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -2993,7 +2993,7 @@ static void StripVGMData(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			ChipID = 0x00;
 			switch(Command)
@@ -3094,7 +3094,7 @@ static void StripVGMData(void)
 				}
 				break;
 			}
-			
+
 			SetChipSet(ChipID);
 			switch(Command)
 			{
@@ -3137,11 +3137,11 @@ static void StripVGMData(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
 				//SetChipSet(ChipID);
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -3319,7 +3319,7 @@ static void StripVGMData(void)
 				if (StripVGM[ChipID].YMF278B_All ||
 					(StripVGM[ChipID].YMF278B_FM.All && StripVGM[ChipID].YMF278B_WT.All))
 					WriteEvent = false;
-				
+
 				if (StripVGM[ChipID].YMF278B_FM.All && VGMPnt[0x01] < 0x02 &&
 					! (VGMPnt[0x01] == 0x01 && VGMPnt[0x02] == 0x05))
 					WriteEvent = false;	// Don't kill the WaveTable-On Command at Reg 0x105
@@ -3524,7 +3524,7 @@ static void StripVGMData(void)
 				break;
 			}
 		}
-		
+
 		if (WriteEvent || VGMPos == LoopOfs)
 		{
 			if (VGMPos != LoopOfs)
@@ -3538,7 +3538,7 @@ static void StripVGMData(void)
 					TempSht = (UINT16)AllDelay;
 				else
 					TempSht = 0xFFFF;
-				
+
 				if (WroteCmd80)
 				{
 					// highest delay compression - Example:
@@ -3557,7 +3557,7 @@ static void StripVGMData(void)
 						TempSht -= 1764;
 					else if (TempSht >= 1617 && TempSht <= 1632)	// 62 63
 						TempSht -= 1617;
-					
+
 				//	if (TempSht >= 0x10 && TempSht <= 0x1F)
 				//		TempSht = 0x0F;
 				//	else if (TempSht >= 0x20)
@@ -3622,10 +3622,10 @@ static void StripVGMData(void)
 			}
 			AllDelay = CmdDelay;
 			CmdDelay = 0x00;
-			
+
 			if (VGMPos == LoopOfs)
 				NewLoopS = DstPos;
-			
+
 			if (WriteEvent)
 			{
 				// Write Event
@@ -3660,7 +3660,7 @@ static void StripVGMData(void)
 		VGMHead.lngLoopOffset = NewLoopS - 0x1C;
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		VGMPos = 0x14 + VGMHead.lngGD3Offset;
@@ -3669,7 +3669,7 @@ static void StripVGMData(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			VGMHead.lngGD3Offset = DstPos - 0x14;
 			memcpy(&DstData[DstPos], &VGMData[VGMPos], CmdLen);
 			DstPos += CmdLen;
@@ -3677,7 +3677,7 @@ static void StripVGMData(void)
 	}
 	VGMDataLen = DstPos;
 	VGMHead.lngEOFOffset = VGMDataLen - 0x04;
-	
+
 	if (StripClock(&StripVGM[0].SN76496.All, &VGMHead.lngHzPSG))
 	{
 		VGMHead.shtPSG_Feedback = 0x00;
@@ -3725,28 +3725,28 @@ static void StripVGMData(void)
 	StripClock(&StripVGM[0].Pokey.All, &VGMHead.lngHzPokey);
 	StripClock(&StripVGM[0].QSound.All, &VGMHead.lngHzQSound);
 	//StripClock(&StripVGM[0].SCSP.All, &VGMHead.lngHzSCSP);
-	
+
 	// PatchVGM will rewrite the header later
-	
+
 	VGMData = (UINT8*)realloc(VGMData, VGMDataLen);
 	memcpy(VGMData, DstData, VGMDataLen);
 	free(DstData);
-	
+
 	FreeAllChips();
-	
+
 	return;
 }
 
 static bool StripClock(bool* StripAllPtr, UINT32* ClockPtr)
 {
 	bool* StpAll1 = (bool*)((STRIP_DATA*)StripAllPtr + 1);	// StripVGM[1].###.All
-	
+
 	if (*StpAll1)
 		*ClockPtr &= ~0x40000000;	// strip Chip 1 clock
-	
+
 	if (*ClockPtr & 0x40000000)
 		return false;	// Chip 1 still in use - don't stip chip 0 clock
-	
+
 	// if Chip 0 to be stripped and Chip 1 is not used
 	if (*StripAllPtr)
 	{

--- a/vgm_smp1.c
+++ b/vgm_smp1.c
@@ -39,9 +39,9 @@ int main(int argc, char* argv[])
 	int argbase;
 	int ErrVal;
 	char FileName[0x100];
-	
+
 	printf("Remove 1 Sample Delays\n----------------------\n\n");
-	
+
 	ErrVal = 0;
 	MAX_SMALL_DELAY = 0x0000;
 	argbase = 1;
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 	}
 	if (! MAX_SMALL_DELAY)
 		MAX_SMALL_DELAY = 1;
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -80,9 +80,9 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	RoundVGMData();
-	
+
 	if (DidSomething)
 	{
 		if (argc > argbase + 1)
@@ -96,13 +96,13 @@ int main(int argc, char* argv[])
 		}
 		WriteVGMFile(FileName);
 	}
-	
+
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -112,20 +112,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -146,7 +146,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -156,7 +156,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -164,14 +164,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -184,25 +184,25 @@ static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
 	const char* FileTitle;
-	
+
 	printf("\t\t\t\t\t\t\t\t\r");
 	FileTitle = strrchr(FileName, '\\');
 	if (FileTitle == NULL)
 		FileTitle = FileName;
 	else
 		FileTitle ++;
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
 		printf("Error writing %s!\n", FileTitle);
 		return;
 	}
-	
+
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
 	printf("%s written.\n", FileTitle);
-	
+
 	return;
 }
 
@@ -227,11 +227,11 @@ static void RoundVGMData(void)
 	bool WriteEvent;
 	UINT32 LoopPos;
 	UINT32 DelayQueue;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen);
 	VGMPos = VGMHead.lngDataOffset;
 	DstPos = VGMHead.lngDataOffset;
-	
+
 	DidSomething = false;
 #ifdef WIN32
 	CmdTimer = 0;
@@ -247,7 +247,7 @@ static void RoundVGMData(void)
 		Command = VGMData[VGMPos + 0x00];
 		WasDelay = IsDelay;
 		IsDelay = false;
-		
+
 		CmdDelay = 0x00;
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
@@ -347,7 +347,7 @@ static void RoundVGMData(void)
 				}
 				break;
 			}
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -487,7 +487,7 @@ static void RoundVGMData(void)
 			}
 		}
 		WriteEvent = ! IsDelay;
-		
+
 		if (VGMHead.lngLoopOffset && VGMPos == VGMHead.lngLoopOffset)
 		{
 			LoopPos = DstPos;
@@ -518,7 +518,7 @@ static void RoundVGMData(void)
 						TempSht = (UINT16)CmdDelay;
 					else
 						TempSht = 0xFFFF;
-					
+
 					if (TempSht <= 0x10)
 					{
 						DstData[DstPos] = 0x70 | (TempSht - 0x01);
@@ -543,7 +543,7 @@ static void RoundVGMData(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -558,12 +558,12 @@ static void RoundVGMData(void)
 #endif
 	}
 	VGMHead.lngTotalSamples = VGMSmplPos - DelayQueue;
-	
+
 	if (VGMHead.lngLoopOffset && ! LoopPos)
 		printf("Warning! Failed to relocate Loop Point!\n");
-	
+
 	WriteVGMHeader(DstData, VGMData, DstPos, LoopPos);
-	
+
 	return;
 }
 
@@ -574,15 +574,15 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 	UINT32 DstPos;
 	UINT32 CmdLen;
 	UINT32 TempLng;
-	
+
 	memcpy(DstData, VGMData, VGMHead.lngDataOffset);	// Copy Header
-	
+
 	memcpy(&DstData[0x18], &VGMHead.lngTotalSamples, 0x04);
 	TempLng = LoopPos;
 	if (TempLng)
 		TempLng -= 0x1C;
 	memcpy(&DstData[0x1C], &TempLng, 0x04);
-	
+
 	DstPos = EOFPos;
 	if (VGMHead.lngGD3Offset && VGMHead.lngGD3Offset + 0x0B < VGMHead.lngEOFOffset)
 	{
@@ -592,17 +592,17 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 		{
 			memcpy(&CmdLen, &VGMData[CurPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			TempLng = DstPos - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
 			memcpy(&DstData[DstPos], &VGMData[CurPos], CmdLen);	// Copy GD3 Tag
 			DstPos += CmdLen;
 		}
 	}
-	
+
 	DstDataLen = DstPos;
 	TempLng = DstDataLen - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);	// Write EOF Position
-	
+
 	return;
 }

--- a/vgm_sptd.c
+++ b/vgm_sptd.c
@@ -43,9 +43,9 @@ int main(int argc, char* argv[])
 	char FileName[0x100];
 	char SplitTxt[0x100];
 	UINT32 SplitDelay;
-	
+
 	printf("VGM Splitter (Delay Edition)\n------------\n\n");
-	
+
 	ErrVal = 0;
 	DIGIT_COUNT = 2;
 	HEXION_SPLIT = 0x00;
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
 	}
 	if (! DIGIT_COUNT)
 		DIGIT_COUNT = 1;
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	printf("Split Delay (in Samples):\t");
 	if (argc <= argbase + 1)
 	{
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
 	SplitDelay = strtoul(SplitTxt, NULL, 0);
 	if (! SplitDelay)
 		SplitDelay = 0x8000;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -104,16 +104,16 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	SetTrimOptions(0x00, 0x00);
 	SplitVGMData(SplitDelay);
-	
+
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -123,20 +123,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -157,7 +157,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -167,7 +167,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -175,14 +175,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -195,7 +195,7 @@ static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
 	const char* FileTitle;
-	
+
 	//printf("                                                                \r");
 	printf("\t\t\t\t\t\t\t\t\r");
 	FileTitle = strrchr(FileName, '\\');
@@ -203,18 +203,18 @@ static void WriteVGMFile(const char* FileName)
 		FileTitle = FileName;
 	else
 		FileTitle ++;
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
 		printf("Error writing %s!\n", FileTitle);
 		return;
 	}
-	
+
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
 	printf("%s written.\n", FileTitle);
-	
+
 	return;
 }
 
@@ -241,12 +241,12 @@ static void SplitVGMData(const UINT32 SplitDelay)
 	bool IgnoreCmd;
 	UINT32 LastCmdDly;
 	UINT32 AddMask;
-	
+
 	// +0x100 - Make sure to have enough room for additional delays
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	CmdDelay = 0;
 	VGMPos = VGMHead.lngDataOffset;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -263,7 +263,7 @@ static void SplitVGMData(const UINT32 SplitDelay)
 		Command = VGMData[VGMPos + 0x00];
 		IsDelay = false;
 		IgnoreCmd = false;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -362,7 +362,7 @@ static void SplitVGMData(const UINT32 SplitDelay)
 				}
 				break;
 			}
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -611,7 +611,7 @@ static void SplitVGMData(const UINT32 SplitDelay)
 			}
 		}
 		VGMPos += CmdLen;
-		
+
 		if ((INT32)CmdDelay >= 200)
 			LastCmdDly = VGMSmplPos;
 		if (! IsDelay)
@@ -649,7 +649,7 @@ static void SplitVGMData(const UINT32 SplitDelay)
 				if (TempLng > VGMSmplStart)	// prevent 0-sample files
 				{
 					TrimVGMData(VGMSmplStart, 0x00, TempLng, false, true);
-					
+
 					SplitFile ++;
 					sprintf(TempStr, "%s_%02u.vgm", FileBase, SplitFile);
 					WriteVGMFile(TempStr);
@@ -657,7 +657,7 @@ static void SplitVGMData(const UINT32 SplitDelay)
 #ifdef WIN32
 				CmdTimer = 0;
 #endif
-				
+
 				VGMSmplStart = LastCmdDly;
 				CmdDelay = 0x00;
 				EmptyFile = true;
@@ -666,7 +666,7 @@ static void SplitVGMData(const UINT32 SplitDelay)
 		}
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -682,6 +682,6 @@ static void SplitVGMData(const UINT32 SplitDelay)
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
 	printf("Done.\n");
-	
+
 	return;
 }

--- a/vgm_spts.c
+++ b/vgm_spts.c
@@ -37,9 +37,9 @@ int main(int argc, char* argv[])
 	int argbase;
 	int ErrVal;
 	char FileName[0x100];
-	
+
 	printf("VGM Splitter (Sample Edition)\n------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	printf("File Name:\t");
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -62,16 +62,16 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	SetTrimOptions(0x00, 0x00);
 	SplitVGMData(argc, argv);
-	
+
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -81,20 +81,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -115,7 +115,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -125,7 +125,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -133,14 +133,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -153,7 +153,7 @@ static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
 	const char* FileTitle;
-	
+
 	//printf("                                                                \r");
 	printf("\t\t\t\t\t\t\t\t\r");
 	FileTitle = strrchr(FileName, '\\');
@@ -161,18 +161,18 @@ static void WriteVGMFile(const char* FileName)
 		FileTitle = FileName;
 	else
 		FileTitle ++;
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
 		printf("Error writing %s!\n", FileTitle);
 		return;
 	}
-	
+
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
 	printf("%s written.\n", FileTitle);
-	
+
 	return;
 }
 
@@ -198,16 +198,16 @@ static void SplitVGMData(int argc, char* argv[])
 	char SplitTxt[0x100];
 	INT32 SplitSmpl;
 	bool IgnoreCmd;
-	
+
 	// +0x100 - Make sure to have enough room for additional delays
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	CmdDelay = 0;
 	VGMPos = VGMHead.lngDataOffset;
-	
+
 	VGMSmplPos = 0x00;
 	SplitFile = 0x00;
 	StopVGM = false;
-	
+
 	CurArg = 2;
 	while(! StopVGM)
 	{
@@ -232,11 +232,11 @@ static void SplitVGMData(int argc, char* argv[])
 			printf("Invalid Sample Point!\n");
 			continue;
 		}
-		
+
 		TempLng = 0x00;
 		memcpy(&VGMData[0x1C], &TempLng, 0x04);	// Disable Loops
 		memcpy(&VGMData[0x20], &TempLng, 0x04);
-		
+
 #ifdef WIN32
 		CmdTimer = 0;
 #endif
@@ -249,7 +249,7 @@ static void SplitVGMData(int argc, char* argv[])
 			Command = VGMData[VGMPos + 0x00];
 			IsDelay = false;
 			IgnoreCmd = false;
-			
+
 			if (Command >= 0x70 && Command <= 0x8F)
 			{
 				switch(Command & 0xF0)
@@ -348,7 +348,7 @@ static void SplitVGMData(int argc, char* argv[])
 					}
 					break;
 				}
-				
+
 				switch(Command)
 				{
 				case 0x66:	// End Of File
@@ -527,7 +527,7 @@ static void SplitVGMData(int argc, char* argv[])
 				}
 			}
 			VGMPos += CmdLen;
-			
+
 			if (! IsDelay)
 			{
 				if (! IgnoreCmd)
@@ -548,23 +548,23 @@ static void SplitVGMData(int argc, char* argv[])
 				{
 					VGMSmplStart = VGMSmplPos;
 					CmdDelay = 0x00;
-				} 
+				}
 				if (VGMSmplPos >= SplitSmpl || StopVGM)
 				{
 					TempLng = VGMSmplPos - CmdDelay;
 					TrimVGMData(VGMSmplStart, 0x00, TempLng, false, true);
-					
+
 					SplitFile ++;
 					sprintf(TempStr, "%s_%02u.vgm", FileBase, SplitFile);
 					WriteVGMFile(TempStr);
-					
+
 					VGMSmplStart = VGMSmplPos;
 					break;
 				}
 			}
 			if (StopVGM)
 				break;
-			
+
 #ifdef WIN32
 			if (CmdTimer < GetTickCount())
 			{
@@ -581,6 +581,6 @@ static void SplitVGMData(int argc, char* argv[])
 	}
 	//printf("\t\t\t\t\t\t\t\t\r");
 	//printf("Done.\n");
-	
+
 	return;
 }

--- a/vgm_sro.c
+++ b/vgm_sro.c
@@ -91,9 +91,9 @@ int main(int argc, char* argv[])
 	int ErrVal;
 	char FileName[0x100];
 	UINT8 CurROM;
-	
+
 	printf("VGM Sample-ROM Optimizer\n------------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	printf("File Name:\t");
@@ -108,7 +108,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 1;
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -116,14 +116,14 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	DstData = NULL;
 	for (CurROM = 0x00; CurROM < ROM_TYPES; CurROM ++)
 	{
 		ROMRgnLst[CurROM][0x00].Regions = NULL;
 		ROMRgnLst[CurROM][0x01].Regions = NULL;
 	}
-	
+
 	if (! VGMHead.lngHzSPCM && ! VGMHead.lngHzYM2608 && ! VGMHead.lngHzYM2610 &&
 		! VGMHead.lngHzY8950 && ! VGMHead.lngHzYMZ280B && ! VGMHead.lngHzRF5C68 &&
 		! VGMHead.lngHzRF5C164 && ! VGMHead.lngHzYMF271 && ! VGMHead.lngHzOKIM6295 &&
@@ -137,7 +137,7 @@ int main(int argc, char* argv[])
 		ErrVal = 2;
 		goto BreakProgress;
 	}
-	
+
 	CancelFlag = false;
 	FindUsedROMData();
 	if (CancelFlag)
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
 	}
 	EnumerateROMRegions();
 	OptimizeVGMSampleROM();
-	
+
 	if (DstDataLen < VGMDataLen)
 	{
 		if (argc > argbase + 1)
@@ -161,7 +161,7 @@ int main(int argc, char* argv[])
 		}
 		WriteVGMFile(FileName);
 	}
-	
+
 BreakProgress:
 	free(VGMData);
 	free(DstData);
@@ -170,10 +170,10 @@ BreakProgress:
 		free(ROMRgnLst[CurROM][0x00].Regions);	ROMRgnLst[CurROM][0x00].Regions = NULL;
 		free(ROMRgnLst[CurROM][0x01].Regions);	ROMRgnLst[CurROM][0x01].Regions = NULL;
 	}
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -183,20 +183,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000150)
 	{
@@ -217,7 +217,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -227,7 +227,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -235,14 +235,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -254,13 +254,13 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -282,15 +282,15 @@ static void FindUsedROMData(void)
 	UINT32 CmdLen;
 	bool StopVGM;
 	const UINT8* VGMPnt;
-	
+
 	printf("Creating ROM-Usage Mask ...\n");
 	VGMPos = VGMHead.lngDataOffset;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
 	InitAllChips();
-	
+
 	if (VGMHead.lngHzSPCM)
 	{
 		SetChipSet(0x00);
@@ -337,13 +337,13 @@ static void FindUsedROMData(void)
 			es550x_w(0xFF, VGMHead.lngHzES5506 >> 31);
 		}
 	}
-	
+
 	StopVGM = false;
 	while(VGMPos < VGMHead.lngEOFOffset)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -362,7 +362,7 @@ static void FindUsedROMData(void)
 		else
 		{
 			VGMPnt = &VGMData[VGMPos];
-			
+
 			// Cheat Mode (to use 2 instances of 1 chip)
 			ChipID = 0x00;
 			switch(Command)
@@ -399,7 +399,7 @@ static void FindUsedROMData(void)
 				break;
 			}
 			SetChipSet(ChipID);
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -427,11 +427,11 @@ static void FindUsedROMData(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMPnt[0x02];
 				memcpy(&TempLng, &VGMPnt[0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
 				SetChipSet(ChipID);
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -649,11 +649,11 @@ static void FindUsedROMData(void)
 				break;
 			}
 		}
-		
+
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -668,14 +668,14 @@ static void FindUsedROMData(void)
 #endif
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-		
+
 	return;
 }
 
 char* GetROMRegionText(UINT8 ROM_ID)
 {
 	char* RetStr;
-	
+
 	switch(ROM_ID)
 	{
 	case 0x80:	// SegaPCM ROM
@@ -754,7 +754,7 @@ char* GetROMRegionText(UINT8 ROM_ID)
 		RetStr = "???";
 		break;
 	}
-	
+
 	return RetStr;
 }
 
@@ -772,10 +772,10 @@ static void EnumerateROMRegions(void)
 	UINT32 CurPos;
 	UINT32 PosStart;
 	UINT8 MaskVal;
-	
+
 	RgnMemCount = 0x100;
 	RgnMemory = (ROM_REGION*)malloc(RgnMemCount * sizeof(ROM_REGION));
-	
+
 	printf("\nROM Region List\n---------------\n");
 	printf("From\tTo\tLength\tStatus\n");
 	for (CurROM = 0x00; CurROM < ROM_TYPES; CurROM ++)
@@ -783,19 +783,19 @@ static void EnumerateROMRegions(void)
 		for (CurChip = 0x00; CurChip < 0x02; CurChip ++)
 		{
 			TempRRL = &ROMRgnLst[CurROM][CurChip];
-			
+
 			TempRRL->RegionCount = 0x00;
-			
+
 			SetChipSet(CurChip);
 			ROMSize = GetROMMask(ROM_LIST[CurROM], &ROMMask);
 			if (! ROMSize || ROMMask == NULL)
 				continue;
-			
+
 			if (! CurChip)
 				printf("  %s\n", GetROMRegionText(ROM_LIST[CurROM]));
 			else
 				printf("  %s #%u\n", GetROMRegionText(ROM_LIST[CurROM]), CurChip + 1);
-			
+
 			CurRgn = 0x00;
 			RgnMemory[CurRgn].AddrStart = 0xFFFFFFFF;
 			PosStart = 0x00;
@@ -806,7 +806,7 @@ static void EnumerateROMRegions(void)
 				{
 					printf("%06X\t%06X\t%6X\t%s\n", PosStart, CurPos - 1, CurPos - PosStart,
 							STATUS_TEXT[MaskVal]);
-					
+
 					if (MaskVal == 0x01)
 					{
 						if (! CurRgn)
@@ -835,13 +835,13 @@ static void EnumerateROMRegions(void)
 						}
 						RgnMemory[CurRgn].AddrStart = 0xFFFFFFFF;
 					}
-					
+
 					if (CurPos < ROMSize)
 						MaskVal = ROMMask[CurPos];
 					PosStart = CurPos;
 				}
 			}
-			
+
 			if (! CurRgn)
 			{
 				// to make sure that the ROM is at least allocated,
@@ -850,7 +850,7 @@ static void EnumerateROMRegions(void)
 				RgnMemory[CurRgn].AddrEnd = 0x00;
 				CurRgn ++;
 			}
-			
+
 			TempRRL->RegionCount = CurRgn;
 			TempRRL->Regions = (ROM_REGION*)malloc(TempRRL->RegionCount * sizeof(ROM_REGION));
 			for (CurRgn = 0x00; CurRgn < TempRRL->RegionCount; CurRgn ++)
@@ -858,7 +858,7 @@ static void EnumerateROMRegions(void)
 			TempRRL->IsWritten = false;
 		}
 	}
-	
+
 	free(RgnMemory);
 	return;
 }
@@ -887,13 +887,13 @@ static void OptimizeVGMSampleROM(void)
 	UINT8 CurRgn;
 	ROM_RGN_LIST* TempRRL;
 	ROM_REGION* TempRgn;
-	
+
 	DstData = (UINT8*)malloc(VGMDataLen + 0x100);
 	VGMPos = VGMHead.lngDataOffset;
 	DstPos = VGMHead.lngDataOffset;
 	NewLoopS = 0x00;
 	memcpy(DstData, VGMData, VGMPos);	// Copy Header
-	
+
 #if 1
 	for (TempByt = 0x00; TempByt < ROM_TYPES; TempByt ++)
 	{
@@ -901,7 +901,7 @@ static void OptimizeVGMSampleROM(void)
 		{
 			if ((ROM_LIST[TempByt] & 0xC0) != 0xC0)
 				continue;
-			
+
 			SetChipSet(ChipID);
 			ROMSize = GetROMData(ROM_LIST[TempByt], &ROMData);
 			TempRRL = &ROMRgnLst[TempByt][ChipID];
@@ -913,7 +913,7 @@ static void OptimizeVGMSampleROM(void)
 					continue;	// RAM size isn't changeable
 				CmdLen = (ROM_LIST[TempByt] & 0x20) ? 0x04 : 0x02;
 				CmdLen += DataLen;
-				
+
 				DstData[DstPos + 0x00] = 0x67;
 				DstData[DstPos + 0x01] = 0x66;
 				DstData[DstPos + 0x02] = ROM_LIST[TempByt];
@@ -936,7 +936,7 @@ static void OptimizeVGMSampleROM(void)
 		}
 	}
 #endif
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -947,7 +947,7 @@ static void OptimizeVGMSampleROM(void)
 		CmdLen = 0x00;
 		Command = VGMData[VGMPos + 0x00];
 		WriteEvent = true;
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -992,11 +992,11 @@ static void OptimizeVGMSampleROM(void)
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMData[VGMPos + 0x02];
 				memcpy(&TempLng, &VGMData[VGMPos + 0x03], 0x04);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
 				SetChipSet(ChipID);
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -1023,7 +1023,7 @@ static void OptimizeVGMSampleROM(void)
 							// Note: There are empty ROM Blocks to set the ROM Size
 							CmdLen = 0x08 + DataLen;
 							DataStart = TempRgn->AddrStart;
-							
+
 							DstData[DstPos + 0x00] = 0x67;
 							DstData[DstPos + 0x01] = 0x66;
 							DstData[DstPos + 0x02] = TempByt;
@@ -1051,13 +1051,13 @@ static void OptimizeVGMSampleROM(void)
 								continue;	// RAM size isn't changeable
 							CmdLen = (TempByt & 0x20) ? 0x04 : 0x02;
 							CmdLen += DataLen;
-							
+
 							DstData[DstPos + 0x00] = 0x67;
 							DstData[DstPos + 0x01] = 0x66;
 							DstData[DstPos + 0x02] = TempByt;
 							memcpy(&DstData[DstPos + 0x03], &CmdLen, 0x04);
 							DstData[DstPos + 0x06] |= (ChipID << 7);	// set '2nd Chip'-bit
-							
+
 							if (! (TempByt & 0x20))	// C0-DF - small RAM (<= 64 KB)
 							{
 								TempSht = TempRgn->AddrStart & 0xFFFF;
@@ -1134,7 +1134,7 @@ static void OptimizeVGMSampleROM(void)
 				break;
 			}
 		}
-		
+
 		// Note: In the case that the loop offset points to a Data Block,
 		//       it gets moved to the first command after it.
 		if (VGMPos == VGMHead.lngLoopOffset)
@@ -1147,7 +1147,7 @@ static void OptimizeVGMSampleROM(void)
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -1169,7 +1169,7 @@ static void OptimizeVGMSampleROM(void)
 		memcpy(&DstData[0x1C], &TempLng, 0x04);
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	if (VGMHead.lngGD3Offset && VGMHead.lngGD3Offset + 0x0B < VGMHead.lngEOFOffset)
 	{
 		VGMPos = VGMHead.lngGD3Offset;
@@ -1178,7 +1178,7 @@ static void OptimizeVGMSampleROM(void)
 		{
 			memcpy(&CmdLen, &VGMData[VGMPos + 0x08], 0x04);
 			CmdLen += 0x0C;
-			
+
 			TempLng = DstPos - 0x14;
 			memcpy(&DstData[0x14], &TempLng, 0x04);
 			memcpy(&DstData[DstPos], &VGMData[VGMPos], CmdLen);
@@ -1188,21 +1188,21 @@ static void OptimizeVGMSampleROM(void)
 	DstDataLen = DstPos;
 	TempLng = DstDataLen - 0x04;
 	memcpy(&DstData[0x04], &TempLng, 0x04);
-	
+
 	FreeAllChips();
-	
+
 	return;
 }
 
 static UINT8 GetRomRgnFromType(UINT8 ROMType)
 {
 	UINT8 CurType;
-	
+
 	for (CurType = 0x00; CurType < ROM_TYPES; CurType ++)
 	{
 		if (ROM_LIST[CurType] == ROMType)
 			return CurType;
 	}
-	
+
 	return 0x00;
 }

--- a/vgm_stat.c
+++ b/vgm_stat.c
@@ -74,11 +74,11 @@ int main(int argc, char* argv[])
 	char* FileExt;
 	bool PLMode;
 	UINT32 TempLng;
-	
+
 	setlocale(LC_CTYPE, "");	// set to use system codepage
-	
+
 	printf("VGM Statistics\n--------------\n\n");
-	
+
 //printf("ZLib Version: %s\n", zlibVersion());
 	ErrVal = 0;
 	printf("File Path or PlayList:\t");
@@ -93,11 +93,11 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	AllTotal = 0;
 	AllLoop = 0;
 	PLMode = false;
-	
+
 	if (FileName[strlen(FileName) - 1] != DIR_SEP)
 	{
 #ifdef WIN32
@@ -110,7 +110,7 @@ int main(int argc, char* argv[])
 			FileExt = strrchr(FileName, '.');
 			if (FileExt < strrchr(FileName, DIR_SEP))
 				FileExt = NULL;
-			
+
 			if (FileExt != NULL)
 			{
 				FileExt ++;
@@ -123,7 +123,7 @@ int main(int argc, char* argv[])
 			strcat(FileName, "/");
 		}
 	}
-	
+
 	TrackCount = 0;
 	TrackAlloc = 0;
 	TrackList = NULL;
@@ -132,7 +132,7 @@ int main(int argc, char* argv[])
 		ReadDirectory(FileName);
 	else
 		ReadPlaylist(FileName);
-	
+
 	TempLng = TrackCount;
 	TrkCntDigits = 0;
 	do
@@ -142,17 +142,17 @@ int main(int argc, char* argv[])
 	} while(TempLng);
 	if (TrkCntDigits < 2)
 		TrkCntDigits = 2;
-	
+
 #ifdef SHOW_FILE_STATS
 	ShowFileStats(NULL);
 	printf("\n\n");
 #endif
-	
+
 	ShowStatistics();
-	
+
 //EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -164,16 +164,16 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 TempLng;
 	char* TempPnt;
 	INT16 LoopCnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &fccHeader, 0x04);
 	if (fccHeader != FCC_VGM)
 		goto OpenErr;
-	
+
 	if (gzseek(hFile, 0x00, SEEK_SET) == -1)
 	{
 		printf("gzseek Error!!\n");
@@ -191,7 +191,7 @@ static bool OpenVGMFile(const char* FileName)
 	}
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// relative -> absolute addresses
 	VGMHead.lngEOFOffset += 0x00000004;
 	if (VGMHead.lngGD3Offset)
@@ -199,7 +199,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -209,10 +209,10 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	if (! VGMHead.bytLoopModifier)
 		VGMHead.bytLoopModifier = 0x10;
-	
+
 //printf("\tTrack %u, Data Ofs 0x%X, Version %X\n", TrackCount, VGMHead.lngDataOffset, VGMHead.lngVersion);
 //printf("\tSamples Total: %u, Samples Loop: %u\n", VGMHead.lngTotalSamples, VGMHead.lngLoopOffset);
 //printf("\tGD3 Offset: 0x%X, EOF Offset: 0x%X\n", VGMHead.lngGD3Offset, VGMHead.lngEOFOffset);
@@ -224,7 +224,7 @@ static bool OpenVGMFile(const char* FileName)
 	}
 	CurTrkEntry = &TrackList[TrackCount];
 	TrackCount ++;
-	
+
 	// Read GD3 Tag
 	if (VGMHead.lngGD3Offset)
 	{
@@ -234,7 +234,7 @@ static bool OpenVGMFile(const char* FileName)
 			VGMHead.lngGD3Offset = 0x00000000;
 			//goto OpenErr;
 	}
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		CurPos = VGMHead.lngGD3Offset;
@@ -259,7 +259,7 @@ static bool OpenVGMFile(const char* FileName)
 	{
 		VGMTag.strTrackNameE = L"";
 	}
-		
+
 	TempLng = wcslen(VGMTag.strTrackNameE);
 	if (TempLng)
 	{
@@ -293,15 +293,15 @@ static bool OpenVGMFile(const char* FileName)
 	}
 	CurTrkEntry->SmplTotal = VGMHead.lngTotalSamples;
 	CurTrkEntry->SmplLoop = VGMHead.lngLoopSamples;
-	
+
 	AllTotal += CurTrkEntry->SmplTotal;
 	LoopCnt = (2 * VGMHead.bytLoopModifier + 0x08) / 0x10 - VGMHead.bytLoopBase;
 	if (LoopCnt < 1)
 		LoopCnt = 1;
 	AllLoop += CurTrkEntry->SmplLoop * (LoopCnt - 1);
-	
+
 	gzclose(hFile);
-	
+
 	return true;
 
 OpenErr:
@@ -325,7 +325,7 @@ static wchar_t* ReadWStrFromFile(gzFile hFile, UINT32* FilePos, UINT32 EOFPos)
 	TextStr = (wchar_t*)malloc((EOFPos - CurPos) / 0x02 * sizeof(wchar_t));
 	if (TextStr == NULL)
 		return NULL;
-	
+
 	gzseek(hFile, CurPos, SEEK_SET);
 	TempStr = TextStr;
 	StrLen = 0x00;
@@ -339,10 +339,10 @@ static wchar_t* ReadWStrFromFile(gzFile hFile, UINT32* FilePos, UINT32 EOFPos)
 		if (CurPos >= EOFPos)
 			break;
 	} while(*(TempStr - 1));
-	
+
 	TextStr = (wchar_t*)realloc(TextStr, StrLen * sizeof(wchar_t));
 	*FilePos = CurPos;
-	
+
 	return TextStr;
 }
 
@@ -386,7 +386,7 @@ static void ReadDirectory(const char* DirName)
 #endif
 	strcpy(FileName, FilePath);
 	TempPnt = FileName + strlen(FileName);
-	
+
 #ifdef SHOW_FILE_STATS
 	printf("\t\t    Sample\t    Time\n");
 	printf("File Title\tTotal\tLoop\tTotal\tLoop\n\n");
@@ -452,14 +452,14 @@ static void ReadPlaylist(const char* FileName)
 	const char M3UV2_HEAD[] = "#EXTM3U";
 	const char M3UV2_META[] = "#EXTINF:";
 	UINT32 METASTR_LEN;
-	
+
 	FILE* hFile;
 	UINT32 LineNo;
 	bool IsV2Fmt;
 	char TempStr[MAX_PATH];
 	char FileVGM[MAX_PATH];
 	char* RetStr;
-	
+
 	RetStr = strrchr(FileName, '\\');
 	if (RetStr != NULL)
 	{
@@ -473,11 +473,11 @@ static void ReadPlaylist(const char* FileName)
 		strcpy(FilePath, "");
 	}
 //printf("  Base Path: %s\n", FilePath);
-	
+
 	hFile = fopen(FileName, "rt");
 	if (hFile == NULL)
 		return;
-	
+
 #ifdef SHOW_FILE_STATS
 	printf("\t\t    Sample\t    Time\n");
 	printf("File Title\tTotal\tLoop\tTotal\tLoop\n\n");
@@ -501,7 +501,7 @@ static void ReadPlaylist(const char* FileName)
 		}
 		if (! strlen(TempStr))
 			continue;
-		
+
 //printf("  Read Line: %s\n", TempStr);
 		if (! LineNo)
 		{
@@ -521,7 +521,7 @@ static void ReadPlaylist(const char* FileName)
 				continue;
 			}
 		}
-		
+
 		strcpy(FileVGM, FilePath);
 		strcat(FileVGM, TempStr);
 		RetStr = strrchr(TempStr, '\\');
@@ -529,7 +529,7 @@ static void ReadPlaylist(const char* FileName)
 			RetStr = TempStr;
 		else
 			RetStr ++;
-		
+
 //printf("  Full File Path: %s\n", FileVGM);
 		if (! OpenVGMFile(FileVGM))
 			printf("%s\tError opening the file!\n", RetStr);
@@ -539,9 +539,9 @@ static void ReadPlaylist(const char* FileName)
 #endif
 		LineNo ++;
 	}
-	
+
 	fclose(hFile);
-	
+
 	return;
 }
 
@@ -552,7 +552,7 @@ static void ShowFileStats(const char* FileTitle)
 	UINT32 SmplLoop;
 	char TimeTotal[0x10];
 	char TimeLoop[0x10];
-	
+
 	if (FileTitle != NULL)
 	{
 		SmplTotal = VGMHead.lngTotalSamples;
@@ -566,9 +566,9 @@ static void ShowFileStats(const char* FileTitle)
 	}
 	PrintSampleTime(TimeTotal, SmplTotal, false);
 	PrintSampleTime(TimeLoop, SmplLoop, true);
-	
+
 	printf("%s\t%u\t%u\t%s\t%s\n", FileTitle, SmplTotal, SmplLoop, TimeTotal, TimeLoop);
-	
+
 	return;
 }
 #endif
@@ -579,13 +579,13 @@ static void PrintSampleTime(char* buffer, const UINT32 Samples, bool LoopMode)
 	UINT16 HourVal;
 	UINT16 MinVal;
 	UINT16 SecVal;
-	
+
 	if (! Samples && LoopMode)
 	{
 		sprintf(buffer, " -");
 		return;
 	}
-	
+
 	SmplVal = Samples + 22050;	// Round to whole seconds
 	SmplVal /= 44100;
 	SecVal = (UINT16)(SmplVal % 60);
@@ -593,12 +593,12 @@ static void PrintSampleTime(char* buffer, const UINT32 Samples, bool LoopMode)
 	MinVal = (UINT16)(SmplVal % 60);
 	SmplVal /= 60;
 	HourVal = (UINT16)SmplVal;
-	
+
 	if (HourVal)
 		sprintf(buffer, "%2u:%02u:%02u", HourVal, MinVal, SecVal);
 	else
 		sprintf(buffer, "%2u:%02u", MinVal, SecVal);
-	
+
 	return;
 }
 
@@ -616,17 +616,17 @@ static void ShowStatistics(void)
 	char* TempStr;
 	UINT32 CurLine;
 	UINT32 LineCnt;
-	
+
 	TempStrAlloc = 0x00;
 	TempStr = NULL;
-	
+
 	printf("Song                        Length |Total |Loop\n");
 	printf("-----------------------------------+------+----\n");
 	for (CurTL = 0; CurTL < TrackCount; CurTL ++)
 	{
 		char* TitleWithNumber;
 		CurTrkEntry = &TrackList[CurTL];
-		
+
 		if (IsPlayList)
 		{
 			TitleWithNumber = (char*)malloc(TrkCntDigits + 1 + strlen(CurTrkEntry->Title) + 1);
@@ -636,63 +636,63 @@ static void ShowStatistics(void)
 		{
 			TitleWithNumber = strdup(CurTrkEntry->Title);
 		}
-		
+
 		LineCnt = GetTitleLines(&TempStrAlloc, &TempStr, TitleWithNumber);
 		TitleStr = (LineCnt) ? TempStr : TitleWithNumber;
 		if (! LineCnt)
 			LineCnt ++;
-		
+
 		for (CurLine = 0; CurLine < LineCnt; CurLine ++)
 		{
 			if (CurLine)
 				printf("\n");
-			
+
 			TitleLen = strlen(TitleStr);
 			if (TitleLen <= MAX_TITLE_CHARS)
 				Spaces = MAX_TITLE_CHARS - TitleLen;
 			else
 				Spaces = 0;
-			
+
 			printf("%.*s", MAX_TITLE_CHARS, TitleStr);
-			
+
 			TitleStr += TitleLen + 1;
 		}
-		
+
 		while(Spaces)
 		{
 			printf(" ");
 			Spaces --;
 		}
-		
+
 		PrintSampleTime(TimeTotal, CurTrkEntry->SmplTotal, false);
 		PrintSampleTime(TimeLoop, CurTrkEntry->SmplLoop, true);
-		
+
 		printf("%s  %s\n", TimeTotal, TimeLoop);
 		free(TitleWithNumber);
 	}
 	printf("\n");
-	
+
 	if (TempStr != NULL)
 	{
 		free(TempStr);	TempStr = NULL;
 	}
-	
+
 	TitleStr = "Total Length";
 	TitleLen = strlen(TitleStr);
 	Spaces = MAX_TITLE_CHARS - TitleLen;
-	
+
 	printf("%.*s", MAX_TITLE_CHARS, TitleStr);
 	while(Spaces)
 	{
 		printf(" ");
 		Spaces --;
 	}
-	
+
 	PrintSampleTime(TimeTotal, AllTotal, false);
 	PrintSampleTime(TimeLoop, AllTotal + AllLoop, false);
-	
+
 	printf("%s  %s\n", TimeTotal, TimeLoop);
-	
+
 	return;
 }
 
@@ -704,17 +704,17 @@ UINT32 GetTitleLines(UINT32* StrAlloc, char** String, const char* TitleStr)
 	UINT32 NoAlphaPos;
 	const char* SrcPtr;
 	char* DstPtr;
-	
+
 	CurPos = strlen(TitleStr);
 	if (CurPos <= MAX_TITLE_CHARS)
 		return 0;	// didn't do anything
-	
+
 	if (*StrAlloc < CurPos + 0x10)
 	{
 		*StrAlloc = (CurPos + 0x20) & ~0x0F;
 		*String = (char*)realloc(*String, *StrAlloc);
 	}
-	
+
 	SrcPtr = TitleStr;
 	DstPtr = *String;
 	NoAlphaPos = SpcPos = CurPos = 0;
@@ -728,7 +728,7 @@ UINT32 GetTitleLines(UINT32* StrAlloc, char** String, const char* TitleStr)
 	{
 		if (SrcPtr[CurPos] == ' ')
 			SpcPos = CurPos;
-		
+
 		if (CurPos >= MAX_TITLE_CHARS)
 		{
 			if (SpcPos)	// Space found
@@ -755,7 +755,7 @@ UINT32 GetTitleLines(UINT32* StrAlloc, char** String, const char* TitleStr)
 				SrcPtr += CurPos - 1;
 				DstPtr += CurPos + 1;
 			}
-			
+
 			CurPos = (DstPtr - *String) + strlen(SrcPtr);
 			if (*StrAlloc < CurPos + 0x10)
 			{
@@ -764,7 +764,7 @@ UINT32 GetTitleLines(UINT32* StrAlloc, char** String, const char* TitleStr)
 				*String = (char*)realloc(*String, *StrAlloc);
 				DstPtr = *String + SpcPos;
 			}
-			
+
 			NoAlphaPos = SpcPos = CurPos = 0;
 			if (IsPlayList)
 			{
@@ -778,14 +778,14 @@ UINT32 GetTitleLines(UINT32* StrAlloc, char** String, const char* TitleStr)
 			}
 			CurLine ++;
 		}
-		
+
 		if (! isalnum(SrcPtr[CurPos]))
 			NoAlphaPos = CurPos;
-		
+
 		DstPtr[CurPos] = SrcPtr[CurPos];
 		CurPos ++;
 	}
 	DstPtr[CurPos] = '\0';
-	
+
 	return CurLine;
 }

--- a/vgm_tag.c
+++ b/vgm_tag.c
@@ -90,7 +90,7 @@ const SYSTEM_SHORT SYSTEM_NAMES[] =
 	{"NES",		"Nintendo Entertainment System", "&#x30d5;&#x30a1;&#x30df;&#x30ea;&#x30fc;&#x30b3;&#x30f3;&#x30d4;&#x30e5;&#x30fc;&#x30bf;"},
 	{"FDS",		"Famicom Disk System", "&#x30d5;&#x30a1;&#x30df;&#x30ea;&#x30fc;&#x30b3;&#x30f3;&#x30d4;&#x30e5;&#x30fc;&#x30bf; "
 										"&#x30c7;&#x30a3;&#x30b9;&#x30af;&#x30b7;&#x30b9;&#x30c6;&#x30e0;"},
-	{"NESFDS",	"Nintendo Entertainment System / Famicom Disk System", 
+	{"NESFDS",	"Nintendo Entertainment System / Famicom Disk System",
 				"&#x30d5;&#x30a1;&#x30df;&#x30ea;&#x30fc;&#x30b3;&#x30f3;&#x30d4;&#x30e5;&#x30fc;&#x30bf; / "
 				"&#x30d5;&#x30a1;&#x30df;&#x30ea;&#x30fc;&#x30b3;&#x30f3;&#x30d4;&#x30e5;&#x30fc;&#x30bf; "
 				"&#x30c7;&#x30a3;&#x30b9;&#x30af;&#x30b7;&#x30b9;&#x30c6;&#x30e0;"},
@@ -121,9 +121,9 @@ int main(int argc, char* argv[])
 	bool FileCompr;
 	int ErrVal;
 	UINT8 RetVal;
-	
+
 	printf("VGM Tagger\n----------\n\n");
-	
+
 	ErrVal = 0;
 	if (argc <= 0x01)
 	{
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
 	{
 		printf("Help\n----\n");
 		printf("Usage: vgm_tag [-command1] [-command2] file1.vgm file2.vgz\n");
-		
+
 		printf("Command List\n------------\n");
 		printf("General Commands:\n");
 		printf("(no command)  like -ShowTag\n");
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
 		printf("\t-ShowTagU   like above, but tries to print real Unicode-Chars\n");
 		printf("\t-ShowTag8   like above, but UTF-8 is used to print Unicode-Chars\n");
 		printf("\n");
-		
+
 		printf("Tagging Commands:\n");
 		printf("Command format: -command:value or -command:\"value with spaces\"\n");
 		printf("\t-Title      Track Title\n");
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
 		printf("\t-NotesB     Notes and Comments (insert at beginning)\n");
 		printf("\t-NotesE     Notes and Comments (append to end)\n");
 		printf("\n");
-		
+
 		printf("*If the system's short name is given,");
 		printf("the Japanese system name is filled too.\n");
 		printf("  Otherwise the English system name is set and the Japanese one is cleared.\n");
@@ -183,7 +183,7 @@ int main(int argc, char* argv[])
 		}
 		goto EndProgram;
 	}
-	
+
 	for (CmdCnt = 0x01; CmdCnt < argc; CmdCnt ++)
 	{
 		if (*argv[CmdCnt] != '-')
@@ -194,7 +194,7 @@ int main(int argc, char* argv[])
 		printf("Error: No files specified!\n");
 		goto EndProgram;
 	}
-	
+
 	for (CurArg = CmdCnt; CurArg < argc; CurArg ++)
 	{
 		printf("File: %s ...\n", argv[CurArg]);
@@ -205,7 +205,7 @@ int main(int argc, char* argv[])
 			ErrVal |= 1;	// There was at least 1 opening-error.
 			continue;
 		}
-		
+
 		RetVal = TagVGM(CmdCnt - 0x01, argv + 0x01);
 		if (RetVal == 0x10)
 		{
@@ -230,10 +230,10 @@ int main(int argc, char* argv[])
 		}
 		printf("\n");
 	}
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -243,29 +243,29 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 	UINT32 fccHeader;
 	UINT32 CurPos;
 	UINT32 TempLng;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &fccHeader, 0x04);
 	if (fccHeader != FCC_VGM)
 		goto OpenErr;
-	
+
 	*Compressed = ! gzdirect(hFile);
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, 0x40);	// I don't need more data
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// relative -> absolute addresses
 	VGMHead.lngEOFOffset += 0x00000004;
 	if (VGMHead.lngGD3Offset)
 		VGMHead.lngGD3Offset += 0x00000014;
-	
+
 	VGMDataLen = VGMHead.lngEOFOffset;
-	
+
 	// Read GD3 Tag
 	if (VGMHead.lngGD3Offset)
 	{
@@ -275,11 +275,11 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 			VGMHead.lngGD3Offset = 0x00000000;
 			//goto OpenErr;
 	}
-	
+
 	if (VGMHead.lngGD3Offset)
 	{
 		VGMDataLen = VGMHead.lngGD3Offset;	// That's the actual VGM Data without Tag
-		
+
 		CurPos = VGMHead.lngGD3Offset;
 		gzseek(hFile, CurPos, SEEK_SET);
 		gzread(hFile, &VGMTag, 0x0C);
@@ -297,16 +297,16 @@ static bool OpenVGMFile(const char* FileName, bool* Compressed)
 		VGMTag.strCreator = ReadWStrFromFile(hFile, &CurPos, TempLng);
 		VGMTag.strNotes = ReadWStrFromFile(hFile, &CurPos, TempLng);
 	}
-	
+
 	// Read Data
 	VGMData = (UINT8*)malloc(VGMDataLen);
 	if (VGMData == NULL)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	return true;
 
 OpenErr:
@@ -322,7 +322,7 @@ static wchar_t* ReadWStrFromFile(gzFile hFile, UINT32* FilePos, const UINT32 EOF
 	wchar_t* TempStr;
 	UINT32 StrLen;
 	UINT16 UnicodeChr;
-	
+
 	// Unicode 2-Byte -> 4-Byte conversion is not neccessary,
 	// but it's easier to handle wchar_t than unsigned short
 	// (note: wchar_t is 16-bit on Windows, but 32-bit on Linux)
@@ -330,7 +330,7 @@ static wchar_t* ReadWStrFromFile(gzFile hFile, UINT32* FilePos, const UINT32 EOF
 	TextStr = (wchar_t*)malloc((EOFPos - CurPos) / 0x02 * sizeof(wchar_t));
 	if (TextStr == NULL)
 		return NULL;
-	
+
 	gzseek(hFile, CurPos, SEEK_SET);
 	TempStr = TextStr;
 	StrLen = 0x00;
@@ -344,10 +344,10 @@ static wchar_t* ReadWStrFromFile(gzFile hFile, UINT32* FilePos, const UINT32 EOF
 		if (CurPos >= EOFPos)
 			break;
 	} while(*(TempStr - 1));
-	
+
 	TextStr = (wchar_t*)realloc(TextStr, StrLen * sizeof(wchar_t));
 	*FilePos = CurPos;
-	
+
 	return TextStr;
 }
 
@@ -355,7 +355,7 @@ static UINT8 ConvertUnicode2UTF8(char* Buffer, const UINT16 UnicodeChr)
 {
 	// Convert Unicode to UTF-8
 	// return legnth of written data
-	
+
 	if (UnicodeChr & 0xF800)
 	{
 		// 0800 - FFFF
@@ -382,7 +382,7 @@ static UINT8 ConvertUnicode2UTF8(char* Buffer, const UINT16 UnicodeChr)
 static bool WriteVGMFile(const char* FileName, const bool Compress)
 {
 	FGZ_PTR hFile;
-	
+
 	FileCompression = Compress;
 	if (! FileCompression)
 		hFile.f = fopen(FileName, "wb");
@@ -390,7 +390,7 @@ static bool WriteVGMFile(const char* FileName, const bool Compress)
 		hFile.gz = gzopen(FileName, "wb9");
 	if (hFile.f == NULL)
 		return false;
-	
+
 	// Write VGM Data (excluding GD3 Tag)
 	if (! FileCompression)
 	{
@@ -402,7 +402,7 @@ static bool WriteVGMFile(const char* FileName, const bool Compress)
 		gzseek(hFile.gz, 0x00, SEEK_SET);
 		gzwrite(hFile.gz, VGMData, VGMDataLen);
 	}
-	
+
 	// Write GD3 Tag
 	if (VGMHead.lngGD3Offset)
 	{
@@ -432,13 +432,13 @@ static bool WriteVGMFile(const char* FileName, const bool Compress)
 		WriteWStrToFile(hFile, VGMTag.strCreator);
 		WriteWStrToFile(hFile, VGMTag.strNotes);
 	}
-	
+
 	if (! FileCompression)
 		fclose(hFile.f);
 	else
 		gzclose(hFile.gz);
 	printf("Tag written.\n");
-	
+
 	return true;
 }
 
@@ -447,7 +447,7 @@ static UINT32 WriteWStrToFile(const FGZ_PTR hFile, const wchar_t* WString)
 	const wchar_t* TextStr;
 	UINT32 WrittenChars;
 	UINT16 UnicodeChr;
-	
+
 	TextStr = WString;
 	WrittenChars = 0x00;
 	while(*TextStr)
@@ -457,7 +457,7 @@ static UINT32 WriteWStrToFile(const FGZ_PTR hFile, const wchar_t* WString)
 			fwrite(&UnicodeChr, 0x02, 0x01, hFile.f);
 		else
 			gzwrite(hFile.gz, &UnicodeChr, 0x02);
-		
+
 		TextStr ++;
 		WrittenChars ++;
 	}
@@ -467,7 +467,7 @@ static UINT32 WriteWStrToFile(const FGZ_PTR hFile, const wchar_t* WString)
 		fwrite(&UnicodeChr, 0x02, 0x01, hFile.f);
 	else
 		gzwrite(hFile.gz, &UnicodeChr, 0x02);
-	
+
 	return WrittenChars;
 }
 
@@ -480,12 +480,12 @@ static void Copy2TagStr(wchar_t** TagStr, const char* DataStr)
 	const char* ChrStr;
 	UINT16 UnicodeChr;
 	char NCRStr[0x10];
-	
+
 	if (DataStr != NULL)
 		DataLen = strlen(DataStr);
 	else
 		DataLen = 0x00;
-	
+
 	*TagStr = (wchar_t*)realloc(*TagStr, (DataLen + 0x01) * sizeof(wchar_t));
 	SrcStr = DataStr;
 	DstStr = *TagStr;
@@ -532,9 +532,9 @@ static void Copy2TagStr(wchar_t** TagStr, const char* DataStr)
 					UnicodeChr = (UINT16)strtoul(NCRStr + 0x01, NULL, 0x10);
 				else
 					UnicodeChr = (UINT16)strtoul(NCRStr, NULL, 10);
-				
+
 				*DstStr = (wchar_t)UnicodeChr;
-				
+
 				SrcStr = ChrStr;
 				DstStr ++;
 				DataLen ++;
@@ -547,7 +547,7 @@ static void Copy2TagStr(wchar_t** TagStr, const char* DataStr)
 		DataLen ++;
 	}
 	*DstStr = 0x0000;
-	
+
 	return;
 }
 
@@ -565,34 +565,34 @@ static void CopySys2TagStr(wchar_t** TagStr, const SYSTEM_SHORT* System, bool Mo
 	UINT16 UnicodeChr;
 	char NCRStr[0x10];
 	bool DoWildcard;
-	
+
 	if (Mode == SYSMODE_ENG)
 		DataStr = System->NameE;
 	else if (Mode == SYSMODE_JAP)
 		DataStr = System->NameJ;
 	else
 		return;
-	
+
 	DataLen = strlen(DataStr);
-	
+
 	CmdPos = System->Abbr;
 	while(! (*CmdPos == 0x00 || *CmdPos == '*'))
 		CmdPos ++;
 	if (*CmdPos == 0x00)
 	{
 		CmdPos = NULL;
-		
+
 		DoWildcard = false;
 	}
 	else
 	{
 		CmdPos = CmdStr + (CmdPos - System->Abbr);
 		DoWildcard = true;
-		
+
 		DataLen += strlen(CmdPos) - 0x01;
 	}
 	CmdPos2 = System->Abbr;
-	
+
 	*TagStr = (wchar_t*)realloc(*TagStr, (DataLen + 0x01) * sizeof(wchar_t));
 	SrcStr = DataStr;
 	DstStr = *TagStr;
@@ -661,9 +661,9 @@ static void CopySys2TagStr(wchar_t** TagStr, const SYSTEM_SHORT* System, bool Mo
 					UnicodeChr = (UINT16)strtoul(NCRStr + 0x01, NULL, 0x10);
 				else
 					UnicodeChr = (UINT16)strtoul(NCRStr, NULL, 10);
-				
+
 				*DstStr = (wchar_t)UnicodeChr;
-				
+
 				SrcStr = ChrStr;
 				DstStr ++;
 				DataLen ++;
@@ -682,7 +682,7 @@ static void CopySys2TagStr(wchar_t** TagStr, const SYSTEM_SHORT* System, bool Mo
 		DataLen ++;
 	}
 	*DstStr = 0x0000;
-	
+
 	return;
 }
 
@@ -692,7 +692,7 @@ static bool CompareSystemNames(const char* StrA, const char* StrB)
 	{
 		if (*StrB == '*')
 			return true;	// Wildcard found
-		
+
 		if (*StrB != '?' || *StrA == '\0')
 		{
 			if (toupper(*StrA) != toupper(*StrB))
@@ -701,14 +701,14 @@ static bool CompareSystemNames(const char* StrA, const char* StrB)
 		StrA ++;
 		StrB ++;
 	}
-	
+
 	return true;
 }
 
 static UINT16 GetSystemString(const char* SystemName)
 {
 	UINT16 CurSys;
-	
+
 	CurSys = 0x00;
 	while(SYSTEM_NAMES[CurSys].Abbr != NULL)
 	{
@@ -716,7 +716,7 @@ static UINT16 GetSystemString(const char* SystemName)
 			return CurSys;
 		CurSys ++;
 	}
-	
+
 	return 0xFFFF;
 }
 
@@ -735,7 +735,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 	UINT32 TempLng;
 	UINT8 TempByt;
 	UINT8 RetVal;
-	
+
 	if (! VGMHead.lngGD3Offset)
 	{
 		VGMTag.fccGD3 = 0x20336447;
@@ -751,7 +751,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 		if (CurArg != 'Y')
 			return 0x01;
 	}
-	
+
 	// Execute Commands
 	RetVal = 0x10;	// nothing done - skip writing
 	if (! ArgCount)
@@ -763,14 +763,14 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 			free(CmdStr);
 		//CmdStr = ArgList[CurArg] + 0x01;	// Skip the '-' at the beginning
 		CmdStr = strdup(ArgList[CurArg] + 0x01);	// I need a copy, since I remove the '=' character
-		
+
 		CmdData = strchr(CmdStr, ':');
 		if (CmdData != NULL)
 		{
 			*CmdData = 0x00;
 			CmdData ++;
 		}
-		
+
 		if (! stricmp(CmdStr, "ShowTag"))
 		{
 			ShowTag(0x00);
@@ -786,16 +786,16 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 			ShowTag(0x02);
 			continue;
 		}
-		
+
 		if (! stricmp(CmdStr, "RmvEqual"))
 		{
 			if (CmdData != NULL)
 				TempByt = (toupper(CmdData[0x00]) == 'J') ? 1 : 0;
 			else
 				TempByt = 0;
-			printf("Removing redundant tags (default to %s): ", 
+			printf("Removing redundant tags (default to %s): ",
 					TempLng ? "Eng" : "Jap");
-			
+
 			TempLng = 0x00;
 			TempLng |= RemoveEqualTag(&VGMTag.strTrackNameE,	&VGMTag.strTrackNameJ,	TempByt) << 0;
 			TempLng |= RemoveEqualTag(&VGMTag.strGameNameE,		&VGMTag.strGameNameJ,	TempByt) << 1;
@@ -820,7 +820,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 		else if (! stricmp(CmdStr, "RmvUnknown"))
 		{
 			printf("Removing \"Unknown Author\" tag: ");
-			
+
 			TempLng = 0x00;
 			TempLng |= RemoveUnknown(&VGMTag.strAuthorNameE) << 0;
 			TempLng |= RemoveUnknown(&VGMTag.strAuthorNameJ) << 1;
@@ -836,7 +836,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 			printf("\n");
 			continue;
 		}
-		
+
 		RetVal = 0x00;
 		if (! stricmp(CmdStr, "RemoveTag"))
 		{
@@ -848,7 +848,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 			}
 			break;
 		}
-		
+
 		if (! VGMHead.lngGD3Offset)
 		{
 			printf("Tag created.\n");
@@ -876,7 +876,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 			Copy2TagStr(&VGMTag.strCreator, "");
 			Copy2TagStr(&VGMTag.strNotes, "");
 		}
-		
+
 		if (! stricmp(CmdStr, "ClearTag"))
 		{
 			printf("Tag cleared.\n");
@@ -982,11 +982,11 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 				StrLen = wcslen(VGMTag.strNotes);	// +0x01 = Null-Terminator
 				NoteStr = (wchar_t*)malloc((StrLen + 0x01) * sizeof(wchar_t));
 				wcscpy(NoteStr, VGMTag.strNotes);
-				
+
 				// convert new String
 				TempStr = NULL;
 				Copy2TagStr(&TempStr, CmdData);
-				
+
 				// rewrite Notes-Tag
 				StrLen = wcslen(TempStr) + wcslen(VGMTag.strNotes);
 				VGMTag.strNotes = (wchar_t*)realloc(VGMTag.strNotes,
@@ -1001,11 +1001,11 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 				StrLen = wcslen(VGMTag.strNotes);	// +0x01 = Null-Terminator
 				NoteStr = (wchar_t*)malloc((StrLen + 0x01) * sizeof(wchar_t));
 				wcscpy(NoteStr, VGMTag.strNotes);
-				
+
 				// convert new String
 				TempStr = NULL;
 				Copy2TagStr(&TempStr, CmdData);
-				
+
 				// rewrite Notes-Tag
 				StrLen = wcslen(VGMTag.strNotes) + wcslen(TempStr);
 				VGMTag.strNotes = (wchar_t*)realloc(VGMTag.strNotes,
@@ -1024,7 +1024,7 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 	}
 	if (CmdStr != NULL)
 		free(CmdStr);
-	
+
 	if (RetVal != 0x10)
 	{
 		// only care about that if we modified something
@@ -1048,35 +1048,35 @@ static UINT8 TagVGM(const int ArgCount, char* ArgList[])
 		{
 			VGMHead.lngEOFOffset = VGMDataLen;
 		}
-		
+
 		// Write VGM Header
 		TempLng = VGMHead.lngEOFOffset - 0x04;
 		memcpy(&VGMData[0x04], &TempLng, 0x04);
 		TempLng = VGMHead.lngGD3Offset ? (VGMHead.lngGD3Offset - 0x14) : 0x00;
 		memcpy(&VGMData[0x14], &TempLng, 0x04);
 	}
-	
+
 	return RetVal;
 }
 
 static bool RemoveEqualTag(wchar_t** TagE, wchar_t** TagJ, UINT8 Mode)
 {
 	// Remove redundant tags
-	
+
 	if (*TagE == NULL || *TagJ == NULL)
 		return false;	// NULL - break
-	
+
 	if (wcscmp(*TagE, *TagJ))
 		return false;	// both are different
 	if (! wcslen(*TagE))
 		return false;	// both are empty
-	
+
 	// both are equal
 	if (! Mode)
 		Copy2TagStr(TagJ, "");
 	else
 		Copy2TagStr(TagE, "");
-	
+
 	return true;
 }
 
@@ -1084,10 +1084,10 @@ static bool RemoveUnknown(wchar_t** Tag)
 {
 	if (*Tag == NULL)
 		return false;	// NULL - break
-	
+
 	if (wcsicmp(*Tag, L"unknown") && wcsicmp(*Tag, L"Unknown Author"))
 		return false;
-	
+
 	Copy2TagStr(Tag, "");
 	return true;
 }
@@ -1095,13 +1095,13 @@ static bool RemoveUnknown(wchar_t** Tag)
 static void ShowTag(const UINT8 UnicodeMode)
 {
 	char* TempStr;
-	
+
 	if (! VGMHead.lngGD3Offset)
 	{
 		printf("This VGM File has no GD3 Tag!\n");
 		return;
 	}
-	
+
 	switch(UnicodeMode)
 	{
 	case 0x00:	// HTML NCRs
@@ -1188,7 +1188,7 @@ static void ShowTag(const UINT8 UnicodeMode)
 		free(TempStr);
 		break;
 	}
-	
+
 	return;
 }
 
@@ -1199,12 +1199,12 @@ char* ConvertWStr2ASCII_NCR(const wchar_t* WideStr)
 	char* DstStr;
 	UINT32 StrLen;
 	UINT16 UnicodeChr;
-	
+
 	// HTML NCR: &#xABCD;
 	// Length;   12345678
 	StrLen = wcslen(WideStr);
 	RetStr = (char*)malloc((StrLen * 0x08) + 0x01);	// space for 1 NCR for every char
-	
+
 	SrcStr = WideStr;
 	DstStr = RetStr;
 	while(*SrcStr)
@@ -1224,7 +1224,7 @@ char* ConvertWStr2ASCII_NCR(const wchar_t* WideStr)
 		SrcStr ++;
 	}
 	*DstStr = 0x00;
-	
+
 	return RetStr;
 }
 
@@ -1235,10 +1235,10 @@ char* ConvertWStr2UTF8(const wchar_t* WideStr)
 	char* DstStr;
 	UINT32 StrLen;
 	UINT16 UnicodeChr;
-	
+
 	StrLen = wcslen(WideStr);
 	RetStr = (char*)malloc((StrLen * 0x04) + 0x01);	// space for 4 Bytes per char
-	
+
 	SrcStr = WideStr;
 	DstStr = RetStr;
 	while(*SrcStr)
@@ -1248,7 +1248,7 @@ char* ConvertWStr2UTF8(const wchar_t* WideStr)
 		SrcStr ++;
 	}
 	*DstStr = 0x00;
-	
+
 	return RetStr;
 }
 
@@ -1256,7 +1256,7 @@ static wchar_t* wcscap(wchar_t* string)
 {
 	wchar_t* CurChr;
 	bool LastWasLetter;
-	
+
 	CurChr = string;
 	LastWasLetter = false;
 	while(*CurChr != L'\0')
@@ -1276,6 +1276,6 @@ static wchar_t* wcscap(wchar_t* string)
 		}
 		CurChr ++;
 	}
-	
+
 	return string;
 }

--- a/vgm_trim.c
+++ b/vgm_trim.c
@@ -43,9 +43,9 @@ int main(int argc, char* argv[])
 	bool KeepLSmpl;
 	UINT8 OptsTrim;
 	UINT8 OptsWarn;
-	
+
 	printf("VGM Trimmer\n-----------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
 	OptsTrim = 0x00;
@@ -77,9 +77,9 @@ int main(int argc, char* argv[])
 			break;
 		}
 	}
-	
+
 	SetTrimOptions(OptsTrim, ! OptsWarn);
-	
+
 	printf("File Name:\t");
 	if (argc <= argbase + 0)
 	{
@@ -92,7 +92,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	printf("Start Sample (in Samples):\t");
 	if (argc <= argbase + 1)
 	{
@@ -106,7 +106,7 @@ int main(int argc, char* argv[])
 	StartSmpl = strtol(InputTxt, NULL, 0);
 	if (! StartSmpl)
 		StartSmpl = 0x00;
-	
+
 	printf("Loop Sample (in Samples):\t");
 	if (argc <= argbase + 2)
 	{
@@ -118,7 +118,7 @@ int main(int argc, char* argv[])
 		printf("%s\n", InputTxt);
 	}
 	LoopSmpl = strtol(InputTxt, NULL, 0);
-	
+
 	printf("End Sample (in Samples):\t");
 	if (argc <= argbase + 3)
 	{
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
 		printf("%s\n", InputTxt);
 	}
 	EndSmpl = strtol(InputTxt, NULL, 0);
-	
+
 	if (! OpenVGMFile(FileName))
 	{
 		printf("Error opening the file!\n");
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
 		goto EndProgram;
 	}
 	printf("\n");
-	
+
 	KeepLSmpl = false;
 	if (EndSmpl == -1)
 	{
@@ -184,7 +184,7 @@ int main(int argc, char* argv[])
 		printf("Warning: Negative Start Sample - Silence added!\n");
 	if ((UINT32)EndSmpl > VGMHead.lngTotalSamples)
 		printf("Warning: End Sample after End of File - Silence added!\n");
-	
+
 	if (LoopSmpl == -1)
 	{
 		LoopSmpl = StartSmpl;
@@ -200,7 +200,7 @@ int main(int argc, char* argv[])
 	{
 		HasLoop = LoopSmpl ? true : false;
 	}
-	
+
 	TrimVGMData(StartSmpl, LoopSmpl, EndSmpl, HasLoop, KeepLSmpl);
 	if (argc > argbase + 4)
 		strcpy(FileName, argv[argbase + 4]);
@@ -212,14 +212,14 @@ int main(int argc, char* argv[])
 		strcat(FileName, "_trimmed.vgm");
 	}
 	WriteVGMFile(FileName);
-	
+
 QuickExit:
 	free(VGMData);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -229,20 +229,20 @@ static bool OpenVGMFile(const char* FileName)
 	UINT32 CurPos;
 	UINT32 TempLng;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -266,7 +266,7 @@ static bool OpenVGMFile(const char* FileName)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -276,7 +276,7 @@ static bool OpenVGMFile(const char* FileName)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	VGMDataLen = VGMHead.lngEOFOffset;
 	VGMData = (UINT8*)malloc(VGMDataLen);
@@ -284,14 +284,14 @@ static bool OpenVGMFile(const char* FileName)
 		goto OpenErr;
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, VGMData, VGMDataLen);
-	
+
 	gzclose(hFile);
-	
+
 	strcpy(FileBase, FileName);
 	TempPnt = strrchr(FileBase, '.');
 	if (TempPnt != NULL)
 		*TempPnt = 0x00;
-	
+
 	return true;
 
 OpenErr:
@@ -304,24 +304,24 @@ static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
 	const char* FileTitle;
-	
+
 	printf("\t\t\t\t\t\t\t\t\r");
 	FileTitle = strrchr(FileName, '\\');
 	if (FileTitle == NULL)
 		FileTitle = FileName;
 	else
 		FileTitle ++;
-	
+
 	hFile = fopen(FileName, "wb");
 	if (hFile == NULL)
 	{
 		printf("Error writing %s!\n", FileTitle);
 		return;
 	}
-	
+
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
 	printf("%s written.\n", FileTitle);
-	
+
 	return;
 }

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -132,14 +132,14 @@ typedef struct rewrite_chipset_new
 
 #define CHIP_COUNT	0x29
 
-static const char* CHIP_STRS[CHIP_COUNT] = 
+static const char* CHIP_STRS[CHIP_COUNT] =
 {	"SN76496", "YM2413", "YM2612", "YM2151", "SegaPCM", "RF5C68", "YM2203", "YM2608",
 	"YM2610", "YM3812", "YM3526", "Y8950", "YMF262", "YMF278B/OPL", "YMF271", "YMZ280B",
 	"RF5C164", "PWM", "AY8910", "GameBoy", "NES APU", "MultiPCM", "uPD7759", "OKIM6258",
 	"OKIM6295", "K051649", "K054539", "HuC6280", "C140", "K053260", "Pokey", "QSound",
 	"SCSP", "WSwan", "VSU", "SAA1099", "ES5503", "ES5506", "X1-010", "C352",
 	"GA20"};
-static const char* CHIP_STRS2[CHIP_COUNT] = 
+static const char* CHIP_STRS2[CHIP_COUNT] =
 {	"", "", "", "", "", "", "", "",
 	"", "", "", "", "", "YMF278B/PCM", "", "",
 	"", "", "", "", "", "", "", "",
@@ -202,7 +202,7 @@ void SetTrimOptions(UINT8 TrimMode, UINT8 WarnMask)
 		exit(-1);
 	}
 #endif
-	
+
 	HARD_SPLIT = false;
 	COMPLETE_REWRITE = false;
 	VGMTOOL_TRIM = false;
@@ -223,7 +223,7 @@ void SetTrimOptions(UINT8 TrimMode, UINT8 WarnMask)
 		break;
 	}
 	WARN_PLAY_NOTES = (WarnMask) ? true : false;
-	
+
 	return;
 }
 
@@ -231,12 +231,12 @@ static void PrepareChipMemory(void)
 {
 	REWRT_CHIPSET_NEW* TempRC;
 	UINT8 CurCSet;
-	
+
 	for (CurCSet = 0x00; CurCSet < CHIP_SETS; CurCSet ++)
 	{
 		TempRC = &RC[CurCSet];
 		memset(TempRC, 0x00, sizeof(REWRT_CHIPSET_NEW));
-		
+
 		if (VGMHead.lngHzPSG)
 		{
 			// SN76496 Register Map:
@@ -599,7 +599,7 @@ static void PrepareChipMemory(void)
 			}
 		}
 	}
-	
+
 	return;
 }
 
@@ -611,16 +611,16 @@ static void SetImportantCommands(void)
 	UINT8 CurCSet;
 	UINT8 CurChip;
 	UINT16 CurReg;
-	
+
 	for (CurCSet = 0x00; CurCSet < CHIP_SETS; CurCSet ++)
 	{
 		TempCD = (CHIP_DATA*)&RC[CurCSet];
-		
+
 		for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++, TempCD ++)
 		{
 			TempReg = &TempCD->Regs;
 			TempMem = &TempCD->Mem;
-			
+
 			if (TempReg->RegCount)
 			{
 				if (! TempReg->Mode)
@@ -652,10 +652,10 @@ static void SetImportantCommands(void)
 			}
 			TempMem->HadWrt = false;
 			TempMem->MemPtr = NULL;
-			
+
 			if (! TempReg->RegCount)
 				continue;
-			
+
 			switch(CurChip)
 			{
 			case 0x00:	// SN76496
@@ -767,7 +767,7 @@ static void SetImportantCommands(void)
 				// Control Regs
 				for (CurReg = 0x00; CurReg < 0x03; CurReg ++)
 					TempReg->RegMask[0x14 + CurReg] |= 0x80;
-				
+
 				// WaveRAM
 				for (CurReg = 0x00; CurReg < 0x10; CurReg ++)
 					TempReg->RegMask[0x20 | CurReg] |= 0x80;
@@ -798,7 +798,7 @@ static void SetImportantCommands(void)
 				TempReg->RegData.R08[0x0C] = (VGMHead.lngHzOKIM6295 >> 31) & 0x01;
 				for (CurReg = 0x0B; CurReg <= 0x0C; CurReg ++)
 					TempReg->RegMask[CurReg] |= 0x80;
-				
+
 				// 0E - NMK112 bank switch enable
 				// 0F - Bank Base (non-NMK112)
 				for (CurReg = 0x0E; CurReg <= 0x0F; CurReg ++)
@@ -816,7 +816,7 @@ static void SetImportantCommands(void)
 				// Control Regs (Balance, LFO)
 				for (CurReg = 0xE4; CurReg < 0xE8; CurReg ++)
 					TempReg->RegMask[CurReg] |= 0x80;
-				
+
 				// Wave RAM
 				for (CurReg = 0x00; CurReg < 0xC0; CurReg ++)
 					TempReg->RegMask[CurReg] |= 0x80;
@@ -872,7 +872,7 @@ static void SetImportantCommands(void)
 			}
 		}
 	}
-	
+
 	return;
 }
 
@@ -892,21 +892,21 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 	CHIP_MEMORY* TempMem;
 	UINT8 ChipCmd;
 	UINT8 CmdType;
-	
+
 	if (VGMTOOL_TRIM)
 		return;
-	
+
 	for (CurCSet = 0x00; CurCSet < CHIP_SETS; CurCSet ++)
 	{
 		TempCD = (CHIP_DATA*)&RC[CurCSet];
-		
+
 		for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++, TempCD ++)
 		{
 			TempMem = &TempCD->Mem;
-			
+
 			if (! TempMem->MemSize || ! TempMem->HadWrt)
 				continue;
-			
+
 			switch(CurChip)
 			{
 			case 0x07:	// YM2608
@@ -944,13 +944,13 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstData[DstPos + 0x01] = 0x66;
 					DstData[DstPos + 0x02] = CmdType;
 					WriteLE32(&DstData[DstPos + 0x03], 0x08);
-					
+
 					WriteLE32(&DstData[DstPos + 0x07], TempMem->MemSize);
 					WriteLE32(&DstData[DstPos + 0x0B], 0x00);
 					DstPos += 0x07 + 0x08;
 					break;
 				}
-				
+
 				if (ChipCmd && (TempCD->Regs.RegMask[CurReg] & 0x7F) == 0x01)
 				{
 					// make sure that the memory configuration register is initialized before writing the data block
@@ -980,14 +980,14 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				{
 					DstDataLen += TempMem->MemSize;
 					DstData = (UINT8*)realloc(DstData, DstDataLen);
-					
+
 					DstData[DstPos + 0x00] = 0x67;
 					DstData[DstPos + 0x01] = 0x66;
 					DstData[DstPos + 0x02] = CmdType;
-					
+
 					TempLng = TempMem->MemSize + 0x08;
 					WriteLE32(&DstData[DstPos + 0x03], TempLng);
-					
+
 					WriteLE32(&DstData[DstPos + 0x07], TempMem->MemSize);
 					WriteLE32(&DstData[DstPos + 0x0B], 0x00);	// DataStart: 0x00
 					memcpy(&DstData[DstPos + 0x0F], TempMem->MemData, TempMem->MemSize);
@@ -1011,11 +1011,11 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					TempByt = 0x20;
 				else if (CurChip == 0x24)
 					TempByt = 0x21;
-				
+
 				DstData[DstPos + 0x00] = 0x67;
 				DstData[DstPos + 0x01] = 0x66;
 				DstData[DstPos + 0x02] = 0xC0 | TempByt;
-				
+
 				if (! TempMem->MemMaxOfs)
 					TempMem->MemMaxOfs = TempMem->MemSize;
 				if (! (TempByt & 0x20))
@@ -1023,7 +1023,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				else
 					TempLng = TempMem->MemMaxOfs + 0x04;
 				WriteLE32(&DstData[DstPos + 0x03], TempLng);
-				
+
 				TempSht = 0x0000;
 				if (! (TempByt & 0x20))
 				{
@@ -1038,7 +1038,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					memcpy(&DstData[DstPos + 0x0B], TempMem->MemData, TempMem->MemMaxOfs);
 				}
 				DstPos += 0x07 + TempLng;
-				
+
 				if (CurChip == 0x05 || CurChip == 0x10)
 				{
 					// make sure that the memory bank register is initialized properly
@@ -1051,18 +1051,18 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			}
 		}
 	}
-	
+
 	for (CurCSet = 0x00; CurCSet < CHIP_SETS; CurCSet ++)
 	{
 		TempCD = (CHIP_DATA*)&RC[CurCSet];
-		
+
 		for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++, TempCD ++)
 		{
 			TempReg = &TempCD->Regs;
-			
+
 			if (! TempReg->RegCount || HARD_SPLIT)
 				continue;
-			
+
 			for (CurReg = 0x00; CurReg < TempReg->RegCount; CurReg ++)
 			{
 				if ((TempReg->RegMask[CurReg] & 0x80) || COMPLETE_REWRITE)
@@ -1070,7 +1070,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				else
 					TempReg->RegMask[CurReg] = 0x00;
 			}
-			
+
 			// CmdType
 			//		10 - 1 Port
 			//		11 - 2 Ports, Port is ORed with Command Byte
@@ -1088,7 +1088,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstData[DstPos + 0x01] = TempReg->RegData.R08[CurReg];
 					DstPos += 0x02;
 				}
-				
+
 				ChipCmd = 0x50 - CurCSet * 0x20;
 				for (CurReg = 0x08; CurReg < 0x10; CurReg ++)
 				{
@@ -1097,7 +1097,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstData[DstPos + 0x00] = ChipCmd;
 						DstData[DstPos + 0x01] = TempReg->RegData.R08[CurReg];
 						DstPos += 0x02;
-						
+
 						TempByt = CurReg & 0x07;
 						if (CurReg < 0x0E && ! (CurReg & 0x01) &&
 							TempReg->RegMask[TempByt])
@@ -1109,7 +1109,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						}
 					}
 				}
-				
+
 				CmdType = 0x00;
 				break;
 			case 0x01:	// YM2413
@@ -1134,13 +1134,13 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					ChipCmd = 0xB0;
 				else if (CurChip == 0x10)
 					ChipCmd = 0xB1;
-				
+
 				TempByt = 0xFF;
 				for (CurReg = 0x00; CurReg < TempReg->RegCount; CurReg ++)
 				{
 					if (CurReg / 0x07 >= 8)
 						break;
-					
+
 					if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 					{
 						if (TempByt != (CurReg / 0x07))
@@ -1151,7 +1151,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 							DstData[DstPos + 0x02] = 0xC0 | TempByt;
 							DstPos += 0x03;
 						}
-						
+
 						DstData[DstPos + 0x00] = ChipCmd;
 						DstData[DstPos + 0x01] = (CurCSet << 7) | (CurReg % 0x07);
 						DstData[DstPos + 0x02] = TempReg->RegData.R08[CurReg];
@@ -1174,7 +1174,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstPos += 0x03;
 					}
 				}
-				
+
 				CmdType = 0x00;
 				break;
 			case 0x06:	// YM2203
@@ -1204,7 +1204,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x0C:	// YMF262
 				ChipCmd = 0x5E + CurCSet * 0x50;
 				CmdType = 0x11;
-				
+
 				CurReg = 0x105;	// OPL3 Enabe
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1214,7 +1214,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstPos += 0x03;
 					TempReg->RegMask[CurReg] = 0x00;
 				}
-				
+
 				CurReg = 0x104;	// 4-Op Mode
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1228,7 +1228,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x0D:	// YMF278B
 				ChipCmd = 0xD0;
 				CmdType = 0x20;
-				
+
 				CurReg = 0x105;	// OPL3 Enabe
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1239,7 +1239,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstPos += 0x04;
 					TempReg->RegMask[CurReg] = 0x00;
 				}
-				
+
 				CurReg = 0x104;	// 4-Op Mode
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1271,7 +1271,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstPos += 0x03;
 					}
 				}
-				
+
 				CmdType = 0x00;
 				break;
 			case 0x12:	// AY8910
@@ -1281,7 +1281,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x13:	// GB DMG
 				ChipCmd = 0xB3;
 				CmdType = 0x12;
-				
+
 				CurReg = 0x16;	// Master Enable must be always written first
 				if ((TempReg->RegMask[CurReg] & 0x01) &&
 					(TempReg->RegData.R08[CurReg] & 0x80))
@@ -1292,7 +1292,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstPos += 0x03;
 					TempReg->RegMask[CurReg] = 0x00;
 				}
-				
+
 				// was completely written / complete write ahead?
 				TempByt = 0x01;
 				for (CurReg = 0x20; CurReg < 0x30; CurReg ++)
@@ -1312,7 +1312,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						TempReg->RegMask[CurReg] = 0x00;
 					}
 				}
-				
+
 				// now write the other control regs
 				for (CurReg = 0x14; CurReg <= 0x15; CurReg ++)
 				{
@@ -1355,7 +1355,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					VGMHead.bytOKI6258Flags &= ~0x03;
 					VGMHead.bytOKI6258Flags |= TempReg->RegData.R08[0x0C] & 0x03;
 				}
-				
+
 				for (CurReg = 0x00; CurReg < 0x03; CurReg ++)
 				{
 					WrtReg = (0x02 + CurReg) % 0x03;	// write in order 02, 00, 01
@@ -1371,7 +1371,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x18:	// OKIM6295
 				ChipCmd = 0xB8;
 				CmdType = 0x12;
-				
+
 				if (! CurCSet &&	// only chip 1 can change the master clock
 					((TempReg->RegMask[0x0B] & 0x7F) == 0x01 ||
 					(TempReg->RegMask[0x0C] & 0x7F) == 0x01))
@@ -1391,7 +1391,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					for (CurReg = 0x08; CurReg <= 0x0C; CurReg ++)
 						TempReg->RegMask[CurReg] = TempReg->RegMask[0x0B];
 				}
-				
+
 				// start with non-NMK112 banking (0F)
 				// then write NMK112 bank enable (0E)
 				for (CurReg = 0x0F; CurReg >= 0x0E; CurReg --)
@@ -1410,7 +1410,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x19:	// K051649
 				ChipCmd = 0xD2;
 				CmdType = 0xFF;
-				
+
 				CurReg = 0xB0;	// Deformation Register
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1421,7 +1421,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstPos += 0x04;
 					TempReg->RegMask[CurReg] = 0x00;
 				}
-				
+
 				for (CurReg = 0x00; CurReg < 0xB0; CurReg ++)
 				{
 					if ((TempReg->RegMask[CurReg] & 0x6F) == 0x01)
@@ -1459,7 +1459,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				break;
 			case 0x1B:	// HuC6280
 				ChipCmd = 0xB9;
-				
+
 				for (CurReg = 0xE5; CurReg < 0xE8; CurReg ++)
 				{
 					if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
@@ -1474,7 +1474,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstPos += 0x03;
 					}
 				}
-				
+
 				for (TempByt = 0x00; TempByt < 0x06; TempByt ++)
 				{
 					CmdType = 0x00;
@@ -1487,7 +1487,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstData[DstPos + 0x02] = TempByt;
 						DstPos += 0x03;
 						CmdType = 0x01;
-						
+
 						// make sure the waveform index is reset
 						DstData[DstPos + 0x00] = ChipCmd;
 						DstData[DstPos + 0x01] = (CurCSet << 7) | 0x04;
@@ -1499,20 +1499,20 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstPos += 0x03;
 						if (TempReg->RegData.R08[WrtReg + 0x02] == 0x00)
 							TempReg->RegMask[WrtReg + 0x02] = 0x00;
-						
+
 						// write actual waveform data
 						for (CurReg = 0x00; CurReg < 0x20; CurReg ++)
 						{
 							if (! (TempReg->RegMask[TempByt * 0x20 + CurReg] & 0x7F))
 								break;
-							
+
 							DstData[DstPos + 0x00] = ChipCmd;
 							DstData[DstPos + 0x01] = (CurCSet << 7) | 0x06;
 							DstData[DstPos + 0x02] = TempReg->RegData.R08[TempByt * 0x20 + CurReg];
 							DstPos += 0x03;
 						}
 					}
-					
+
 					for (TempSht = 0x00; TempSht < 0x05; TempSht ++)
 					{
 						if (TempSht == 0x00)
@@ -1523,7 +1523,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 							CurReg = 0x03;	// Volume
 						else if (TempSht == 0x04)
 							CurReg = 0x02;	// Control
-						
+
 						if ((TempReg->RegMask[WrtReg + CurReg] & 0x7F) == 0x01)
 						{
 							if (! CmdType)
@@ -1535,7 +1535,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 								DstPos += 0x03;
 								CmdType = 0x01;
 							}
-							
+
 							DstData[DstPos + 0x00] = ChipCmd;
 							DstData[DstPos + 0x01] = (CurCSet << 7) | (0x02 + CurReg);
 							DstData[DstPos + 0x02] = TempReg->RegData.R08[WrtReg + CurReg];
@@ -1543,7 +1543,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						}
 					}
 				}
-				
+
 				CurReg = 0xE4;
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1552,7 +1552,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					DstData[DstPos + 0x02] = TempReg->RegData.R08[CurReg];
 					DstPos += 0x03;
 				}
-				
+
 				CmdType = 0x00;
 				break;
 			case 0x1C:	// C140
@@ -1569,7 +1569,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				break;
 			case 0x1F:	// QSound
 				ChipCmd = 0xC4;
-				
+
 				for (CurReg = 0x00; CurReg < TempReg->RegCount; CurReg ++)
 				{
 					if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
@@ -1582,7 +1582,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						DstPos += 0x04;
 					}
 				}
-				
+
 				CmdType = 0xFF;
 				break;
 			case 0x20:	// SCSP
@@ -1600,7 +1600,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x23:	// SAA1099
 				ChipCmd = 0xBD;
 				CmdType = 0x12;
-				
+
 				CurReg = 0x1C;	// All Sound Enable
 				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 				{
@@ -1635,7 +1635,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				CmdType = 0xFF;
 				break;
 			}
-			
+
 			switch(CmdType & 0xF0)
 			{
 			case 0x10:
@@ -1705,7 +1705,7 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 							if ((CurReg & 0xF0) == 0xA0)
 								TempSht = 0xB0 | (CurReg & 0x10F);
 							else	// order for A0..A7 is A4 A0 A5 A1 A6 A2 A7 A3
-								TempSht = 0xA0 | (CurReg & 0x108) | 
+								TempSht = 0xA0 | (CurReg & 0x108) |
 											((CurReg & 0x07) >> 1) |
 											((~CurReg & 0x01) << 2);
 						}
@@ -1741,10 +1741,10 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			}
 		}
 	}
-	
+
 	*DstPosRef = DstPos;
 	*DstDataRef = DstData;
-	
+
 	return;
 }
 
@@ -1752,7 +1752,7 @@ static UINT16 GetChipCommand(UINT8 Command)
 {
 	// Note: returns ChipID only for PSG and YM-chips
 	UINT8 ChipID;
-	
+
 	// Cheat Mode (to use 2 instances of 1 chip)
 	ChipID = 0x00;
 	switch(Command)
@@ -1846,7 +1846,7 @@ static UINT16 GetChipCommand(UINT8 Command)
 		}
 		break;
 	}
-	
+
 	return (ChipID << 8) | (Command << 0);
 }
 
@@ -1856,7 +1856,7 @@ static void HandleDeltaTWrite(CHIP_DATA* ChipData, UINT8 ChipType, UINT16 BaseRe
 	CHIP_MEMORY* TempMem;
 	const UINT8* RegData;
 	UINT8 AddrShift;
-	
+
 	if (Reg < BaseReg || Reg >= BaseReg + 0x10)
 		return;
 	// Handle RAM writes
@@ -1864,10 +1864,10 @@ static void HandleDeltaTWrite(CHIP_DATA* ChipData, UINT8 ChipType, UINT16 BaseRe
 	TempMem = &ChipData->Mem;
 	RegData = &TempReg->RegData.R08[BaseReg];
 	Reg -= BaseReg;
-	
+
 	if ((RegData[0x00] & 0xE0) != 0x60)
 		return;
-	
+
 	if (Reg == 0x00)
 	{
 		if (TempMem->MemData == NULL || ! TempMem->MemSize)
@@ -1905,7 +1905,7 @@ static void HandleDeltaTWrite(CHIP_DATA* ChipData, UINT8 ChipType, UINT16 BaseRe
 		}
 		TempMem->CurAddr ++;
 	}
-	
+
 	return;
 }
 
@@ -1922,14 +1922,14 @@ static UINT32 ReadCommand(UINT8 Mask)
 	CHIP_STATE* TempReg;
 	CHIP_MEMORY* TempMem;
 	UINT32 CmdLen;
-	
+
 	CmdReg = GetChipCommand(VGMData[VGMPos + 0x00]);
 	if (! CmdReg)
 		return 0x00;
-	
+
 	ChipID = (CmdReg & 0x0FF00) >> 8;
 	Command = (CmdReg & 0x00FF) >> 0;
-	
+
 	CmdLen = 0x00;
 	TempChp = NULL;
 	switch(Command)
@@ -1944,7 +1944,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				TempReg->RegData.R08[0x11] = (UINT8)CmdReg;
 			else
 				CmdReg = TempReg->RegData.R08[0x11] & 0x07;
-			
+
 			if (CmdReg < TempReg->RegCount)
 			{
 				TempReg->RegMask[CmdReg] |= Mask;
@@ -1952,7 +1952,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x01];
 			}
 		}
-		
+
 		CmdLen = 0x02;
 		break;
 	case 0x4F:	// GG Stereo
@@ -1965,7 +1965,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 			if (Mask == 0x01)
 				TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x01];
 		}
-		
+
 		CmdLen = 0x02;
 		break;
 	case 0x51:	// YM2413 write
@@ -1987,7 +1987,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 		else if (Command == 0x5D)
 			TempChp = &RC[ChipID].YMZ280B;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			CmdReg = VGMData[VGMPos + 0x01];
@@ -2002,7 +2002,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				}
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0x52:	// YM2612 write port 0
@@ -2022,7 +2022,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 		else if ((Command & 0xFE) == 0x5E)
 			TempChp = &RC[ChipID].YMF262;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			CmdReg = ((Command & 0x01) << 8) | VGMData[VGMPos + 0x01];
@@ -2039,7 +2039,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				}
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0x54:	// YM2151 write
@@ -2052,7 +2052,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				CmdReg = 0xFFFF;
 			else if (CmdReg == 0x19 && (VGMData[VGMPos + 0x02] & 0x80))
 				CmdReg = 0x1A;
-			
+
 			if (CmdReg < TempReg->RegCount)
 			{
 				TempReg->RegMask[CmdReg] |= Mask;
@@ -2060,7 +2060,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0xC0:	// Sega PCM memory write
@@ -2076,7 +2076,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x03];
 			}
 		}
-		
+
 		CmdLen = 0x04;
 		break;
 	case 0xB0:	// RF5C68 register write
@@ -2110,7 +2110,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				TempReg->RegMask[CmdReg] |= Mask;
 				if (Mask == 0x01)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
-				
+
 				CmdReg ^= 0x01;	// force Chip Enable for both regs
 				TempReg->RegData.R08[CmdReg] |= VGMData[VGMPos + 0x02] & 0x80;
 			}
@@ -2122,7 +2122,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0xC3:	// MultiPCM bank write
@@ -2157,7 +2157,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 		else if (Command == 0xC8)
 			TempChp = &RC[ChipID].X1_010;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			CmdReg = ((VGMData[VGMPos + 0x01] & 0x7F) << 8) | VGMData[VGMPos + 0x02];
@@ -2178,7 +2178,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 							TempMem->CurAddr &= 0x3FFFFF;
 							if (TempReg->RegData.R08[0x202] & 0x02)
 								printf("Warning: OPL4 in Mem Mode 1! Please report!\n");
-							
+
 							// subtract ROM size (results in intended overflow for ROM offsets)
 							TempMem->CurAddr -= TempMem->StopAddr;
 						}
@@ -2197,14 +2197,14 @@ static UINT32 ReadCommand(UINT8 Mask)
 				}
 			}
 		}
-		
+
 		CmdLen = 0x04;
 		break;
 	case 0xD2:	// SCC1 write
 		ChipID = VGMData[VGMPos + 0x01] >> 7;
 		TempChp = &RC[ChipID].K051649;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			CmdReg = VGMData[VGMPos + 0x01] & 0x7F;
@@ -2235,7 +2235,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				}
 			}
 		}
-		
+
 		CmdLen = 0x04;
 		break;
 	case 0xB2:	// PWM register write
@@ -2252,7 +2252,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 													(VGMData[VGMPos + 0x02] << 0);
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0xA0:	// AY8910 write
@@ -2293,7 +2293,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 		else if (Command == 0xBF)
 			TempChp = &RC[ChipID].GA20;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			CmdReg = VGMData[VGMPos + 0x01] & 0x7F;
@@ -2304,14 +2304,14 @@ static UINT32 ReadCommand(UINT8 Mask)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0xB9:	// HuC6280 write
 		ChipID = VGMData[VGMPos + 0x01] >> 7;
 		TempChp = &RC[ChipID].HuC6280;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			// 00-BF - Waveform RAM
@@ -2335,7 +2335,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 					CmdReg = 0xFFFF;
 					break;
 				}
-				
+
 				ChnReg = 0xC0 + TempReg->RegData.R08[0xE4] * 0x06;
 				if (CmdReg == 0x04)
 				{
@@ -2370,7 +2370,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 				CmdReg = 0xFFFF;
 				break;
 			}
-			
+
 			if (CmdReg < TempReg->RegCount)
 			{
 				TempReg->RegMask[CmdReg] |= Mask;
@@ -2378,13 +2378,13 @@ static UINT32 ReadCommand(UINT8 Mask)
 					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
 			}
 		}
-		
+
 		CmdLen = 0x03;
 		break;
 	case 0xC4:	// Q-Sound write
 		TempChp = &RC[ChipID].QSound;
 		TempReg = &TempChp->Regs;
-		
+
 		if (TempReg->RegCount)
 		{
 			CmdReg = VGMData[VGMPos + 0x03];
@@ -2396,7 +2396,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 													(VGMData[VGMPos + 0x02] << 0);
 			}
 		}
-		
+
 		CmdLen = 0x04;
 		break;
 	case 0xBE:	// ES5506 write (8-bit data)
@@ -2407,7 +2407,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 		break;
 	}
 	CommandCheck(0x00, Command, TempChp, CmdReg);
-	
+
 	return CmdLen;
 }
 
@@ -2420,21 +2420,21 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 	UINT8 CurChn;
 	UINT8 KeyOnOff;
 	UINT16 TempSht;
-	
+
 	if (ChpData == NULL)
 		return;
 	TempReg = &ChpData->Regs;
 	TempChn = &ChpData->Chns;
 	if (! TempChn->ChnCount)
 		return;
-	
+
 	switch(Command)
 	{
 	case 0x50:	// SN76496 write
 		CmdReg &= ~0x09;
 		CurChn = (CmdReg & 0x06) >> 1;
 		KeyOnOff = 0x00;
-		
+
 		if (CurChn < 3)	// not on noise channel
 		{
 			// test Frequency
@@ -2446,7 +2446,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		// test volume
 		if ((TempReg->RegData.R08[CmdReg | 0x09] & 0x0F) == 0x0F)
 			KeyOnOff |= 0x01;	// volume 0 - key off
-		
+
 		KeyOnOff = ! KeyOnOff;
 		TempChn->ChnMask &= ~(1 << CurChn);
 		TempChn->ChnMask |= (KeyOnOff << CurChn);
@@ -2467,7 +2467,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		{
 			CurChn = 9 + 5;	// 9 FM + 5 Rhythm
 			KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-			
+
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}
@@ -2510,7 +2510,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		{
 			CurChn = TempReg->RegData.R08[CmdReg] & 0x07;
 			KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x78) ? 0x01 : 0x00;
-			
+
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}
@@ -2520,7 +2520,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		{
 			CurChn = (CmdReg >> 3) & 0x0F;
 			KeyOnOff = TempReg->RegData.R08[CmdReg] & 0x01;
-			
+
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}
@@ -2539,7 +2539,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		{
 			CurChn = (CmdReg & 0x1C) >> 2;
 			KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-			
+
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}
@@ -2557,7 +2557,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			{
 				CurChn = CmdReg - 0x68;
 				KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-				
+
 				TempChn->ChnMask2 &= ~(1 << CurChn);
 				TempChn->ChnMask2 |= (KeyOnOff << CurChn);
 			}
@@ -2584,7 +2584,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			TempSht = ~TempReg->RegData.R08[0x07] & 0x3F;
 			CurChn = CmdReg - 0x08;
 			KeyOnOff = TempReg->RegData.R08[CmdReg] ? 0x09 : 0;
-			
+
 			TempChn->ChnMask &= ~(0x09 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn) & TempSht;
 		}
@@ -2596,7 +2596,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			{
 				CurChn = CmdReg / 0x05;
 				KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-				
+
 				// just ORs the enable-bit, doesn't reset it
 				TempChn->ChnMask |= (KeyOnOff << CurChn);
 			}
@@ -2604,7 +2604,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			{
 				CurChn = CmdReg / 0x05;
 				KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-				
+
 				TempChn->ChnMask &= ~(1 << CurChn);
 				TempChn->ChnMask |= (KeyOnOff << CurChn);
 			}
@@ -2615,7 +2615,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		{
 			TempChn->ChnMask = TempReg->RegData.R08[0x15] & 0x1F;
 		}
-		
+
 		break;
 	case 0xB9:	// HuC6280 write
 		if (CmdReg >= 0xC0 && CmdReg <= 0xE3)
@@ -2625,7 +2625,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			{
 				CurChn = TempSht / 0x06;
 				KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-				
+
 				TempChn->ChnMask &= ~(1 << CurChn);
 				TempChn->ChnMask |= (KeyOnOff << CurChn);
 			}
@@ -2645,7 +2645,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 					KeyOnOff = 0x00;	// frequency 0
 				else if (! TempReg->RegData.R16[TempSht | 0x06])
 					KeyOnOff = 0x00;	// volume 0
-				
+
 				TempChn->ChnMask &= ~(1 << CurChn);
 				TempChn->ChnMask |= (KeyOnOff << CurChn);
 			}
@@ -2663,7 +2663,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			{
 				CurChn = TempSht >> 4;
 				KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
-				
+
 				TempChn->ChnMask &= ~(1 << CurChn);
 				TempChn->ChnMask |= (KeyOnOff << CurChn);
 			}
@@ -2691,7 +2691,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			TempSht = TempReg->RegData.R08[0x14] | TempReg->RegData.R08[0x15];
 			CurChn = CmdReg & 0x07;
 			KeyOnOff = TempReg->RegData.R08[CmdReg] ? 1 : 0;
-			
+
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn) & TempSht;
 		}
@@ -2709,7 +2709,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 	case 0xBF:	// GA20 write
 		break;
 	}
-	
+
 	return;
 }
 
@@ -2718,7 +2718,7 @@ static void CmdChk_OPL(CHIP_CHNS* ChnState, UINT8 OPLMode, UINT16 CmdReg, UINT8 
 	UINT16 RhythmReg;
 	UINT8 CurChn;
 	UINT8 KeyOnOff;
-	
+
 	if (OPLMode == 'L')
 	{
 		// OPLL register order
@@ -2732,11 +2732,11 @@ static void CmdChk_OPL(CHIP_CHNS* ChnState, UINT8 OPLMode, UINT16 CmdReg, UINT8 
 			return;
 		RhythmReg = 0xBD;
 	}
-	
+
 	if (CmdReg == RhythmReg)
 	{
 		CurChn = (OPLMode == '3') ? 18 : 9;	// base channel for drums
-		
+
 		// Rhythm Off: disable all, Rhythm On: use mask
 		KeyOnOff = (Data & 0x20) ? (Data & 0x1F) : 0x00;
 		ChnState->ChnMask &= ~(0x1F << CurChn);
@@ -2749,11 +2749,11 @@ static void CmdChk_OPL(CHIP_CHNS* ChnState, UINT8 OPLMode, UINT16 CmdReg, UINT8 
 			KeyOnOff = (Data & 0x10) >> 4;
 		else
 			KeyOnOff = (Data & 0x20) >> 5;
-		
+
 		ChnState->ChnMask &= ~(1 << CurChn);
 		ChnState->ChnMask |= (KeyOnOff << CurChn);
 	}
-	
+
 	return;
 }
 
@@ -2763,7 +2763,7 @@ static void CmdChk_OPN(CHIP_CHNS* ChnState, UINT8 OPNMode, UINT16 CmdReg, UINT8 
 	UINT16 ADPCMReg;
 	UINT8 CurChn;
 	UINT8 KeyOnOff;
-	
+
 	if (OPNMode == 'A')
 	{
 		ADPCMReg = 0x010;
@@ -2779,14 +2779,14 @@ static void CmdChk_OPN(CHIP_CHNS* ChnState, UINT8 OPNMode, UINT16 CmdReg, UINT8 
 		ADPCMReg = 0x00;
 		DeltaTReg = 0x00;
 	}
-	
+
 	if (CmdReg == 0x028)	// OPN Key On/Off
 	{
 		CurChn = Data & 0x03;
 		if (OPNMode != 0)	// all but YM2203: enable channels 3-5
 			CurChn += ((Data & 0x04) / 0x04 * 3);
 		KeyOnOff = (Data & 0xF0) ? 0x01 : 0x00;
-		
+
 		ChnState->ChnMask &= ~(1 << CurChn);
 		ChnState->ChnMask |= (KeyOnOff << CurChn);
 	}
@@ -2815,11 +2815,11 @@ static void CmdChk_OPN(CHIP_CHNS* ChnState, UINT8 OPNMode, UINT16 CmdReg, UINT8 
 	{
 		CurChn = 6 + 6;	// 6 FM + 6 ADPCM
 		KeyOnOff = (Data & 0x80) >> 7;
-		
+
 		ChnState->ChnMask &= ~(1 << CurChn);
 		ChnState->ChnMask |= (KeyOnOff << CurChn);
 	}
-	
+
 	return;
 }
 
@@ -2855,13 +2855,13 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 	bool ForceCmdWrite;
 	const UINT8* TempData;
 	UINT32 DataStart;
-	
+
 	// +0x100 - Make sure to have enough room for additional delays
 	DstDataLen = VGMDataLen + 0x100;
 	CmdDelay = 0;
 	VGMPos = VGMHead.lngDataOffset;
 	DstPos = VGMHead.lngDataOffset;
-	
+
 	switch(HasLoop)
 	{
 	case 0x00:	// No Loop
@@ -2875,24 +2875,24 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 		break;
 	}
 	EndSmplA = EndSmpl + (KeepESmpl ? 1 : 0);
-	
+
 	PrepareChipMemory();
 	SetImportantCommands();
-	
+
 	for (ChipID = 0x00; ChipID < CHIP_SETS; ChipID ++)
 	{
 		TempCD = (CHIP_DATA*)&RC[ChipID];
-		
+
 		for (TempByt = 0x00; TempByt < CHIP_COUNT; TempByt ++, TempCD ++)
 		{
 			DstDataLen += TempCD->Mem.MemSize;
 		}
 		RC[ChipID].YMF278B.Mem.StopAddr = 0x200000;	// default ROM size is 2 MB
 	}
-	
+
 	if (DstData == NULL)	// now allocate memory, if needed
 		DstData = (UINT8*)malloc(DstDataLen);
-	
+
 #ifdef SHOW_PROGRESS
 	CmdTimer = 0;
 #endif
@@ -2901,7 +2901,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 	StopVGM = false;
 	DlyToWrt = false;
 	WriteMode = 0x00;
-	
+
 	CmdLen = 0x00;
 	CmdDelay = 0x00;
 	DelayOff = false;
@@ -2912,7 +2912,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 		//       This is intentional, because the first sample requires to check the VGM start sample
 		//       before the first command is read. In all other cases, the check must occour between
 		//       reading the command and copying it to the trimmed file.
-		
+
 		// --- Loop Part 2: Trimming ---
 		switch(WriteMode)
 		{
@@ -2920,12 +2920,12 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 			if (VGMSmplPos >= StartSmpl)
 			{
 				// Beginn to write to trimmed vgm
-				
+
 				// Rewrite neccessary commands
 				VGMReadAhead(VGMPos + CmdLen, 2 * 44100);	// Read 2 seconds ahead
-				
+
 				InitializeVGM(&DstData, &DstPos);
-				
+
 				CmdDelay = VGMSmplPos - StartSmpl;	// queue Initial Delay
 				if (CmdDelay & 0x80000000)	// if CmdDelay < 0 for unsigned
 				{
@@ -2933,7 +2933,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 					CmdDelay = 0x00;
 				}
 				DlyToWrt = true;
-				
+
 				DelayOff = true;
 				WriteMode = 0x01;
 			}
@@ -2961,9 +2961,9 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 						TempLng = 0x00;
 					}
 					VGMLib_WriteDelay(DstData, &DstPos, TempLng, NULL);
-					
+
 					LoopPos = DstPos;
-					
+
 					CmdDelay = VGMSmplPos - LoopSmplA;	// queue Delay after Loop
 					if (CmdDelay & 0x80000000)	// CmdDelay overflow check
 					{
@@ -2988,7 +2988,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 					VGMLib_WriteDelay(DstData, &DstPos, TempLng, NULL);
 					DstData[DstPos] = 0x66;
 					DstPos ++;
-					
+
 					if (HasLoop)
 					{
 						WriteVGMHeader(DstData, VGMData, DstPos, EndSmpl - StartSmpl,
@@ -3001,7 +3001,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 						WriteVGMHeader(DstData, VGMData, DstPos, EndSmpl - StartSmpl,
 										0x00, 0x00);
 					}
-					
+
 					StopVGM = true;
 					WriteMode = 0x02;
 					break;
@@ -3011,7 +3011,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 					IsDelay = false;
 				}
 			}
-			
+
 			if (DlyToWrt)
 			{
 				// write remaining delays ("left-overs" from Start and Loop Start)
@@ -3030,7 +3030,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 		VGMPos += CmdLen;
 		if (StopVGM)
 			break;
-		
+
 		// --- Loop Part 1: Reading a Command ---
 		CmdDelay = 0x00;
 		DelayOff = false;
@@ -3062,7 +3062,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 			CmdLen = ReadCommand(0x01);
 			if (! CmdLen)
 			{
-			
+
 			ChipID = 0x00;
 			switch(Command)
 			{
@@ -3094,10 +3094,10 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 			case 0x67:	// PCM Data Stream
 				TempByt = VGMData[VGMPos + 0x02];
 				TempLng = ReadLE32(&VGMData[VGMPos + 0x03]);
-				
+
 				ChipID = (TempLng & 0x80000000) >> 31;
 				TempLng &= 0x7FFFFFFF;
-				
+
 				switch(TempByt & 0xC0)
 				{
 				case 0x00:	// Database Block
@@ -3111,7 +3111,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 						UINT32 ROMSize;
 						UINT32 DataStart;
 						UINT32 DataLen;
-						
+
 						TempMem = NULL;
 						if (TempByt == 0x81)	// YM2608 DeltaT RAM
 							TempMem = &RC[ChipID].YM2608.Mem;
@@ -3124,7 +3124,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 						ROMSize = ReadLE32(&VGMData[VGMPos + 0x07]);
 						DataStart = ReadLE32(&VGMData[VGMPos + 0x0B]);
 						DataLen = TempLng - 0x08;
-						
+
 						if (TempMem->MemData == NULL || TempMem->MemSize != ROMSize)
 						{
 							TempMem->MemSize = ROMSize;
@@ -3199,7 +3199,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 								DataStart = 0x8000;
 								CmdLen -= TempSht;
 							}
-							
+
 							DataStart &= 0x7FFF;
 							memcpy(&TempMem->MemData[DataStart], TempData, CmdLen);
 							if (DataStart + CmdLen > TempMem->MemMaxOfs)
@@ -3258,7 +3258,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 				TempSht = (VGMData[VGMPos + 0x01] << 8) | (VGMData[VGMPos + 0x02] << 0);
 				ChipID = (TempSht & 0x8000) >> 15;
 				TempSht &= 0x7FFF;
-				
+
 				TempMem = &RC[ChipID].WSwan.Mem;
 				if (TempMem->MemSize)
 				{
@@ -3321,10 +3321,10 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 				}
 				break;
 			}	// end switch(Command)
-			
+
 			}	// end if (! CmdLen)
 		}
-		
+
 #ifdef SHOW_PROGRESS
 		if (CmdTimer < GetTickCount())
 		{
@@ -3338,11 +3338,11 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 		}
 #endif
 	}
-	
+
 	for (ChipID = 0x00; ChipID < CHIP_SETS; ChipID ++)
 	{
 		TempCD = (CHIP_DATA*)&RC[ChipID];
-		
+
 		for (TempByt = 0x00; TempByt < CHIP_COUNT; TempByt ++, TempCD ++)
 		{
 			if (TempCD->Regs.RegData.R08 != NULL)
@@ -3353,7 +3353,7 @@ void TrimVGMData(const INT32 StartSmpl, const INT32 LoopSmpl, const INT32 EndSmp
 				free(TempCD->Mem.MemData);
 		}
 	}
-	
+
 	return;
 }
 
@@ -3365,7 +3365,7 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 	UINT32 DstPos;
 	UINT32 CmdLen;
 	UINT32 TempLng;
-	
+
 	memcpy(DstData, VGMData, VGMHead.lngDataOffset);	// Copy Header
 	WriteLE32(&DstData[0x18], SampleCount);
 	TempLng = LoopPos;
@@ -3384,7 +3384,7 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 		// rewrite OKIM6295 clock
 		WriteLE32(&DstData[0x98], VGMHead.lngHzOKIM6295);
 	}
-	
+
 	DstPos = EOFPos;
 	if (VGMHead.lngGD3Offset && VGMHead.lngGD3Offset + 0x0B < VGMHead.lngEOFOffset)
 	{
@@ -3394,18 +3394,18 @@ static void WriteVGMHeader(UINT8* DstData, const UINT8* SrcData, const UINT32 EO
 		{
 			CmdLen = ReadLE32(&VGMData[CurPos + 0x08]);
 			CmdLen += 0x0C;
-			
+
 			TempLng = DstPos - 0x14;
 			WriteLE32(&DstData[0x14], TempLng);
 			memcpy(&DstData[DstPos], &VGMData[CurPos], CmdLen);	// Copy GD3 Tag
 			DstPos += CmdLen;
 		}
 	}
-	
+
 	DstDataLen = DstPos;
 	TempLng = DstDataLen - 0x04;
 	WriteLE32(&DstData[0x04], TempLng);	// Write EOF Position
-	
+
 	return;
 }
 
@@ -3423,10 +3423,10 @@ static void VGMReadAhead(const UINT32 StartPos, const UINT32 Samples)
 	//UINT16 CmdReg;
 	//UINT8* TempPnt;
 	bool StopVGM;
-	
+
 	if (COMPLETE_REWRITE || VGMTOOL_TRIM)
 		return;
-	
+
 	CurPos = StartPos;
 	CurSmpl = 0x00;
 	StopVGM = false;
@@ -3434,7 +3434,7 @@ static void VGMReadAhead(const UINT32 StartPos, const UINT32 Samples)
 	{
 		CmdLen = 0x00;
 		Command = VGMData[CurPos + 0x00];
-		
+
 		if (Command >= 0x70 && Command <= 0x8F)
 		{
 			switch(Command & 0xF0)
@@ -3455,7 +3455,7 @@ static void VGMReadAhead(const UINT32 StartPos, const UINT32 Samples)
 			CmdLen = ReadCommand(0x02);
 			if (! CmdLen)
 			{
-			
+
 			switch(Command)
 			{
 			case 0x66:	// End Of File
@@ -3540,7 +3540,7 @@ static void VGMReadAhead(const UINT32 StartPos, const UINT32 Samples)
 				}
 				break;
 			}
-			
+
 			}
 		}
 		CurPos += CmdLen;
@@ -3549,7 +3549,7 @@ static void VGMReadAhead(const UINT32 StartPos, const UINT32 Samples)
 		if (StopVGM)
 			break;
 	}
-	
+
 	return;
 }
 
@@ -3561,13 +3561,13 @@ static void DisplayPlayingNoteWarning(void)
 	CHIP_CHNS* TempChn;
 	char ChnStr[0x80];	// enough space for 32+ channels
 	bool DidWarn;
-	
+
 	DidWarn = false;
 	// go through all chips and check for playing notes ...
 	for (CurCSet = 0x00; CurCSet < CHIP_SETS; CurCSet ++)
 	{
 		TempCD = (CHIP_DATA*)&RC[CurCSet];
-		
+
 		for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++, TempCD ++)
 		{
 			TempChn = &TempCD->Chns;
@@ -3578,14 +3578,14 @@ static void DisplayPlayingNoteWarning(void)
 					printf("Warning: Notes playing after EOF!\n");
 					DidWarn = true;
 				}
-				
+
 				ShowPlayingNotes(CHIP_STRS[CurChip], TempChn->ChnCount, TempChn->ChnMask, ChnStr, TempChn->unsafeKey);
 				if (TempChn->ChnCount2)
 					ShowPlayingNotes(CHIP_STRS2[CurChip], TempChn->ChnCount2, TempChn->ChnMask2, ChnStr, TempChn->unsafeKey);
 			}
 		}
 	}
-	
+
 	return;
 }
 
@@ -3594,7 +3594,7 @@ static void ShowPlayingNotes(const char* ChipStr, UINT16 ChnCount, UINT32 ChnMas
 	char* ChnPtr;
 	UINT16 CurChn;
 	UINT16 PlayChnCnt;
-	
+
 	ChnPtr = Buffer;
 	PlayChnCnt = 0x00;
 	for (CurChn = 0x00; CurChn < ChnCount; CurChn ++)
@@ -3608,10 +3608,10 @@ static void ShowPlayingNotes(const char* ChipStr, UINT16 ChnCount, UINT32 ChnMas
 	if (! PlayChnCnt)
 		return;
 	ChnPtr[-2] = '\0';	// strip last ", "
-	
+
 	printf("%s: %u channel%s %splaying (%s)\n", ChipStr, PlayChnCnt, unsafe ? "possibly " : "",
 			(PlayChnCnt != 1) ? "s" : "", Buffer);
-	
+
 	return;
 }
 

--- a/vgm_vol.c
+++ b/vgm_vol.c
@@ -40,7 +40,7 @@ static void PrintVolMod(UINT16 MaxLvl);
 #endif
 
 
-float RecVolume;	// usually 1.0 or 0.5 
+float RecVolume;	// usually 1.0 or 0.5
 UINT32 VGMDataLen;
 char FilePath[MAX_PATH];
 char* FileTitle;
@@ -57,12 +57,12 @@ int main(int argc, char* argv[])
 	char* FileExt;
 	bool PLMode;
 #endif
-	
+
 	printf("VGM Volume Detector\n-------------------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 1;
-	
+
 #ifdef WIN32
 	printf("File Path or PlayList:\t");
 #else
@@ -79,7 +79,7 @@ int main(int argc, char* argv[])
 	}
 	if (! strlen(FileName))
 		return 0;
-	
+
 	printf("Volume Setting (default 1.0):\t");
 	if (argc <= argbase + 1)
 	{
@@ -93,10 +93,10 @@ int main(int argc, char* argv[])
 	RecVolume = (float)strtod(InputStr, NULL);
 	if (RecVolume == 0.0f)
 		RecVolume = 1.0f;
-	
+
 #ifdef WIN32
 	PLMode = false;
-	
+
 	if (FileName[strlen(FileName - 0x01)] != '\\')
 	{
 		if (! (GetFileAttributes(FileName) & FILE_ATTRIBUTE_DIRECTORY))
@@ -104,7 +104,7 @@ int main(int argc, char* argv[])
 			FileExt = strrchr(FileName, '.');
 			if (FileExt < strrchr(FileName, '\\'))
 				FileExt = NULL;
-			
+
 			if (FileExt != NULL)
 			{
 				FileExt ++;
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
 			strcat(FileName, "\\");
 		}
 	}
-	
+
 	MaxLvlAlbum = 0x0000;
 	IsPlayList = PLMode;
 	if (! PLMode)
@@ -130,14 +130,14 @@ int main(int argc, char* argv[])
 	IsPlayList = true;
 	ReadPlaylist(FileName);
 #endif
-	
+
 	printf("\nAll tracks\t");
 	PrintVolMod(MaxLvlAlbum);
 	printf("\n");
-	
+
 //EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -150,7 +150,7 @@ static void ReadWAVFile(const char* FileName)
 	INT16 TempSSht;
 	UINT32 TempLng;
 	UINT16 MaxLvl;
-	
+
 	printf("%s\t", FileTitle);
 	hFile = fopen(FileName, "rb");
 	if (hFile == NULL)
@@ -158,7 +158,7 @@ static void ReadWAVFile(const char* FileName)
 		printf("Error opening file!\n");
 		return;
 	}
-	
+
 	fseek(hFile, 0x00, SEEK_SET);
 	fread(&fccHeader, 0x04, 0x01, hFile);
 	if (fccHeader != FCC_RIFF)
@@ -167,7 +167,7 @@ static void ReadWAVFile(const char* FileName)
 		goto OpenErr;
 	}
 	fread(&TempLng, 0x04, 0x01, hFile);
-	
+
 	fread(&fccHeader, 0x04, 0x01, hFile);
 	if (fccHeader != FCC_WAVE)
 	{
@@ -181,7 +181,7 @@ static void ReadWAVFile(const char* FileName)
 		goto OpenErr;
 	}
 	fread(&TempLng, 0x04, 0x01, hFile);	// get format tag length
-	
+
 	// read format data
 	CurPos = ftell(hFile);
 	fread(&TempSht, 0x02, 0x01, hFile);
@@ -198,21 +198,21 @@ static void ReadWAVFile(const char* FileName)
 		goto OpenErr;
 	}
 	fseek(hFile, CurPos + TempLng, SEEK_SET);
-	
+
 	// read data
 	fread(&fccHeader, 0x04, 0x01, hFile);
 	while(fccHeader != FCC_data)
 	{
 		fread(&TempLng, 0x04, 0x01, hFile);
 		fseek(hFile, TempLng, SEEK_CUR);
-		
+
 		if (! fread(&fccHeader, 0x04, 0x01, hFile))
 		{
 			printf("Unable to find wave data!\n");
 			goto OpenErr;
 		}
 	}
-	
+
 	fread(&TempLng, 0x04, 0x01, hFile);	// get data length
 	CurPos = 0x00;
 	MaxLvl = 0x0000;
@@ -221,7 +221,7 @@ static void ReadWAVFile(const char* FileName)
 		if (! fread(&TempSSht, 0x02, 0x01, hFile))
 			break;	// early file end
 		CurPos += 0x02;
-		
+
 		if (abs(TempSSht) > MaxLvl)
 		{
 			MaxLvl = abs(TempSSht);
@@ -232,13 +232,13 @@ static void ReadWAVFile(const char* FileName)
 			}
 		}
 	}
-	
+
 	fclose(hFile);
-	
+
 	PrintVolMod(MaxLvl);
 	if (MaxLvl > MaxLvlAlbum)
 		MaxLvlAlbum = MaxLvl;
-	
+
 	return;
 
 OpenErr:
@@ -251,13 +251,13 @@ static void PrintVolMod(UINT16 MaxLvl)
 {
 	float Factor;
 	INT16 VolMod;
-	
+
 	if (! MaxLvl)
 	{
 		printf("--\n");
 		return;
 	}
-	
+
 	Factor = (float)0x8000 / MaxLvl * RecVolume;
 	if (Factor < 0.25f)
 		Factor = 0.25f;
@@ -268,7 +268,7 @@ static void PrintVolMod(UINT16 MaxLvl)
 		VolMod = -0x003F;
 	VolMod &= 0xFF;
 	printf("MaxLevel: %04X\tFactor: %.3f\tVolMod: 0x%02X\n", MaxLvl, Factor, VolMod);
-	
+
 	return;
 }
 
@@ -281,12 +281,12 @@ static void ReadDirectory(const char* DirName)
 	char FileName[MAX_PATH];
 	char* TempPnt;
 	char* FileExt;
-	
+
 	strcpy(FilePath, DirName);
 	TempPnt = strrchr(FilePath, '\\');
 	if (TempPnt == NULL)
 		strcpy(FilePath, "");
-	
+
 	TempPnt = strrchr(FilePath, '\\');
 	if (TempPnt != NULL)
 		TempPnt[0x01] = 0x00;
@@ -302,31 +302,31 @@ static void ReadDirectory(const char* DirName)
 	}
 	strcpy(FileName, FilePath);
 	TempPnt = FileName + strlen(FileName);
-	
+
 	do
 	{
 		if (FindFileData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
 			goto SkipFile;
-		
+
 		FileExt = strrchr(FindFileData.cFileName, '.');
 		if (FileExt == NULL)
 			goto SkipFile;
 		FileExt ++;
-		
+
 		if (stricmp(FileExt, "wav"))
 			goto SkipFile;
-		
+
 		strcpy(TempPnt, FindFileData.cFileName);
 		FileTitle = TempPnt;
 		ReadWAVFile(FileName);
-		
+
 SkipFile:
 		RetVal = FindNextFile(hFindFile, &FindFileData);
 	}
 	while(RetVal);
-	
+
 	RetVal = FindClose(hFindFile);
-	
+
 	return;
 }
 #endif
@@ -336,14 +336,14 @@ static void ReadPlaylist(const char* FileName)
 	const char M3UV2_HEAD[] = "#EXTM3U";
 	const char M3UV2_META[] = "#EXTINF:";
 	UINT32 METASTR_LEN;
-	
+
 	FILE* hFile;
 	UINT32 LineNo;
 	bool IsV2Fmt;
 	char TempStr[MAX_PATH];
 	char FileVGM[MAX_PATH];
 	char* RetStr;
-	
+
 	RetStr = strrchr(FileName, '\\');
 	if (RetStr != NULL)
 	{
@@ -356,11 +356,11 @@ static void ReadPlaylist(const char* FileName)
 	{
 		strcpy(FilePath, "");
 	}
-	
+
 	hFile = fopen(FileName, "rt");
 	if (hFile == NULL)
 		return;
-	
+
 	LineNo = 0x00;
 	IsV2Fmt = false;
 	METASTR_LEN = strlen(M3UV2_META);
@@ -380,7 +380,7 @@ static void ReadPlaylist(const char* FileName)
 		}
 		if (! strlen(TempStr))
 			continue;
-		
+
 		if (! LineNo)
 		{
 			if (! strcmp(TempStr, M3UV2_HEAD))
@@ -399,11 +399,11 @@ static void ReadPlaylist(const char* FileName)
 				continue;
 			}
 		}
-		
+
 		RetStr = strrchr(TempStr, '.');
 		if (RetStr != NULL)
 			strcpy(RetStr + 1, "wav");
-		
+
 		strcpy(FileVGM, FilePath);
 		strcat(FileVGM, TempStr);
 		RetStr = strrchr(TempStr, '\\');
@@ -412,12 +412,12 @@ static void ReadPlaylist(const char* FileName)
 		else
 			RetStr ++;
 		FileTitle = RetStr;
-		
+
 		ReadWAVFile(FileVGM);
 		LineNo ++;
 	}
-	
+
 	fclose(hFile);
-	
+
 	return;
 }

--- a/vgmmerge.c
+++ b/vgmmerge.c
@@ -91,12 +91,12 @@ int main(int argc, char* argv[])
 	char FileName[0x100];
 	UINT8 FileNo;
 	UINT32 TempLng;
-	
+
 	printf("VGM Merger\n----------\n\n");
-	
+
 	ErrVal = 0;
 	argbase = 0;
-	
+
 	argbase = 1;
 	while(argbase < argc && argv[argbase][0] == '-')
 	{
@@ -128,7 +128,7 @@ int main(int argc, char* argv[])
 		}
 	}
 	SrcVGM = (VGM_INF*)malloc(MAX_VGMS * sizeof(VGM_INF));
-	
+
 	for (FileNo = 0x00; FileNo < MAX_VGMS; FileNo ++)
 	{
 		printf("File #%u:\t", FileNo + 1);
@@ -143,7 +143,7 @@ int main(int argc, char* argv[])
 		}
 		if (! strlen(FileName))
 			return 0;
-		
+
 		if (! OpenVGMFile(FileName, FileNo))
 		{
 			printf("Error opening the file!\n");
@@ -158,9 +158,9 @@ int main(int argc, char* argv[])
 		}
 	}
 	printf("\n");
-	
+
 	MergeVGMData();
-	
+
 	if (argc > argbase + MAX_VGMS)
 		strcpy(FileName, argv[argbase + MAX_VGMS]);
 	else
@@ -171,14 +171,14 @@ int main(int argc, char* argv[])
 		strcat(FileName, "_merged.vgm");
 	}
 	WriteVGMFile(FileName);
-	
+
 	for (FileNo = 0x00; FileNo < MAX_VGMS; FileNo ++)
 		free(SrcVGM[FileNo].Data);
 	free(DstData);
-	
+
 EndProgram:
 	DblClickWait(argv[0]);
-	
+
 	return ErrVal;
 }
 
@@ -189,20 +189,20 @@ static bool OpenVGMFile(const char* FileName, const UINT8 VgmNo)
 	VGM_HEADER VGMHead;
 	UINT32 CurPos;
 	char* TempPnt;
-	
+
 	hFile = gzopen(FileName, "rb");
 	if (hFile == NULL)
 		return false;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &TempLng, 0x04);
 	if (TempLng != FCC_VGM)
 		goto OpenErr;
-	
+
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, &VGMHead, sizeof(VGM_HEADER));
 	ZLIB_SEEKBUG_CHECK(VGMHead);
-	
+
 	// Header preperations
 	if (VGMHead.lngVersion < 0x00000101)
 	{
@@ -234,7 +234,7 @@ static bool OpenVGMFile(const char* FileName, const UINT8 VgmNo)
 	if (! VGMHead.lngDataOffset)
 		VGMHead.lngDataOffset = 0x0000000C;
 	VGMHead.lngDataOffset += 0x00000034;
-	
+
 	CurPos = VGMHead.lngDataOffset;
 	if (VGMHead.lngVersion < 0x00000150)
 		CurPos = 0x40;
@@ -244,7 +244,7 @@ static bool OpenVGMFile(const char* FileName, const UINT8 VgmNo)
 	else
 		TempLng = 0x00;
 	memset((UINT8*)&VGMHead + CurPos, 0x00, TempLng);
-	
+
 	// Read Data
 	SrcVGM[VgmNo].DataLen = VGMHead.lngEOFOffset;
 	SrcVGM[VgmNo].Data = (UINT8*)malloc(SrcVGM[VgmNo].DataLen);
@@ -253,9 +253,9 @@ static bool OpenVGMFile(const char* FileName, const UINT8 VgmNo)
 	gzseek(hFile, 0x00, SEEK_SET);
 	gzread(hFile, SrcVGM[VgmNo].Data, SrcVGM[VgmNo].DataLen);
 	SrcVGM[VgmNo].Head = VGMHead;
-	
+
 	gzclose(hFile);
-	
+
 	if (! VgmNo)
 	{
 		strcpy(FileBase, FileName);
@@ -263,7 +263,7 @@ static bool OpenVGMFile(const char* FileName, const UINT8 VgmNo)
 		if (TempPnt != NULL)
 			*TempPnt = 0x00;
 	}
-	
+
 	return true;
 
 OpenErr:
@@ -275,13 +275,13 @@ OpenErr:
 static void WriteVGMFile(const char* FileName)
 {
 	FILE* hFile;
-	
+
 	hFile = fopen(FileName, "wb");
 	fwrite(DstData, 0x01, DstDataLen, hFile);
 	fclose(hFile);
-	
+
 	printf("File written.\n");
-	
+
 	return;
 }
 
@@ -296,14 +296,14 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 	UINT32* DstClock;
 	bool DualSupport;
 	CHIP_MAP* TempMap;
-	
+
 	if (DstHead->lngVersion != SrcHead->lngVersion)
 	{
 		printf("Warning! Merging VGM files with different versions!\n");
 		if (DstHead->lngVersion < SrcHead->lngVersion)
 			DstHead->lngVersion = SrcHead->lngVersion;
 	}
-	
+
 	DstHead->lngLoopOffset |= SrcHead->lngLoopOffset;	// I just need to know if there IS one
 	if (DstHead->lngLoopSamples != SrcHead->lngLoopSamples)
 	{
@@ -322,7 +322,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 		else if (DstHead->bytLoopModifier != SrcHead->bytLoopModifier)
 			printf("Warning! Different Loop Modifier!\n");
 	}
-	
+
 	// merge chip clocks
 	memset(SrcChpMap, 0x00, sizeof(CHIP_MAPS));
 	TempMap = &SrcChpMap->SN76496;
@@ -352,7 +352,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 			DstClock = &DstHead->lngHzGBDMG;
 			break;
 		}
-		
+
 		switch(CurChip)
 		{
 		case 0x00:	// SN76496
@@ -386,7 +386,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 			break;
 		}
 		DualSupport &= ! NO_DUAL_MIXING;
-		
+
 		// check chip clock
 		if (*SrcClock)
 		{
@@ -398,7 +398,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 			{
 				if ((*DstClock & 0x80000000) != (*SrcClock & 0x80000000))
 					printf("Warning! Different Clock-Bit 31 for %s!\n", CHIP_NAMES[CurChip]);
-				
+
 				if (! DualSupport || (*DstClock & 0x40000000) || (*SrcClock & 0x40000000))
 				{
 					printf("Warning! Merging multiple %s chips with the same type into "
@@ -413,7 +413,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 					printf("Warning! Different chip clocks for %s!\n", CHIP_NAMES[CurChip]);
 			}
 		}
-		
+
 		// do special checks
 		switch(CurChip)
 		{
@@ -425,7 +425,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 				else if (DstHead->shtPSG_Feedback != SrcHead->shtPSG_Feedback)
 					printf("Warning! Different Feedback for %s!\n", CHIP_NAMES[CurChip]);
 			}
-			
+
 			if (SrcHead->bytPSG_SRWidth)
 			{
 				if (! DstHead->bytPSG_SRWidth)
@@ -433,7 +433,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 				else if (DstHead->bytPSG_SRWidth != SrcHead->bytPSG_SRWidth)
 					printf("Warning! Different SR Width for %s!\n", CHIP_NAMES[CurChip]);
 			}
-				
+
 			if (SrcHead->bytPSG_Flags)
 			{
 				if (! DstHead->bytPSG_Flags)
@@ -477,7 +477,7 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 				else if (DstHead->bytAYType != SrcHead->bytAYType)
 					printf("Warning! Different Chip Type for %s!\n", CHIP_NAMES[CurChip]);
 			}
-			
+
 			if (SrcHead->bytAYFlag)
 			{
 				if (! DstHead->bytAYFlag)
@@ -487,13 +487,13 @@ static void MergeVGMHeader(VGM_HEADER* DstHead, VGM_HEADER* SrcHead, CHIP_MAPS* 
 			}
 			break;
 		}
-		
+
 		// move to next chip clock
 		SrcClock ++;
 		DstClock ++;
 		TempMap ++;
 	}
-	
+
 	return;
 }
 
@@ -544,10 +544,10 @@ static void MergeVGMData(void)
 	UINT8 PtchCmdData[0x08];
 	DATABLK_MAP* TempDBlk;
 	UINT16 DataBlkUsed[0x40];
-	
+
 	SrcPos = (UINT32*)malloc(MAX_VGMS * sizeof(UINT32));
 	EndReached = (bool*)malloc(MAX_VGMS * sizeof(bool));
-	
+
 	DstHead = SrcVGM[0x00].Head;
 	memset(&SrcVGM[0x00].ChipMap, 0x00, sizeof(SrcVGM[0x00].ChipMap));
 	for (FileID = 0x01; FileID < MAX_VGMS; FileID ++)
@@ -564,7 +564,7 @@ static void MergeVGMData(void)
 	}
 	memset(UsedStreams, 0x00, 0x20);
 	memset(DataBlkUsed, 0x00, sizeof(DataBlkUsed));
-	
+
 	DstPos = DstHead.lngDataOffset;
 	DstDataLen = 0x00;
 	DstSmplPos = 0;
@@ -597,10 +597,10 @@ static void MergeVGMData(void)
 	}
 	DstDataLen += 0x100;	// some additional space
 	DstData = (UINT8*)malloc(DstDataLen);
-	
+
 	NxtSmplPos = 0x00;
 	NewLoopPos = 0x00;
-	
+
 #ifdef WIN32
 	CmdTimer = 0;
 #endif
@@ -613,13 +613,13 @@ static void MergeVGMData(void)
 		{
 			if (EndReached[FileID])
 				continue;
-			
+
 			// find sample of next command
 			if (WriteEvent || SrcVGM[FileID].SmplPos < NxtSmplPos)	// Note: This line breaks the auto-completion somehow.
 				NxtSmplPos = SrcVGM[FileID].SmplPos;
 			WriteEvent = false;
 		}
-		
+
 		WasDblk = 0x00;
 		for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 		{
@@ -629,7 +629,7 @@ static void MergeVGMData(void)
 				CmdDelay = 0;
 				PtchCmdFlags = 0x00;
 				Command = TempVGM->Data[TempVGM->Pos];
-				
+
 				// Make the VGMs looks nicer ;)
 				// (write data blocks of all VGMs first, other commands later)
 				if (! WasDblk)
@@ -644,14 +644,14 @@ static void MergeVGMData(void)
 					if (WasDblk == 0x01 && Command != 0x67)
 						break;
 				}
-				
+
 				CmdLen = GetCmdLen(Command);
 				WriteEvent = true;
 				if (TempVGM->Pos == TempVGM->Head.lngLoopOffset && ! NewLoopPos)
 					IsLoopPnt = true;
 				else
 					IsLoopPnt = false;
-				
+
 				if (Command >= 0x70 && Command <= 0x8F)
 				{
 					switch(Command & 0xF0)
@@ -715,7 +715,7 @@ static void MergeVGMData(void)
 						TempByt = TempVGM->Data[TempVGM->Pos + 0x02];
 						if ((TempByt & 0xC0) == 0x40 && TempByt != 0x7F)
 							TempByt &= 0x3F;
-						
+
 						switch(TempByt)
 						{
 						case 0x00:
@@ -805,7 +805,7 @@ static void MergeVGMData(void)
 							TempDBlk->BlockCnt ++;
 							DataBlkUsed[TempByt] ++;
 						}
-						
+
 						if (TempMap != NULL && TempMap->MapToDual)
 						{
 							PtchCmdFlags = 1 << 0x06;
@@ -813,7 +813,7 @@ static void MergeVGMData(void)
 						}
 						memcpy(&TempLng, &TempVGM->Data[TempVGM->Pos + 0x03], 0x04);
 						TempLng &= 0x7FFFFFFF;
-						
+
 						CmdLen = 0x07 + TempLng;
 						break;
 					case 0x68:	// PCM RAM write
@@ -858,14 +858,14 @@ static void MergeVGMData(void)
 							}
 							SET_BIT(UsedStreams, TempVGM->StrmMap[TempByt]);
 						}
-						
+
 						TempMap = &TempVGM->ChipMap.SN76496 + TempVGM->Data[TempVGM->Pos + 0x02];
 						if (TempMap->MapToDual)
 						{
 							PtchCmdFlags = 1 << 0x02;
 							PtchCmdData[0x02] = 0x80 | TempVGM->Data[TempVGM->Pos + 0x02];
 						}
-						
+
 						CmdLen = 0x05;
 						break;
 					case 0x91:	// DAC Ctrl: Set Data
@@ -976,7 +976,7 @@ static void MergeVGMData(void)
 					// placed here because I need to read all delays
 					if (TempVGM->SmplPos > NxtSmplPos)
 						break;	// exit while
-					
+
 					// Write Delay
 					DstDelay = NxtSmplPos - DstSmplPos;
 					while(DstDelay)
@@ -985,7 +985,7 @@ static void MergeVGMData(void)
 							TempSht = (UINT16)DstDelay;
 						else
 							TempSht = 0xFFFF;
-						
+
 						if (WroteCmd80)
 						{
 							// highest delay compression - Example:
@@ -1004,7 +1004,7 @@ static void MergeVGMData(void)
 								TempSht -= 1764;
 							else if (TempSht >= 1617 && TempSht <= 1632)	// 62 63
 								TempSht -= 1617;
-							
+
 							/*if (TempSht >= 0x10 && TempSht <= 0x1F)
 								TempSht = 0x0F;
 							else if (TempSht >= 0x20)
@@ -1068,10 +1068,10 @@ static void MergeVGMData(void)
 						DstDelay -= TempSht;
 						DstSmplPos += TempSht;
 					}
-					
+
 					if (IsLoopPnt)
 						NewLoopPos = DstPos;
-					
+
 					if (WriteEvent)
 					{
 						if (DstPos + CmdLen > DstDataLen)
@@ -1079,13 +1079,13 @@ static void MergeVGMData(void)
 							printf("Error! Allocated space too small!\n");
 							printf("Please report this bug.\n");
 							//return;
-							
+
 							DstData[DstPos] = 0x66;
 							DstPos ++;
 							VGMsRunning = 0x00;
 							break;
 						}
-						
+
 						// Write Event
 						WroteCmd80 = ((Command & 0xF0) == 0x80);
 						if (WroteCmd80)
@@ -1097,7 +1097,7 @@ static void MergeVGMData(void)
 							memcpy(&DstData[DstPos], &TempVGM->Data[TempVGM->Pos], CmdLen);
 						else
 							DstData[DstPos] = Command;	// write the 0x80-command correctly
-						
+
 						if (PtchCmdFlags)
 						{
 							for (TempByt = 0x00; TempByt < 0x04; TempByt ++)
@@ -1113,7 +1113,7 @@ static void MergeVGMData(void)
 				TempVGM->SmplPos += CmdDelay;
 			}	// end while(! EndReached)
 		}	// end for (FileID)
-		
+
 #ifdef WIN32
 		if (CmdTimer < GetTickCount())
 		{
@@ -1138,7 +1138,7 @@ static void MergeVGMData(void)
 		}
 	}
 	printf("\t\t\t\t\t\t\t\t\r");
-	
+
 	for (FileID = 0x00; FileID < MAX_VGMS; FileID ++)
 	{
 		TempVGM = &SrcVGM[FileID];
@@ -1150,7 +1150,7 @@ static void MergeVGMData(void)
 			{
 				memcpy(&CmdLen, &TempVGM->Data[NxtSmplPos + 0x08], 0x04);
 				CmdLen += 0x0C;
-				
+
 				DstHead.lngGD3Offset = DstPos - 0x14;
 				memcpy(&DstData[DstPos], &TempVGM->Data[NxtSmplPos], CmdLen);
 				DstPos += CmdLen;
@@ -1158,12 +1158,12 @@ static void MergeVGMData(void)
 			}
 		}
 	}
-	
+
 	DstDataLen = DstPos;
 	DstHead.lngEOFOffset = DstDataLen - 0x04;
 	DstPos = DstHead.lngDataOffset;
 	DstHead.lngDataOffset -= 0x34;
-	
+
 	// Copy Header
 	if (sizeof(VGM_HEADER) < DstPos)
 	{
@@ -1175,10 +1175,10 @@ static void MergeVGMData(void)
 	{
 		memcpy(&DstData[0x00], &DstHead, DstPos);
 	}
-	
+
 	free(SrcPos);
 	free(EndReached);
-	
+
 	return;
 }
 


### PR DESCRIPTION
These spaces in most are useless and increasing the size of files. Various modern IDEs are usually removing them in dependency from settings. To prevent future confusions and fights for avoiding them in commits, it's better to remove all of them in one time and forever.

No code changed: end line spaces only was removed