### PR TITLE
Channel stripping for YM2612 (and SN76496)

### DIFF
--- a/chip_strp.c
+++ b/chip_strp.c
@@ -192,7 +192,7 @@ bool sn76496_write(UINT8 Command)
 
 	if (Command & 0x80)
 	{
-		Channel = (Command & 0x60) >> 1;
+		Channel = (Command & 0x60) >> 5;
 		chip->LastChn = Channel;
 	}
 	else

--- a/chip_strp.c
+++ b/chip_strp.c
@@ -233,11 +233,15 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 		if (CurChn >= 4) {
 			CurChn--;
 		}
-		return !(strip->ChnMask & (0x01 << CurChn));
+		return !(strip->ChnMask & (1 << CurChn));
 	case 0x2A: // DAC data
-		return !(strip->ChnMask & (0x01 << 6));
+		return !(strip->ChnMask & (1 << 6));
 	case 0x2B: // DAC enable
-		return true;
+		return !(strip->ChnMask & (1 << 6)) || !(strip->ChnMask & (1 << 5));
+	case 0xB6: // Includes stereo control which may also affect DAC
+		if (Port && strip->ChnMask & (1 << 6))
+			return true;
+		break;
 	}
 
 	if (Register < 0x30)
@@ -251,7 +255,7 @@ bool ym2612_write(UINT8 Port, UINT8 Register, UINT8 Data)
 	if (Port)
 		CurChn += 3;
 
-	return !(strip->ChnMask & (0x01 << CurChn));
+	return !(strip->ChnMask & (1 << CurChn));
 }
 
 bool ym2151_write(UINT8 Register, UINT8 Data)

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -885,6 +885,10 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 						{
 							StripVGM[CurCSet].SN76496.Other |= 0x01;
 						}
+						else if (CurChip == 0x02 && ! stricmp(ChipPos, "DAC"))
+						{
+							TempChip->ChnMask |= (1 << 6);
+						}
 						else if (CurChip == 0x05 && ! stricmp(ChipPos, "Mem"))
 						{
 							StripVGM[CurCSet].RF5C68.Other |= 0x01;

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -177,7 +177,7 @@ int main(int argc, char* argv[])
 		printf("    --------       --------\n");
 		printf("    PSG/SN76496    0..3, Stereo\n");
 		printf("    YM2413        *0..8, BD, SD, TT, TC, HH\n");
-		printf("    YM2612        *0..5, DAC\n");
+		printf("    YM2612         0..5, DAC\n");
 		printf("    YM2151        *0..7\n");
 		printf("    RF5C68         0..7, Mem\n");
 		printf("    YM2203        *0..2, S0..S2\n");


### PR DESCRIPTION
See #19.

I followed @ValleyBell's instructions to fix the channel stripping for `SN76496` and implement it for `YM2612`.  I tested it with some Genesis `.vgm` files (from Sonic 1), and it is working.

There's only one problem, and I'm hoping to get some guidance.  The command line help text indicates that specifying something like `-Strip:YM2612:DAC` should work for stripping the DAC, but I could not find where that information gets put in `ChnMask`.  Instead, at this point, `-Strip:YM2612:6` strips the DAC.  Any insight?