### PR TITLE
Add Partial ICS2115, Mikey, MSM5205, MSM5232, BSMT2000 support

### DIFF
--- a/VGMFile.h
+++ b/VGMFile.h
@@ -72,7 +72,7 @@ typedef struct _vgm_file_header
 	UINT8 bytES5503Chns;
 	UINT8 bytES5506Chns;
 	UINT8 bytC352ClkDiv;
-	UINT8 bytESReserved;
+	UINT8 bytOKI5205Flags;
 	UINT32 lngHzX1_010;
 	UINT32 lngHzC352;
 	UINT32 lngHzGA20;

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -311,14 +311,14 @@ typedef struct okim5232_data
 #define BSMT2000_MAX_VOICES   (BSMT2000_CHANNELS + 1)  /* 12 PCM + 1 ADPCM/compressed */
 
 static const UINT8 bsmt2000_regmap[8][7] = {
-    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
-    { 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
-    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
-    { 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
-    { 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
+	{ 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
+	{ 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
+	{ 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
+	{ 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
+	{ 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
 
 typedef struct bsmt2000_data
 {
@@ -2953,7 +2953,7 @@ bool ics2115_write(UINT8 Register, UINT8 Data)
 		if (Data == 0x0F)
 			return false;
 
-		if (Data >= 0x13 && Data <= 0x4E)
+		if ((Data >= 0x13 && Data <= 0x3F) && (Data >= 0x4C && Data <= 0x4E))
 			return false;
 
 		if (Data >= 0x50)
@@ -3209,36 +3209,36 @@ bool bsmt2000_write(UINT8 Offset, UINT16 Value)
 	{
 		switch (Value & 0xFF)
 		{
-        /* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
-        case 0:
-            chip->Voices = 12;
-            chip->ADPCM = 1;
-            chip->Mode = 0;
-            break;
-        /* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
-        case 1:
-            chip->Voices = 11;
-            chip->ADPCM = 1;
-            chip->Mode = 1;
-            break;
-        /* mode 5: 24kHz, 12 channel PCM, stereo */
-        case 5:
-            chip->Voices = 12;
-            chip->ADPCM = 0;
-            chip->Mode = 5;
-            break;
-        /* mode 6: 34kHz, 8 channel PCM, stereo */
-        case 6:
-            chip->Voices = 8;
-            chip->ADPCM = 0;
-            chip->Mode = 6;
-            break;
-        /* mode 7: 32kHz, 9 channel PCM, stereo */
-        case 7:
-            chip->Voices = 9;
-            chip->ADPCM = 0;
-            chip->Mode = 7;
-            break;
+		/* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
+		case 0:
+			chip->Voices = 12;
+			chip->ADPCM = 1;
+			chip->Mode = 0;
+			break;
+		/* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
+		case 1:
+			chip->Voices = 11;
+			chip->ADPCM = 1;
+			chip->Mode = 1;
+			break;
+		/* mode 5: 24kHz, 12 channel PCM, stereo */
+		case 5:
+			chip->Voices = 12;
+			chip->ADPCM = 0;
+			chip->Mode = 5;
+			break;
+		/* mode 6: 34kHz, 8 channel PCM, stereo */
+		case 6:
+			chip->Voices = 8;
+			chip->ADPCM = 0;
+			chip->Mode = 6;
+			break;
+		/* mode 7: 32kHz, 9 channel PCM, stereo */
+		case 7:
+			chip->Voices = 9;
+			chip->ADPCM = 0;
+			chip->Mode = 7;
+			break;
 		}
 		memset(chip->RegFirst, 0x01, 0x80 * sizeof(UINT8));
 		return true;
@@ -3247,46 +3247,46 @@ bool bsmt2000_write(UINT8 Offset, UINT16 Value)
 	if (chip->Mode > 0x07)
 		return false;
 
-    // Standard voices (interleaved register layout)
-    if (Offset < 0x6d)
+	// Standard voices (interleaved register layout)
+	if (Offset < 0x6d)
 	{
-        int voice_index;
-        int regindex = BSMT2000_REG_TOTAL - 1;
-        while (Offset < bsmt2000_regmap[chip->Mode][regindex])
-            --regindex;
+		int voice_index;
+		int regindex = BSMT2000_REG_TOTAL - 1;
+		while (Offset < bsmt2000_regmap[chip->Mode][regindex])
+			--regindex;
 
-        voice_index = Offset - bsmt2000_regmap[chip->Mode][regindex];
-        if (voice_index >= chip->Voices)
-            return;
+		voice_index = Offset - bsmt2000_regmap[chip->Mode][regindex];
+		if (voice_index >= chip->Voices)
+			return false;
 
-        switch (regindex)
+		switch (regindex)
 		{
-            case BSMT2000_REG_CURRPOS:
-            case BSMT2000_REG_RIGHTVOL:
-            case BSMT2000_REG_LEFTVOL:
+			case BSMT2000_REG_CURRPOS:
+			case BSMT2000_REG_RIGHTVOL:
+			case BSMT2000_REG_LEFTVOL:
 				return true;
-        }
-    }
-    // Compressed/ADPCM channel (11-voice model only)
-    else if (Offset >= 0x6d)
+		}
+	}
+	// Compressed/ADPCM channel (11-voice model only)
+	else if (Offset >= 0x6d)
 	{
 		if (chip->ADPCM == 0)
 			return false;
 
-        switch (Offset)
+		switch (Offset)
 		{
-        case 0x6e: // main right channel volume control, used when ADPCM is alreay playing
-        case 0x74:
-        case 0x75:
-        case 0x70: // main left channel volume control, used when ADPCM is alreay playing
-        case 0x78:
+		case 0x6e: // main right channel volume control, used when ADPCM is alreay playing
+		case 0x74:
+		case 0x75:
+		case 0x70: // main left channel volume control, used when ADPCM is alreay playing
+		case 0x78:
 			return true;
-        case 0x6f:
+		case 0x6f:
 			break;
 		default:
 			return false;
-        }
-    }
+		}
+	}
 
 	if (! chip->RegFirst[Offset] && Value == chip->RegData[Offset])
 		return false;

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -285,6 +285,11 @@ typedef struct ics2115_data
 	UINT16 RegData[0x80 * 0x20];
 	UINT16 RegFirst[0x80 * 0x20];
 } ICS2115_DATA;
+typedef struct mikey_data
+{
+	UINT16 RegData[0x51];
+	UINT8 RegFirst[0x51];
+} MIKEY_DATA;
 
 typedef struct all_chips
 {
@@ -328,6 +333,7 @@ typedef struct all_chips
 	K005289_DATA K005289;
 	K007232_DATA K007232;
 	ICS2115_DATA ICS2115;
+	MIKEY_DATA Mikey;
 } ALL_CHIPS;
 
 
@@ -380,6 +386,7 @@ bool wswan_write(UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
 bool k007232_write(UINT8 Register, UINT8 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
+bool mikey_write(UINT8 Register, UINT8 Data);
 
 // Function Prototypes from vgm_cmp.c
 bool GetNextChipCommand(void);
@@ -3001,6 +3008,53 @@ bool ics2115_write(UINT8 Register, UINT8 Data)
 	chip->RegData[RegInd] =
 			(chip->RegData[RegInd] & ~(0xff << RegShift)) |
 			(((UINT16)Data) << RegShift);
+
+	return true;
+}
+
+bool mikey_write(UINT8 Register, UINT8 Data)
+{
+	MIKEY_DATA* chip = &ChDat->Mikey;
+	UINT8 FreqMode, ch;
+
+	if (Register < 0x20)
+		return false;
+	else if (Register < 0x40)
+	{
+		// don't strip counter, direct output and shifter write
+		switch (Register & 0x07)
+		{
+			case 0x01:
+			case 0x02:
+			case 0x03:
+			case 0x04:
+			case 0x05:
+			case 0x06:
+			case 0x07:
+				return true;
+		}
+	}
+	else
+	{
+		switch (Register)
+		{
+		case 0x40:
+		case 0x41:
+		case 0x42:
+		case 0x43:
+		case 0x44:
+		case 0x50:
+			break;
+		default:
+			return false;
+		}
+	}
+
+	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
+		return false;
+
+	chip->RegFirst[Register] = JustTimerCmds;
+	chip->RegData[Register] = Data;
 
 	return true;
 }

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -236,6 +236,7 @@ typedef struct okim6295_data
 	UINT8 RegFirst[0x14];
 } OKIM6295_DATA;
 typedef struct okim6295_data OKIM6258_DATA;
+typedef struct okim6295_data OKIM5205_DATA;
 typedef struct upd7759_data
 {
 	UINT8 RegData[0x04];
@@ -334,6 +335,7 @@ typedef struct all_chips
 	K007232_DATA K007232;
 	ICS2115_DATA ICS2115;
 	MIKEY_DATA Mikey;
+	OKIM5205_DATA OKIM5205;
 } ALL_CHIPS;
 
 
@@ -387,6 +389,7 @@ bool k005289_write(UINT8 Register, UINT16 Data);
 bool k007232_write(UINT8 Register, UINT8 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
+bool okim5205_write(UINT8 Port, UINT8 Data);
 
 // Function Prototypes from vgm_cmp.c
 bool GetNextChipCommand(void);
@@ -3024,14 +3027,14 @@ bool mikey_write(UINT8 Register, UINT8 Data)
 		// don't strip counter, direct output and shifter write
 		switch (Register & 0x07)
 		{
-			case 0x01:
-			case 0x02:
-			case 0x03:
-			case 0x04:
-			case 0x05:
-			case 0x06:
-			case 0x07:
-				return true;
+		case 0x01:
+		case 0x02:
+		case 0x03:
+		case 0x04:
+		case 0x05:
+		case 0x06:
+		case 0x07:
+			return true;
 		}
 	}
 	else
@@ -3055,6 +3058,29 @@ bool mikey_write(UINT8 Register, UINT8 Data)
 
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
+
+	return true;
+}
+
+bool okim5205_write(UINT8 Port, UINT8 Data)
+{
+	OKIM5205_DATA* chip = &ChDat->OKIM5205;
+	Data &= 0x0F;
+	switch (Port & 0x07)
+	{
+	case 0x01: // doesn't strip data write
+		return true;
+	case 0x03:
+	case 0x06:
+	case 0x07:
+		return false;
+	}
+
+	if (! chip->RegFirst[Port] && Data == chip->RegData[Port])
+		return false;
+
+	chip->RegFirst[Port] = JustTimerCmds;
+	chip->RegData[Port] = Data;
 
 	return true;
 }

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -297,6 +297,38 @@ typedef struct okim5232_data
 	UINT8 RegFirst[0x24];
 } OKIM5232_DATA;
 
+#define BSMT2000_CHANNELS     12          /* up to 12 PCM voices, plus ADPCM */
+#define BSMT2000_ADPCM_INDEX  12          /* 0..11 = PCM, 12 = ADPCM/compressed */
+#define BSMT2000_REG_CURRPOS  0
+#define BSMT2000_REG_RATE 1
+#define BSMT2000_REG_LOOPEND     2
+#define BSMT2000_REG_LOOPSTART  3
+#define BSMT2000_REG_BANK 4
+#define BSMT2000_REG_RIGHTVOL     5
+#define BSMT2000_REG_LEFTVOL 6
+#define BSMT2000_REG_TOTAL    7
+
+#define BSMT2000_MAX_VOICES   (BSMT2000_CHANNELS + 1)  /* 12 PCM + 1 ADPCM/compressed */
+
+static const UINT8 bsmt2000_regmap[8][7] = {
+    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
+    { 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
+    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
+    { 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
+    { 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
+
+typedef struct bsmt2000_data
+{
+	UINT16 RegData[0x80];
+	UINT8 RegFirst[0x80];
+	UINT8 KeyOn[0x10];
+	UINT8 Mode;
+	UINT8 ADPCM;
+	UINT8 Voices;
+} BSMT2000_DATA;
 typedef struct all_chips
 {
 	UINT8 GGSt;
@@ -342,6 +374,7 @@ typedef struct all_chips
 	MIKEY_DATA Mikey;
 	OKIM5205_DATA OKIM5205;
 	OKIM5232_DATA OKIM5232;
+	BSMT2000_DATA BSMT2000;
 } ALL_CHIPS;
 
 
@@ -397,6 +430,7 @@ bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
 bool okim5205_write(UINT8 Port, UINT8 Data);
 bool okim5232_write(UINT8 Register, UINT8 Data);
+bool bsmt2000_write(UINT8 Offset, UINT16 Value);
 
 // Function Prototypes from vgm_cmp.c
 bool GetNextChipCommand(void);
@@ -434,6 +468,10 @@ void InitAllChips(void)
 		memset(TempChp->YMZ280B.KeyOn, 0x00, sizeof(UINT8) * 0x08);
 		TempChp->C140.banking_type = 0x00;
 		memset(TempChp->QSound.KeyOn, 0x00, sizeof(UINT8) * 0x10);
+		memset(TempChp->BSMT2000.KeyOn, 0x00, sizeof(UINT8) * 0x10);
+		TempChp->BSMT2000.Mode = 1;
+		TempChp->BSMT2000.ADPCM = 1;
+		TempChp->BSMT2000.Voices = 12;
 
 		memset(&TempChp->OKIM6258.RegFirst[0x08], 0x00, 0x0D-0x08);
 		memset(TempChp->WSwan.RegData, 0x00, 0x20);
@@ -474,6 +512,10 @@ void ResetAllChips(void)
 		memset(TempChp->YMZ280B.KeyOn, 0x00, sizeof(UINT8) * 0x08);
 		TempChp->C140.banking_type = RegBak[0x03];
 		memset(TempChp->QSound.KeyOn, 0x00, sizeof(UINT8) * 0x10);
+		memset(TempChp->BSMT2000.KeyOn, 0x00, sizeof(UINT8) * 0x10);
+		TempChp->BSMT2000.Mode = 1;
+		TempChp->BSMT2000.ADPCM = 1;
+		TempChp->BSMT2000.Voices = 12;
 
 		TempChp->RF5C68.RegData[RF_CBANK] = RegBak[0x00];
 		TempChp->RF5C68.RegData[RF_CHN_LOOP] = RegBak[0x00];
@@ -3156,5 +3198,101 @@ bool okim5232_write(UINT8 Register, UINT8 Data)
 
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
+	return true;
+}
+
+bool bsmt2000_write(UINT8 Offset, UINT16 Value)
+{
+	BSMT2000_DATA* chip = &ChDat->BSMT2000;
+
+	if (Offset == 0x7F) // set mode (reset)
+	{
+		switch (Value & 0xFF)
+		{
+        /* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
+        case 0:
+            chip->Voices = 12;
+            chip->ADPCM = 1;
+            chip->Mode = 0;
+            break;
+        /* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
+        case 1:
+            chip->Voices = 11;
+            chip->ADPCM = 1;
+            chip->Mode = 1;
+            break;
+        /* mode 5: 24kHz, 12 channel PCM, stereo */
+        case 5:
+            chip->Voices = 12;
+            chip->ADPCM = 0;
+            chip->Mode = 5;
+            break;
+        /* mode 6: 34kHz, 8 channel PCM, stereo */
+        case 6:
+            chip->Voices = 8;
+            chip->ADPCM = 0;
+            chip->Mode = 6;
+            break;
+        /* mode 7: 32kHz, 9 channel PCM, stereo */
+        case 7:
+            chip->Voices = 9;
+            chip->ADPCM = 0;
+            chip->Mode = 7;
+            break;
+		}
+		memset(chip->RegFirst, 0x01, 0x80 * sizeof(UINT8));
+		return true;
+	}
+
+	if (chip->Mode > 0x07)
+		return false;
+
+    // Standard voices (interleaved register layout)
+    if (Offset < 0x6d)
+	{
+        int voice_index;
+        int regindex = BSMT2000_REG_TOTAL - 1;
+        while (Offset < bsmt2000_regmap[chip->Mode][regindex])
+            --regindex;
+
+        voice_index = Offset - bsmt2000_regmap[chip->Mode][regindex];
+        if (voice_index >= chip->Voices)
+            return;
+
+        switch (regindex)
+		{
+            case BSMT2000_REG_CURRPOS:
+            case BSMT2000_REG_RIGHTVOL:
+            case BSMT2000_REG_LEFTVOL:
+				return true;
+        }
+    }
+    // Compressed/ADPCM channel (11-voice model only)
+    else if (Offset >= 0x6d)
+	{
+		if (chip->ADPCM == 0)
+			return false;
+
+        switch (Offset)
+		{
+        case 0x6e: // main right channel volume control, used when ADPCM is alreay playing
+        case 0x74:
+        case 0x75:
+        case 0x70: // main left channel volume control, used when ADPCM is alreay playing
+        case 0x78:
+			return true;
+        case 0x6f:
+			break;
+		default:
+			return false;
+        }
+    }
+
+	if (! chip->RegFirst[Offset] && Value == chip->RegData[Offset])
+		return false;
+
+	chip->RegFirst[Offset] = JustTimerCmds;
+	chip->RegData[Offset] = Value;
+
 	return true;
 }

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -291,6 +291,11 @@ typedef struct mikey_data
 	UINT16 RegData[0x51];
 	UINT8 RegFirst[0x51];
 } MIKEY_DATA;
+typedef struct okim5232_data
+{
+	UINT16 RegData[0x24];
+	UINT8 RegFirst[0x24];
+} OKIM5232_DATA;
 
 typedef struct all_chips
 {
@@ -336,6 +341,7 @@ typedef struct all_chips
 	ICS2115_DATA ICS2115;
 	MIKEY_DATA Mikey;
 	OKIM5205_DATA OKIM5205;
+	OKIM5232_DATA OKIM5232;
 } ALL_CHIPS;
 
 
@@ -390,6 +396,7 @@ bool k007232_write(UINT8 Register, UINT8 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
 bool okim5205_write(UINT8 Port, UINT8 Data);
+bool okim5232_write(UINT8 Register, UINT8 Data);
 
 // Function Prototypes from vgm_cmp.c
 bool GetNextChipCommand(void);
@@ -3082,5 +3089,72 @@ bool okim5205_write(UINT8 Port, UINT8 Data)
 	chip->RegFirst[Port] = JustTimerCmds;
 	chip->RegData[Port] = Data;
 
+	return true;
+}
+
+bool okim5232_write(UINT8 Register, UINT8 Data)
+{
+	OKIM5232_DATA* chip = &ChDat->OKIM5232;
+
+	if (Register >= 0x24)
+		return false;
+
+	switch (Register)
+	{
+	case 0x00: // pitch/keyon
+	case 0x01:
+	case 0x02:
+	case 0x03:
+	case 0x04:
+	case 0x05:
+	case 0x06:
+	case 0x07:
+	case 0x0C: // per group control
+	case 0x0D:
+		return true;
+	case 0x08: // per group attack/decay
+	case 0x09:
+	case 0x0A:
+	case 0x0B:
+	case 0x10: // per output volume
+	case 0x11:
+	case 0x12:
+	case 0x13:
+	case 0x14:
+	case 0x15:
+	case 0x16:
+	case 0x17:
+	case 0x18:
+	case 0x19:
+	case 0x1A:
+	case 0x1E:
+	case 0x1F:
+		break;
+	case 0x20:	// Master Clock 000000dd
+	case 0x21:	// Master Clock 0000dd00
+	case 0x22:	// Master Clock 00dd0000
+		if (/*! chip->RegFirst[Register] &&*/ Data == chip->RegData[Register])
+			return false;
+
+		chip->RegData[Register] = Data;
+		chip->RegFirst[Register] = 0x00;
+		chip->RegFirst[0x23] = 0x01;	// force Clock rewrite
+		break;
+	case 0x23:	// Master Clock dd000000
+		if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
+			return false;
+
+		chip->RegData[Register] = Data;
+		chip->RegFirst[Register] = 0x00;
+		break;
+	default:
+		return false;
+	}
+
+	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
+		return false;
+
+	chip->RegFirst[Register] = JustTimerCmds;
+	chip->RegData[Register] = Data;
 	return true;
 }

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -3053,12 +3053,12 @@ bool ics2115_write(UINT8 Register, UINT8 Data)
 	if ((chip->RegAddr <= 0x12) && (chip->RegAddr != 0x0E))
 		RegInd |= (((UINT16)chip->RegCh) << 7);
 	if (! chip->RegFirst[RegInd] &&
-		Data == ((chip->RegData[RegInd] >> RegShift) & 0xff))
+		Data == ((chip->RegData[RegInd] >> RegShift) & 0xFF))
 		return false;
 
 	chip->RegFirst[RegInd] = JustTimerCmds;
 	chip->RegData[RegInd] =
-			(chip->RegData[RegInd] & ~(0xff << RegShift)) |
+			(chip->RegData[RegInd] & ~(0xFF << RegShift)) |
 			(((UINT16)Data) << RegShift);
 
 	return true;

--- a/chip_cmp.c
+++ b/chip_cmp.c
@@ -277,6 +277,14 @@ typedef struct k007232_data
 	UINT8 RegData[0x20];
 	UINT8 RegFirst[0x20];
 } K007232_DATA;
+typedef struct ics2115_data
+{
+	UINT8 RegAddr;
+	UINT8 RegAddrFirst;
+	UINT8 RegCh;
+	UINT16 RegData[0x80 * 0x20];
+	UINT16 RegFirst[0x80 * 0x20];
+} ICS2115_DATA;
 
 typedef struct all_chips
 {
@@ -319,6 +327,7 @@ typedef struct all_chips
 	VSU_DATA VSU;
 	K005289_DATA K005289;
 	K007232_DATA K007232;
+	ICS2115_DATA ICS2115;
 } ALL_CHIPS;
 
 
@@ -370,6 +379,7 @@ bool vsu_write(UINT16 Register, UINT8 Data);
 bool wswan_write(UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
 bool k007232_write(UINT8 Register, UINT8 Data);
+bool ics2115_write(UINT8 Register, UINT8 Data);
 
 // Function Prototypes from vgm_cmp.c
 bool GetNextChipCommand(void);
@@ -2865,6 +2875,132 @@ bool k007232_write(UINT8 Register, UINT8 Data)
 
 	chip->RegFirst[Register] = JustTimerCmds;
 	chip->RegData[Register] = Data;
+
+	return true;
+}
+
+bool ics2115_write(UINT8 Register, UINT8 Data)
+{
+	ICS2115_DATA* chip = &ChDat->ICS2115;
+	UINT8 RegShift, RegBits;
+	UINT16 RegInd;
+
+	if (Register >= 0x04 || Register == 0x00)
+		return false;
+
+	// Register index
+	if (Register == 0x01)
+	{
+		if (Data == 0x0F)
+			return false;
+
+		if (Data >= 0x13 && Data <= 0x4E)
+			return false;
+
+		if (Data >= 0x50)
+			return false;
+
+		if (! chip->RegAddrFirst && Data == chip->RegAddr)
+			return false;
+
+		chip->RegAddrFirst = JustTimerCmds;
+		chip->RegAddr = Data;
+
+		return true;
+	}
+	RegBits = Register & 1;
+	switch (chip->RegAddr)
+	{
+		case 0x00: // [osc] Oscillator Configuration
+			if (!RegBits) // ignore LSB
+				return false;
+			return true; // written dynamically by chip
+
+		case 0x01: // [osc] Wavesample frequency
+			// freq = fc*33075/1024 in 32 voices mode, fc*44100/1024 in 24 voices mode
+			if (!RegBits) // ignore lowest bit
+				Data &= 0xFE;
+			break;
+
+		case 0x02: // [osc] Wavesample loop start high
+		case 0x03: // [osc] Wavesample loop start low
+			break;
+
+		case 0x04: // [osc] Wavesample loop end high
+		case 0x05: // [osc] Wavesample loop end low
+			break;
+
+		case 0x06: // [osc] Volume Increment
+			if (!RegBits) // ignore LSB
+				return false;
+			break;
+		case 0x07: // [osc] Volume Start
+		case 0x08: // [osc] Volume End
+			if (RegBits) // ignore MSB
+				return false;
+			break;
+
+		case 0x09: // [osc] Volume accumulator
+			return true; // written dynamically by chip
+
+		case 0x0a: // [osc] Wavesample address high
+		case 0x0b: // [osc] Wavesample address low
+			return true; // written dynamically by chip
+
+		case 0x0c: // [osc] Pan
+			if (!RegBits) // ignore LSB
+				return false;
+			break;
+
+		case 0x0d: // [osc] Volume Envelope Control
+			if (!RegBits) // ignore LSB
+				return false;
+			return true; // written dynamically by chip
+
+		case 0x0e: // Active Voices
+			if (!RegBits) // ignore LSB
+				return false;
+			Data &= 0x1F;
+			break;
+		//2X8 ?
+		case 0x10: // [osc] Oscillator Control
+			if (!RegBits) // ignore LSB
+				return false;
+			break;
+
+		case 0x11: // [osc] Wavesample static address 27-20
+			if (!RegBits) // ignore LSB
+				return false;
+			break;
+		case 0x12:
+			//Could be per voice! -- investigate.
+			if (!RegBits) // ignore LSB
+				return false;
+			break;
+
+		case 0x4f: // Oscillator Address being Programmed
+			if (RegBits) // ignore MSB
+				return false;
+			chip->RegCh = Data & 0x1f;
+			break;
+
+		default:
+			return false;
+	}
+
+	RegShift = RegBits << 3;
+	RegInd = chip->RegAddr;
+	// per-channel register
+	if ((chip->RegAddr <= 0x12) && (chip->RegAddr != 0x0E))
+		RegInd |= (((UINT16)chip->RegCh) << 7);
+	if (! chip->RegFirst[RegInd] &&
+		Data == ((chip->RegData[RegInd] >> RegShift) & 0xff))
+		return false;
+
+	chip->RegFirst[RegInd] = JustTimerCmds;
+	chip->RegData[RegInd] =
+			(chip->RegData[RegInd] & ~(0xff << RegShift)) |
+			(((UINT16)Data) << RegShift);
 
 	return true;
 }

--- a/chip_srom.c
+++ b/chip_srom.c
@@ -549,6 +549,48 @@ typedef struct ics2115_data
 	ICS2115_VOICE voice[32];
 } ICS2115_DATA;
 
+#define BSMT2000_CHANNELS     12          /* up to 12 PCM voices, plus ADPCM */
+#define BSMT2000_ADPCM_INDEX  12          /* 0..11 = PCM, 12 = ADPCM/compressed */
+#define BSMT2000_REG_CURRPOS  0
+#define BSMT2000_REG_RATE 1
+#define BSMT2000_REG_LOOPEND     2
+#define BSMT2000_REG_LOOPSTART  3
+#define BSMT2000_REG_BANK 4
+#define BSMT2000_REG_RIGHTVOL     5
+#define BSMT2000_REG_LEFTVOL 6
+#define BSMT2000_REG_TOTAL    7
+
+#define BSMT2000_MAX_VOICES   (BSMT2000_CHANNELS + 1)  /* 12 PCM + 1 ADPCM/compressed */
+
+static const UINT8 bsmt2000_regmap[8][7] = {
+    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
+    { 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
+    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
+    { 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
+    { 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
+
+typedef struct _bsmt2000_channel
+{
+	UINT32 bank;		// bank (x16)
+	INT32 address;	// start address
+	INT32 end;		// end address
+} BSMT2000_CHANNEL;
+typedef struct bsmt2000_data
+{
+	BSMT2000_CHANNEL channel[BSMT2000_MAX_VOICES];
+	UINT16 data;	// register latch data
+	UINT8 Mode;
+	UINT8 ADPCM;
+	UINT8 Voices;
+
+	UINT32 ROMSize;
+	UINT8* ROMData;
+	UINT8* ROMUsage;
+} BSMT2000_DATA;
+
 
 typedef struct all_chips
 {
@@ -577,6 +619,7 @@ typedef struct all_chips
 	K007232_DATA K007232;
 	K005289_DATA K005289;
 	ICS2115_DATA ICS2115;
+	BSMT2000_DATA BSMT2000;
 } ALL_CHIPS;
 
 void InitAllChips(void);
@@ -615,6 +658,7 @@ void es550x_w(UINT8 Offset, UINT8 Data);
 void es550x_w16(UINT8 Offset, UINT16 Data);
 void k005289_write(UINT8 Offset, UINT16 data);
 void ics2115_write(UINT8 Offset, UINT8 data);
+void bsmt2000_write(UINT8 Offset, UINT16 Value);
 void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 DataLength,
 					const UINT8* ROMData);
 UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData);
@@ -673,6 +717,9 @@ void InitAllChips(void)
 		ChDat->C140.banking_type = 0x00;
 		ChDat->ES5506.voiceCount = 32;
 		ChDat->ICS2115.voiceCount = 31;
+		ChDat->BSMT2000.Mode = 1;
+		ChDat->BSMT2000.Voices = 12;
+		ChDat->BSMT2000.ADPCM = 1;
 
 		for (CurChn = 0; CurChn < 28; CurChn ++)
 			ChDat->MultiPCM.slot[CurChn].SmplID = 0xFFFF;
@@ -2763,9 +2810,13 @@ void ga20_write(UINT8 offset, UINT8 data)
 		if(data)
 		{
 			startpos = TempChn->start;
-			endpos = TempChn->end;
-			for (addr = startpos; addr < endpos; addr ++)
+			endpos = TempChn->end | 0xF;
+			for (addr = startpos; addr <= endpos; addr ++)
+			{
 				chip->ROMUsage[addr] |= 0x01;
+				if (chip->ROMData[addr] == 0x00)
+					break;
+			}
 		}
 		break;
 	}
@@ -3422,6 +3473,122 @@ void ics2115_write(UINT8 Offset, UINT8 Data)
 	return;
 }
 
+void bsmt2000_write(UINT8 Offset, UINT16 Value)
+{
+	BSMT2000_DATA* chip = &ChDat->BSMT2000;
+
+	UINT8 ch;
+	UINT8 reg;
+	BSMT2000_CHANNEL* TempChn;
+	UINT32 StAddr;
+	UINT32 EndAddr;
+	UINT32 Addr;
+	UINT32 Bank;
+
+	if (Offset == 0x7F)
+	{
+		switch (Value & 0xFF)
+		{
+        /* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
+        case 0:
+            chip->Voices = 12;
+            chip->ADPCM = 1;
+            chip->Mode = 0;
+            break;
+        /* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
+        case 1:
+            chip->Voices = 11;
+            chip->ADPCM = 1;
+            chip->Mode = 1;
+            break;
+        /* mode 5: 24kHz, 12 channel PCM, stereo */
+        case 5:
+            chip->Voices = 12;
+            chip->ADPCM = 0;
+            chip->Mode = 5;
+            break;
+        /* mode 6: 34kHz, 8 channel PCM, stereo */
+        case 6:
+            chip->Voices = 8;
+            chip->ADPCM = 0;
+            chip->Mode = 6;
+            break;
+        /* mode 7: 32kHz, 9 channel PCM, stereo */
+        case 7:
+            chip->Voices = 9;
+            chip->ADPCM = 0;
+            chip->Mode = 7;
+            break;
+		}
+		for (ch = 0; ch < BSMT2000_MAX_VOICES; ch++)
+		{
+			TempChn = &chip->channel[ch];
+			TempChn->bank = 0;
+			TempChn->address = 0;
+			TempChn->end = 0;
+		}
+		return;
+	}
+
+	// Standard voices (interleaved register layout)
+	if (Offset < 0x6d)
+	{
+		int voice_index;
+		int regindex = BSMT2000_REG_TOTAL - 1;
+		while (Offset < bsmt2000_regmap[chip->Mode][regindex])
+			--regindex;
+
+		voice_index = Offset - bsmt2000_regmap[chip->Mode][regindex];
+		if (voice_index >= chip->Voices)
+			return;
+
+        TempChn = &chip->channel[voice_index];
+		reg = regindex;
+    }
+    // Compressed/ADPCM channel (11-voice model only)
+    else if (chip->ADPCM != 0 && Offset >= 0x6d)
+	{
+		TempChn = &chip->channel[BSMT2000_ADPCM_INDEX];
+		switch (Offset) {
+		case 0x6d:
+			reg = BSMT2000_REG_LOOPEND;
+			break;
+        case 0x6f:
+			reg = BSMT2000_REG_BANK;
+            break;
+        case 0x75:
+			reg = BSMT2000_REG_CURRPOS;
+            break;
+        }
+    }
+
+	switch (reg)
+	{
+	case BSMT2000_REG_BANK:
+		TempChn->bank = Value; // REG_BANK
+		break;
+	case BSMT2000_REG_LOOPEND:
+		TempChn->end = Value;
+		break;
+	case BSMT2000_REG_CURRPOS:
+		TempChn->address = Value;
+		break;
+	default:
+		return;
+	}
+
+	Bank = TempChn->bank << 16;
+	StAddr = TempChn->address;
+	EndAddr = TempChn->end;
+	if (Bank >= chip->ROMSize)
+		return;
+	EndAddr ++;
+	for (Addr = StAddr; Addr < EndAddr; Addr ++)
+		chip->ROMUsage[Bank + (Addr & 0xffff)] |= 0x01;
+
+	return;
+}
+
 #define ROM_BORDER_CHECK					\
 	if (DataStart > ROMSize)				\
 		return;								\
@@ -3455,6 +3622,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 	K007232_DATA* k007232;
 	K005289_DATA* k005289;
 	ICS2115_DATA* ics2115;
+	BSMT2000_DATA* bsmt2000;
 
 	switch(ROMType)
 	{
@@ -3836,6 +4004,22 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 		memcpy(k007232->ROMData + DataStart, ROMData, DataLength);
 		memset(k007232->ROMUsage + DataStart, 0x00, DataLength);
 		break;
+	case 0x95:	// BSMT2000 ROM
+		bsmt2000 = &ChDat->BSMT2000;
+
+		if (bsmt2000->ROMSize != ROMSize)
+		{
+			bsmt2000->ROMData = (UINT8*)realloc(bsmt2000->ROMData, ROMSize);
+			bsmt2000->ROMUsage = (UINT8*)realloc(bsmt2000->ROMUsage, ROMSize);
+			bsmt2000->ROMSize = ROMSize;
+			memset(bsmt2000->ROMData, 0xFF, ROMSize);
+			memset(bsmt2000->ROMUsage, 0x02, ROMSize);
+		}
+
+		ROM_BORDER_CHECK
+		memcpy(bsmt2000->ROMData + DataStart, ROMData, DataLength);
+		memset(bsmt2000->ROMUsage + DataStart, 0x00, DataLength);
+		break;
 	case 0x96:	// ICS2115 ROM
 		ics2115 = &ChDat->ICS2115;
 
@@ -3953,6 +4137,7 @@ UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData)
 	K007232_DATA* k007232;
 	K005289_DATA* k005289;
 	ICS2115_DATA* ics2115;
+	BSMT2000_DATA* bsmt2000;
 
 	switch(ROMType)
 	{
@@ -4062,6 +4247,11 @@ UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData)
 
 		*MaskData = k007232->ROMUsage;
 		return k007232->ROMSize;
+	case 0x95:	// BSMT2000 ROM
+		bsmt2000 = &ChDat->BSMT2000;
+
+		*MaskData = bsmt2000->ROMUsage;
+		return bsmt2000->ROMSize;
 	case 0x96:	// ICS2115 ROM
 		ics2115 = &ChDat->ICS2115;
 
@@ -4123,6 +4313,7 @@ UINT32 GetROMData(UINT8 ROMType, UINT8** ROMData)
 	K007232_DATA* k007232;
 	K005289_DATA* k005289;
 	ICS2115_DATA* ics2115;
+	BSMT2000_DATA* bsmt2000;
 
 	switch(ROMType)
 	{
@@ -4231,6 +4422,11 @@ UINT32 GetROMData(UINT8 ROMType, UINT8** ROMData)
 
 		*ROMData = k007232->ROMData;
 		return k007232->ROMSize;
+	case 0x95:	// BSMT2000 ROM
+		bsmt2000 = &ChDat->BSMT2000;
+
+		*ROMData = bsmt2000->ROMData;
+		return bsmt2000->ROMSize;
 	case 0x96:	// ICS2115 ROM
 		ics2115 = &ChDat->ICS2115;
 

--- a/chip_srom.c
+++ b/chip_srom.c
@@ -341,18 +341,18 @@ typedef struct x1010_data
 #define K007232_PCM_MAX   2
 
 typedef struct {
-    UINT32 start;     // start address (17 bits)
-    UINT16 step;      // frequency/step value (12 bits)
-    UINT32 bank;      // base bank address (upper bits, shifted left by 17)
+	UINT32 start;     // start address (17 bits)
+	UINT16 step;      // frequency/step value (12 bits)
+	UINT32 bank;      // base bank address (upper bits, shifted left by 17)
 } K007232_CHANNEL;
 
 typedef struct k007232_data
 {
-    K007232_CHANNEL channel[K007232_PCM_MAX];
-    UINT8 wreg[0x10];
-    UINT32 ROMSize;
-    UINT8* ROMData;
-    UINT8* ROMUsage;
+	K007232_CHANNEL channel[K007232_PCM_MAX];
+	UINT8 wreg[0x10];
+	UINT32 ROMSize;
+	UINT8* ROMData;
+	UINT8* ROMUsage;
 } K007232_DATA;
 
 typedef struct k005289_channel
@@ -563,14 +563,14 @@ typedef struct ics2115_data
 #define BSMT2000_MAX_VOICES   (BSMT2000_CHANNELS + 1)  /* 12 PCM + 1 ADPCM/compressed */
 
 static const UINT8 bsmt2000_regmap[8][7] = {
-    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
-    { 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
-    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
-    { 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
-    { 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
+	{ 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
+	{ 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
+	{ 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
+	{ 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
+	{ 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
 
 typedef struct _bsmt2000_channel
 {
@@ -1751,73 +1751,73 @@ static void k007232_keyon(K007232_DATA* chip, K007232_CHANNEL* v)
 
 void k007232_write(UINT8 offset, UINT8 data)
 {
-    K007232_DATA* chip = &ChDat->K007232;
-    int reg_base;
-    int ch;
-    K007232_CHANNEL* v;
+	K007232_DATA* chip = &ChDat->K007232;
+	int reg_base;
+	int ch;
+	K007232_CHANNEL* v;
 
-    // Handle register 0x1F as a special "read" trigger
-    if (offset == 0x1F) {
-        // "data" is the original offset; treat as a read at that offset
-        if (data == 5 || data == 11) {
-            ch = (data >= 6) ? 1 : 0;
-            k007232_keyon(chip, &chip->channel[ch]);
-        }
-        return;
-    }
+	// Handle register 0x1F as a special "read" trigger
+	if (offset == 0x1F) {
+		// "data" is the original offset; treat as a read at that offset
+		if (data == 5 || data == 11) {
+			ch = (data >= 6) ? 1 : 0;
+			k007232_keyon(chip, &chip->channel[ch]);
+		}
+		return;
+	}
 
-    if(offset >= 0x14 && offset <= 0x15) {
-        switch(offset) {
-            case 0x14:
-                chip->channel[0].bank = data << 17;
-                break;
-            case 0x15:
-                chip->channel[1].bank = data << 17;
-                break;
-        }
-        return;
-    }
+	if(offset >= 0x14 && offset <= 0x15) {
+		switch(offset) {
+			case 0x14:
+				chip->channel[0].bank = data << 17;
+				break;
+			case 0x15:
+				chip->channel[1].bank = data << 17;
+				break;
+		}
+		return;
+	}
 
-    ch = offset / 6;
-    if(ch >= K007232_PCM_MAX) return;
+	ch = offset / 6;
+	if(ch >= K007232_PCM_MAX) return;
 
-    v = &chip->channel[ch];
-    reg_base = ch * 6;
+	v = &chip->channel[ch];
+	reg_base = ch * 6;
 
-    chip->wreg[offset] = data;
+	chip->wreg[offset] = data;
 
-    switch(offset - reg_base)
-    {
-        case 0x00: // Pitch LSB
-        case 0x01: // Pitch MSB
-            v->step = ((chip->wreg[reg_base + 1] & 0x0F) << 8) |
-                       chip->wreg[reg_base + 0];
-            break;
-        case 0x02: // Start LSB
-        case 0x03: // Start MID
-        case 0x04: // Start MSB
-            v->start = ((chip->wreg[reg_base + 4] & 0x01) << 16) |
-                       (chip->wreg[reg_base + 3] << 8) |
-                        chip->wreg[reg_base + 2];
-            break;
-        case 0x05: // Key On
-            k007232_keyon(chip, v);
-            break;
-    }
-    return;
+	switch(offset - reg_base)
+	{
+		case 0x00: // Pitch LSB
+		case 0x01: // Pitch MSB
+			v->step = ((chip->wreg[reg_base + 1] & 0x0F) << 8) |
+					   chip->wreg[reg_base + 0];
+			break;
+		case 0x02: // Start LSB
+		case 0x03: // Start MID
+		case 0x04: // Start MSB
+			v->start = ((chip->wreg[reg_base + 4] & 0x01) << 16) |
+					   (chip->wreg[reg_base + 3] << 8) |
+						chip->wreg[reg_base + 2];
+			break;
+		case 0x05: // Key On
+			k007232_keyon(chip, v);
+			break;
+	}
+	return;
 }
 
 void k005289_write(UINT8 Offset, UINT16 data)
 {
-    K005289_DATA* chip = &ChDat->K005289;
-    int ch;
-    K005289_CHANNEL* v;
+	K005289_DATA* chip = &ChDat->K005289;
+	int ch;
+	K005289_CHANNEL* v;
 	UINT32 start;
 	UINT32 addr;
 	UINT32 end;
 
-    ch = Offset & 1;
-    v = &chip->channel[ch];
+	ch = Offset & 1;
+	v = &chip->channel[ch];
 
 	switch (Offset)
 	{
@@ -3489,36 +3489,36 @@ void bsmt2000_write(UINT8 Offset, UINT16 Value)
 	{
 		switch (Value & 0xFF)
 		{
-        /* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
-        case 0:
-            chip->Voices = 12;
-            chip->ADPCM = 1;
-            chip->Mode = 0;
-            break;
-        /* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
-        case 1:
-            chip->Voices = 11;
-            chip->ADPCM = 1;
-            chip->Mode = 1;
-            break;
-        /* mode 5: 24kHz, 12 channel PCM, stereo */
-        case 5:
-            chip->Voices = 12;
-            chip->ADPCM = 0;
-            chip->Mode = 5;
-            break;
-        /* mode 6: 34kHz, 8 channel PCM, stereo */
-        case 6:
-            chip->Voices = 8;
-            chip->ADPCM = 0;
-            chip->Mode = 6;
-            break;
-        /* mode 7: 32kHz, 9 channel PCM, stereo */
-        case 7:
-            chip->Voices = 9;
-            chip->ADPCM = 0;
-            chip->Mode = 7;
-            break;
+		/* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
+		case 0:
+			chip->Voices = 12;
+			chip->ADPCM = 1;
+			chip->Mode = 0;
+			break;
+		/* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
+		case 1:
+			chip->Voices = 11;
+			chip->ADPCM = 1;
+			chip->Mode = 1;
+			break;
+		/* mode 5: 24kHz, 12 channel PCM, stereo */
+		case 5:
+			chip->Voices = 12;
+			chip->ADPCM = 0;
+			chip->Mode = 5;
+			break;
+		/* mode 6: 34kHz, 8 channel PCM, stereo */
+		case 6:
+			chip->Voices = 8;
+			chip->ADPCM = 0;
+			chip->Mode = 6;
+			break;
+		/* mode 7: 32kHz, 9 channel PCM, stereo */
+		case 7:
+			chip->Voices = 9;
+			chip->ADPCM = 0;
+			chip->Mode = 7;
+			break;
 		}
 		for (ch = 0; ch < BSMT2000_MAX_VOICES; ch++)
 		{
@@ -3542,25 +3542,25 @@ void bsmt2000_write(UINT8 Offset, UINT16 Value)
 		if (voice_index >= chip->Voices)
 			return;
 
-        TempChn = &chip->channel[voice_index];
+		TempChn = &chip->channel[voice_index];
 		reg = regindex;
-    }
-    // Compressed/ADPCM channel (11-voice model only)
-    else if (chip->ADPCM != 0 && Offset >= 0x6d)
+	}
+	// Compressed/ADPCM channel (11-voice model only)
+	else if (chip->ADPCM != 0 && Offset >= 0x6d)
 	{
 		TempChn = &chip->channel[BSMT2000_ADPCM_INDEX];
 		switch (Offset) {
 		case 0x6d:
 			reg = BSMT2000_REG_LOOPEND;
 			break;
-        case 0x6f:
+		case 0x6f:
 			reg = BSMT2000_REG_BANK;
-            break;
-        case 0x75:
+			break;
+		case 0x75:
 			reg = BSMT2000_REG_CURRPOS;
-            break;
-        }
-    }
+			break;
+		}
+	}
 
 	switch (reg)
 	{

--- a/chip_srom.c
+++ b/chip_srom.c
@@ -512,6 +512,44 @@ typedef struct es5506_data
 	ES5506_VOICE voice[32];
 } ES5506_DATA;
 
+
+typedef struct ics2115_voice
+{
+	struct {
+		UINT32 acc, start, end; // address counters (20.9 fixed point)
+		UINT8 ctl, saddr;
+	} osc;
+
+	union {
+		struct {
+			UINT8 ulaw       : 1;   // compressed sample format
+			UINT8 stop       : 1;   // stops wave + vol envelope
+			UINT8 eightbit   : 1;   // 8 bit sample format
+			UINT8 loop       : 1;   // loop enable
+			UINT8 loop_bidir : 1;   // bi-directional loop enable
+			UINT8 irq        : 1;   // enable IRQ generation
+			UINT8 invert     : 1;   // invert direction
+			UINT8 irq_pending: 1;   // (read only?) IRQ pending
+			// IRQ on variable?
+		} bitflags;
+		UINT8 value;
+	} osc_conf;
+	struct {
+		bool on;
+	} state;
+} ICS2115_VOICE;
+typedef struct ics2115_data
+{
+	UINT32 ROMSize;
+	UINT8* ROMData;
+	UINT8* ROMUsage;
+	UINT8 regAddr; // Register address
+	UINT8 voiceSel; // Voice select
+	UINT8 voiceCount;
+	ICS2115_VOICE voice[32];
+} ICS2115_DATA;
+
+
 typedef struct all_chips
 {
 	SEGAPCM_DATA SegaPCM;
@@ -538,6 +576,7 @@ typedef struct all_chips
 	GA20_DATA GA20;
 	K007232_DATA K007232;
 	K005289_DATA K005289;
+	ICS2115_DATA ICS2115;
 } ALL_CHIPS;
 
 void InitAllChips(void);
@@ -574,7 +613,8 @@ void es5503_write(UINT8 Register, UINT8 Data);
 void ymf278b_write(UINT8 Port, UINT8 Register, UINT8 Data);
 void es550x_w(UINT8 Offset, UINT8 Data);
 void es550x_w16(UINT8 Offset, UINT16 Data);
-void k005289_write(UINT8 offset, UINT16 data);
+void k005289_write(UINT8 Offset, UINT16 data);
+void ics2115_write(UINT8 Offset, UINT8 data);
 void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 DataLength,
 					const UINT8* ROMData);
 UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData);
@@ -632,6 +672,7 @@ void InitAllChips(void)
 		ChDat->K054539.flags = K054539_RESET_FLAGS;
 		ChDat->C140.banking_type = 0x00;
 		ChDat->ES5506.voiceCount = 32;
+		ChDat->ICS2115.voiceCount = 31;
 
 		for (CurChn = 0; CurChn < 28; CurChn ++)
 			ChDat->MultiPCM.slot[CurChn].SmplID = 0xFFFF;
@@ -1719,7 +1760,7 @@ void k007232_write(UINT8 offset, UINT8 data)
     return;
 }
 
-void k005289_write(UINT8 offset, UINT16 data)
+void k005289_write(UINT8 Offset, UINT16 data)
 {
     K005289_DATA* chip = &ChDat->K005289;
     int ch;
@@ -1728,10 +1769,10 @@ void k005289_write(UINT8 offset, UINT16 data)
 	UINT32 addr;
 	UINT32 end;
 
-    ch = offset & 1;
+    ch = Offset & 1;
     v = &chip->channel[ch];
 
-	switch (offset)
+	switch (Offset)
 	{
 		case 0:
 		case 1:
@@ -3223,6 +3264,164 @@ void es550x_w16(UINT8 Offset, UINT16 Data)
 	return;
 }
 
+
+
+static void ics2115_do_ctrl(ICS2115_DATA* chip, ICS2115_VOICE* voice)
+{
+	UINT32 baseOfs = (voice->osc.saddr & 0x0F) << 20;
+	UINT32 AddrSt;
+	UINT32 AddrEnd;
+	UINT32 CurAddr;
+
+	if ((chip->voiceSel & 0x1F) > chip->voiceCount)
+		return;
+	if (voice->osc_conf.bitflags.stop)
+		return;
+	if (voice->osc.start > voice->osc.end)
+		return;
+
+	CurAddr = voice->osc.acc >> 12;
+	AddrSt = voice->osc.start >> 12;
+	AddrEnd = voice->osc.end >> 12;
+	if (! (voice->osc_conf.bitflags.invert))
+	{
+		// playing forwards
+		if (CurAddr < AddrSt)
+			AddrSt = CurAddr;
+	}
+	else
+	{
+		// playing backwards
+		if (CurAddr > AddrEnd)
+			AddrEnd = CurAddr;
+	}
+	AddrEnd ++;	// turn <= into <
+
+	// Offsets are indices into 8-Bit data.
+	for (CurAddr = AddrSt; CurAddr < AddrEnd; CurAddr ++)
+		chip->ROMUsage[baseOfs + CurAddr] |= 0x01;
+
+	voice->state.on = false;
+
+	return;
+}
+
+#define ACCESSING_BITS_8_15 ((Mask & 0xFF00) != 0)
+#define ACCESSING_BITS_0_7 ((Mask & 0x00FF) != 0)
+
+static void ics2115_regs_w(ICS2115_DATA* chip, UINT8 Offset, UINT16 Data, UINT16 Mask)
+{
+	ICS2115_VOICE* voice = &chip->voice[chip->voiceSel & 0x1F];
+	if (Offset == 0x4F)	// voice select
+	{
+		if (ACCESSING_BITS_0_7)
+			chip->voiceSel = (Data & 0xff) % (1 + chip->voiceCount);
+		return;
+	}
+	// per-voice register
+	switch(Offset)
+	{
+	case 0x00: // [osc] Oscillator Configuration
+		if (ACCESSING_BITS_8_15)
+		{
+			voice->osc_conf.value &= 0x80;
+			voice->osc_conf.value |= (Data >> 8) & 0x7f;
+			if (voice->state.on && (!voice->osc_conf.bitflags.stop))
+				ics2115_do_ctrl(chip, voice);
+		}
+		break;
+	case 0x02: // [osc] Wavesample loop start high
+		if (ACCESSING_BITS_8_15)
+			voice->osc.start = (voice->osc.start & 0x00ffffff) | ((Data & 0xff00) << 16);
+		if (ACCESSING_BITS_0_7)
+			voice->osc.start = (voice->osc.start & 0xff00ffff) | ((Data & 0x00ff) << 16);
+		break;
+
+	case 0x03: // [osc] Wavesample loop start low
+		if (ACCESSING_BITS_8_15)
+			voice->osc.start = (voice->osc.start & 0xffff00ff) | (Data & 0xff00);
+		// This is unused?
+		//if (ACCESSING_BITS_0_7)
+			//voice->osc.start = (voice->osc.start & 0xffffff00) | (Data & 0);
+		break;
+
+	case 0x04: // [osc] Wavesample loop end high
+		if (ACCESSING_BITS_8_15)
+			voice->osc.end = (voice->osc.end & 0x00ffffff) | ((Data & 0xff00) << 16);
+		if (ACCESSING_BITS_0_7)
+			voice->osc.end = (voice->osc.end & 0xff00ffff) | ((Data & 0x00ff) << 16);
+		break;
+
+	case 0x05: // [osc] Wavesample loop end low
+		if (ACCESSING_BITS_8_15)
+			voice->osc.end = (voice->osc.end & 0xffff00ff) | (Data & 0xff00);
+		// lsb is unused?
+		break;
+
+	case 0x0a: // [osc] Wavesample address high
+		if (ACCESSING_BITS_8_15)
+			voice->osc.acc = (voice->osc.acc & 0x00ffffff) | ((Data & 0xff00) << 16);
+		if (ACCESSING_BITS_0_7)
+			voice->osc.acc = (voice->osc.acc & 0xff00ffff) | ((Data & 0x00ff) << 16);
+		break;
+
+	case 0x0b: // [osc] Wavesample address low
+		if (ACCESSING_BITS_8_15)
+			voice->osc.acc = (voice->osc.acc & 0xffff00ff) | (Data & 0xff00);
+		if (ACCESSING_BITS_0_7)
+			voice->osc.acc = (voice->osc.acc & 0xffffff00) | (Data & 0x00f8);
+		break;
+
+	case 0x0e: // Active Voices
+		//Does this value get added to 1? Not sure. Could trace for writes of 32.
+		if (ACCESSING_BITS_8_15)
+			chip->voiceCount = (Data >> 8) & 0x1f; // & 0x1f ? (Guessing)
+		break;
+	//2X8 ?
+	case 0x10: // [osc] Oscillator Control
+		//Could this be 2X9?
+		//[7 R | 6 M2 | 5 M1 | 4-2 Reserve | 1 - Timer 2 Strt | 0 - Timer 1 Strt]
+
+		if (ACCESSING_BITS_8_15)
+		{
+			Data >>= 8;
+			voice->osc.ctl = (UINT8)Data;
+			voice->state.on = !voice->osc.ctl; // some early PGM games need this
+			if (!Data)
+				ics2115_do_ctrl(chip, voice);
+		}
+		break;
+
+	case 0x11: // [osc] Wavesample static address 27-20
+		if (ACCESSING_BITS_8_15)
+			voice->osc.saddr = (Data >> 8);
+		break;
+	default:
+		break;
+	}
+
+	return;
+}
+
+void ics2115_write(UINT8 Offset, UINT8 Data)
+{
+	ICS2115_DATA* chip = &ChDat->ICS2115;
+
+	switch (Offset & 0x03)
+	{
+	case 0x01:
+		chip->regAddr = Data;
+		break;
+	case 0x02: // Register data LSB
+		ics2115_regs_w(chip, chip->regAddr, Data, 0x00FF);
+		break;
+	case 0x03: // Register data MSB
+		ics2115_regs_w(chip, chip->regAddr, Data << 8, 0xFF00);
+		break;
+	}
+	return;
+}
+
 #define ROM_BORDER_CHECK					\
 	if (DataStart > ROMSize)				\
 		return;								\
@@ -3255,6 +3454,7 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 	GA20_DATA* ga20;
 	K007232_DATA* k007232;
 	K005289_DATA* k005289;
+	ICS2115_DATA* ics2115;
 
 	switch(ROMType)
 	{
@@ -3636,6 +3836,22 @@ void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 Data
 		memcpy(k007232->ROMData + DataStart, ROMData, DataLength);
 		memset(k007232->ROMUsage + DataStart, 0x00, DataLength);
 		break;
+	case 0x96:	// ICS2115 ROM
+		ics2115 = &ChDat->ICS2115;
+
+		if (ics2115->ROMSize != ROMSize)
+		{
+			ics2115->ROMData = (UINT8*)realloc(ics2115->ROMData, ROMSize);
+			ics2115->ROMUsage = (UINT8*)realloc(ics2115->ROMUsage, ROMSize);
+			ics2115->ROMSize = ROMSize;
+			memset(ics2115->ROMData, 0xFF, ROMSize);
+			memset(ics2115->ROMUsage, 0x02, ROMSize);
+		}
+
+		ROM_BORDER_CHECK
+		memcpy(ics2115->ROMData + DataStart, ROMData, DataLength);
+		memset(ics2115->ROMUsage + DataStart, 0x00, DataLength);
+		break;
 	case 0xC0:	// RF5C68 RAM
 	case 0xC1:	// RF5C164 RAM
 		rf5c = (ROMType == 0xC0) ? &ChDat->RF5C68 : &ChDat->RF5C164;
@@ -3736,6 +3952,7 @@ UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData)
 	GA20_DATA* ga20;
 	K007232_DATA* k007232;
 	K005289_DATA* k005289;
+	ICS2115_DATA* ics2115;
 
 	switch(ROMType)
 	{
@@ -3845,6 +4062,11 @@ UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData)
 
 		*MaskData = k007232->ROMUsage;
 		return k007232->ROMSize;
+	case 0x96:	// ICS2115 ROM
+		ics2115 = &ChDat->ICS2115;
+
+		*MaskData = ics2115->ROMUsage;
+		return ics2115->ROMSize;
 	case 0xC0:	// RF5C68 RAM
 		rf5c = &ChDat->RF5C68;
 
@@ -3900,6 +4122,7 @@ UINT32 GetROMData(UINT8 ROMType, UINT8** ROMData)
 	GA20_DATA* ga20;
 	K007232_DATA* k007232;
 	K005289_DATA* k005289;
+	ICS2115_DATA* ics2115;
 
 	switch(ROMType)
 	{
@@ -4003,11 +4226,16 @@ UINT32 GetROMData(UINT8 ROMType, UINT8** ROMData)
 
 		*ROMData = ga20->ROMData;
 		return ga20->ROMSize;
-	case 0x94:	// GA20 ROM
+	case 0x94:	// K007232 ROM
 		k007232 = &ChDat->K007232;
 
 		*ROMData = k007232->ROMData;
 		return k007232->ROMSize;
+	case 0x96:	// ICS2115 ROM
+		ics2115 = &ChDat->ICS2115;
+
+		*ROMData = ics2115->ROMData;
+		return ics2115->ROMSize;
 	case 0xC0:	// RF5C68 RAM
 		rf5c = &ChDat->RF5C68;
 

--- a/chip_strp.c
+++ b/chip_strp.c
@@ -112,6 +112,15 @@ typedef struct k005289_data
 	UINT8 RegFirst[0x8];
 } K005289_DATA;
 
+typedef struct ics2115_data
+{
+	UINT8 ChnSel;
+	UINT8 ChnCnt;
+	UINT8 RegSel;
+	UINT16 RegData[0x80 * 0x20];
+	UINT8 RegFirst[0x80 * 0x20];
+} ICS2115_DATA;
+
 typedef struct all_chips
 {
 	//UINT8 GGSt;
@@ -134,6 +143,7 @@ typedef struct all_chips
 	RF5C68_DATA RF5C164;
 	C140_DATA C140;
 	K005289_DATA K005289;
+	ICS2115_DATA ICS2115;
 } ALL_CHIPS;
 
 
@@ -711,3 +721,43 @@ bool k005289_write(UINT8 Register, UINT16 Data)
 	return true;
 }
 
+bool ics2115_write(UINT8 Register, UINT8 Data)
+{
+	STRIP_PCM* strip = &StpDat->ICS2115;
+	UINT16 RegVal;
+
+	if (strip->All)
+		return false;
+
+	switch (Register)
+	{
+		case 0x01:
+			ChDat->ICS2115.RegSel = Data;
+			break;
+		case 0x02:
+			switch (ChDat->ICS2115.RegSel)
+			{
+				case 0x4F:
+					ChDat->ICS2115.ChnSel = (Data & 0xFF) % (ChDat->ICS2115.ChnCnt + 1);
+					break;
+			}
+			RegVal = ChDat->ICS2115.RegSel;
+			if ((ChDat->ICS2115.RegSel <= 0x12) && (ChDat->ICS2115.RegSel != 0x0E))
+				RegVal |= (ChDat->ICS2115.ChnSel << 7);
+			ChDat->ICS2115.RegData[RegVal] = (ChDat->ICS2115.RegData[RegVal] & 0xFF00) | Data;
+			break;
+		case 0x03:
+			switch (ChDat->ICS2115.RegSel)
+			{
+				case 0x0E:
+					ChDat->ICS2115.ChnCnt = Data & 0x1F;
+					break;
+			}
+			RegVal = ChDat->ICS2115.RegSel;
+			if ((ChDat->ICS2115.RegSel <= 0x12) && (ChDat->ICS2115.RegSel != 0x0E))
+				RegVal |= (ChDat->ICS2115.ChnSel << 7);
+			ChDat->ICS2115.RegData[RegVal] = (ChDat->ICS2115.RegData[RegVal] & 0x00FF) | (((UINT16)Data) << 8);
+			break;
+	}
+	return true;
+}

--- a/chip_strp.c
+++ b/chip_strp.c
@@ -176,6 +176,9 @@ void InitAllChips(void)
 	for (CurChip = 0x00; CurChip < ChipCount; CurChip ++)
 	{
 		memset(ChipData, 0xFF, ChipCount * sizeof(ALL_CHIPS));
+		ChipData->ICS2115.ChnCnt = 31;
+		ChipData->ICS2115.ChnSel = 0;
+		ChipData->ICS2115.RegSel = 0;
 	}
 
 	SetChipSet(0x00);
@@ -750,6 +753,7 @@ bool k005289_write(UINT8 Register, UINT16 Data)
 bool ics2115_write(UINT8 Register, UINT8 Data)
 {
 	STRIP_PCM* strip = &StpDat->ICS2115;
+	ICS2115_DATA* chip = &ChDat->ICS2115;
 	UINT16 RegVal;
 
 	if (strip->All)
@@ -758,31 +762,64 @@ bool ics2115_write(UINT8 Register, UINT8 Data)
 	switch (Register)
 	{
 		case 0x01:
-			ChDat->ICS2115.RegSel = Data;
+			chip->RegSel = Data;
+			return true;
 			break;
 		case 0x02:
-			switch (ChDat->ICS2115.RegSel)
+			RegVal = chip->RegSel;
+			if ((chip->RegSel <= 0x12) && (chip->RegSel != 0x0E))
 			{
+				if (strip->ChnMask & (0x01 << chip->ChnSel))
+					return false;
+
+				RegVal |= (chip->ChnSel << 7);
+			}
+			switch (chip->RegSel)
+			{
+				case 0x01:
+					Data &= 0xFE; // ignore lowest bit
+					break;
+				case 0x09:
+				case 0x0A:
+				case 0x0B:
+					return true;
 				case 0x4F:
-					ChDat->ICS2115.ChnSel = (Data & 0xFF) % (ChDat->ICS2115.ChnCnt + 1);
+					chip->ChnSel = (Data & 0xFF) % (chip->ChnCnt + 1);
 					break;
 			}
-			RegVal = ChDat->ICS2115.RegSel;
-			if ((ChDat->ICS2115.RegSel <= 0x12) && (ChDat->ICS2115.RegSel != 0x0E))
-				RegVal |= (ChDat->ICS2115.ChnSel << 7);
-			ChDat->ICS2115.RegData[RegVal] = (ChDat->ICS2115.RegData[RegVal] & 0xFF00) | Data;
+			if (! chip->RegFirst[RegVal] && Data == (chip->RegData[RegVal] & 0xFF))
+				return false;
+
+			chip->RegFirst[RegVal] = 0x00;
+			chip->RegData[RegVal] = (chip->RegData[RegVal] & 0xFF00) | Data;
 			break;
 		case 0x03:
-			switch (ChDat->ICS2115.RegSel)
+			RegVal = chip->RegSel;
+			if ((chip->RegSel <= 0x12) && (chip->RegSel != 0x0E))
 			{
+				if (strip->ChnMask & (0x01 << chip->ChnSel))
+					return false;
+
+				RegVal |= (chip->ChnSel << 7);
+			}
+			switch (chip->RegSel)
+			{
+				case 0x00:
+				case 0x09:
+				case 0x0A:
+				case 0x0B:
+				case 0x0D:
+					return true;
 				case 0x0E:
-					ChDat->ICS2115.ChnCnt = Data & 0x1F;
+					Data &= 0x1F;
+					chip->ChnCnt = Data;
 					break;
 			}
-			RegVal = ChDat->ICS2115.RegSel;
-			if ((ChDat->ICS2115.RegSel <= 0x12) && (ChDat->ICS2115.RegSel != 0x0E))
-				RegVal |= (ChDat->ICS2115.ChnSel << 7);
-			ChDat->ICS2115.RegData[RegVal] = (ChDat->ICS2115.RegData[RegVal] & 0x00FF) | (((UINT16)Data) << 8);
+			if (! chip->RegFirst[RegVal] && Data == ((chip->RegData[RegVal] >> 8) & 0xFF))
+				return false;
+
+			chip->RegFirst[RegVal] = 0x00;
+			chip->RegData[RegVal] = (chip->RegData[RegVal] & 0x00FF) | (((UINT16)Data) << 8);
 			break;
 	}
 	return true;

--- a/chip_strp.c
+++ b/chip_strp.c
@@ -121,6 +121,12 @@ typedef struct ics2115_data
 	UINT8 RegFirst[0x80 * 0x20];
 } ICS2115_DATA;
 
+typedef struct mikey_data
+{
+	UINT16 RegData[0x51];
+	UINT8 RegFirst[0x51];
+} MIKEY_DATA;
+
 typedef struct all_chips
 {
 	//UINT8 GGSt;
@@ -144,6 +150,7 @@ typedef struct all_chips
 	C140_DATA C140;
 	K005289_DATA K005289;
 	ICS2115_DATA ICS2115;
+	MIKEY_DATA Mikey;
 } ALL_CHIPS;
 
 
@@ -759,5 +766,58 @@ bool ics2115_write(UINT8 Register, UINT8 Data)
 			ChDat->ICS2115.RegData[RegVal] = (ChDat->ICS2115.RegData[RegVal] & 0x00FF) | (((UINT16)Data) << 8);
 			break;
 	}
+	return true;
+}
+
+bool mikey_write(UINT8 Register, UINT8 Data)
+{
+	MIKEY_DATA* chip = &ChDat->Mikey;
+	STRIP_PSG* strip = &StpDat->Mikey;
+	UINT8 Channel;
+	UINT8 ChnMask;
+
+	if (strip->All)
+		return false;
+
+	if (Register < 0x20)
+		return false;
+	else if (Register < 0x40)
+	{
+		Channel = (Register >> 3) & 3;
+		if (strip->ChnMask & (0x01 << Channel))
+			return false;
+		if ((Register & 0x07) == 0x02)
+			return true;
+	}
+	else
+	{
+		switch (Register)
+		{
+		case 0x40:
+		case 0x41:
+		case 0x42:
+		case 0x43:
+			Channel = Register & 3;
+			if (strip->ChnMask & (0x01 << Channel))
+				return false;
+			break;
+		case 0x44:
+		case 0x50:
+			ChnMask = 0x11;
+			for (Channel = 0; Channel < 4; Channel ++, ChnMask <<= 1)
+			{
+				// 0 - enable, 1 - disable
+				//      Channel Enable &&    Strip Channel
+				if (((Data & ChnMask) != ChnMask) && (strip->ChnMask & (0x01 << Channel)))
+					Data |= ChnMask;	// disable channel
+			}
+			break;
+		}
+	}
+	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
+		return false;
+
+	chip->RegFirst[Register] = 0x00;
+	chip->RegData[Register] = Data;
 	return true;
 }

--- a/chip_strp.c
+++ b/chip_strp.c
@@ -127,6 +127,12 @@ typedef struct mikey_data
 	UINT8 RegFirst[0x51];
 } MIKEY_DATA;
 
+typedef struct okim5232_data
+{
+	UINT16 RegData[0x24];
+	UINT8 RegFirst[0x24];
+} OKIM5232_DATA;
+
 typedef struct all_chips
 {
 	//UINT8 GGSt;
@@ -151,6 +157,7 @@ typedef struct all_chips
 	K005289_DATA K005289;
 	ICS2115_DATA ICS2115;
 	MIKEY_DATA Mikey;
+	OKIM5232_DATA OKIM5232;
 } ALL_CHIPS;
 
 
@@ -719,12 +726,24 @@ bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data)
 bool k005289_write(UINT8 Register, UINT16 Data)
 {
 	STRIP_PSG* strip = &StpDat->K005289;
+	K005289_DATA* chip = &ChDat->K005289;
+	UINT8 Channel;
 
 	if (strip->All)
 		return false;
-	return true;
-	ChDat->K005289.RegFirst[Register] = 0x00;
-	ChDat->K005289.RegData[Register] = Data;
+
+	Channel = Register & 1;
+	if (strip->ChnMask & (0x01 << Channel))
+		return false;
+
+	if ((Register & 0x06) == 0x04)
+		return true;
+
+	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
+		return false;
+
+	chip->RegFirst[Register] = 0x00;
+	chip->RegData[Register] = Data;
 	return true;
 }
 
@@ -819,5 +838,30 @@ bool mikey_write(UINT8 Register, UINT8 Data)
 
 	chip->RegFirst[Register] = 0x00;
 	chip->RegData[Register] = Data;
+	return true;
+}
+
+bool okim5232_write(UINT8 Register, UINT8 Data)
+{
+	STRIP_PSG* strip = &StpDat->OKIM5232;
+	OKIM5232_DATA* chip = &ChDat->OKIM5232;
+	UINT16 RegVal;
+	UINT8 Channel;
+
+	if (strip->All)
+		return false;
+
+	if (Register < 0x08)
+	{
+		Channel = Register & 0x07;
+		if (strip->ChnMask & (0x01 << Channel))
+			return false;
+	}
+	if (! chip->RegFirst[Register] && Data == chip->RegData[Register])
+		return false;
+
+	chip->RegFirst[Register] = 0x00;
+	chip->RegData[Register] = Data;
+
 	return true;
 }

--- a/chip_strp.h
+++ b/chip_strp.h
@@ -103,6 +103,7 @@ typedef struct strip_data
 	STRIP_PCM ICS2115;
 	STRIP_PSG Mikey;
 	STRIP_PCM OKIM5205;
+	STRIP_PSG OKIM5232;
 	bool Unknown;
 } STRIP_DATA;
 
@@ -131,3 +132,4 @@ bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
+bool okim5232_write(UINT8 Register, UINT8 Data);

--- a/chip_strp.h
+++ b/chip_strp.h
@@ -102,6 +102,7 @@ typedef struct strip_data
 	STRIP_OPX QSound;
 	STRIP_PCM ICS2115;
 	STRIP_PSG Mikey;
+	STRIP_PCM OKIM5205;
 	bool Unknown;
 } STRIP_DATA;
 

--- a/chip_strp.h
+++ b/chip_strp.h
@@ -104,6 +104,7 @@ typedef struct strip_data
 	STRIP_PSG Mikey;
 	STRIP_PCM OKIM5205;
 	STRIP_PSG OKIM5232;
+	STRIP_PCM BSMT2000;
 	bool Unknown;
 } STRIP_DATA;
 

--- a/chip_strp.h
+++ b/chip_strp.h
@@ -100,6 +100,7 @@ typedef struct strip_data
 	STRIP_PSG K005289;
 	STRIP_PSG Pokey;
 	STRIP_OPX QSound;
+	STRIP_PCM ICS2115;
 	bool Unknown;
 } STRIP_DATA;
 
@@ -126,3 +127,4 @@ bool rf5c164_reg_write(UINT8 Register, UINT8* Data);
 bool rf5c164_mem_write(UINT16 Offset, UINT8 Data);
 bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
+bool ics2115_write(UINT8 Register, UINT8 Data);

--- a/chip_strp.h
+++ b/chip_strp.h
@@ -101,6 +101,7 @@ typedef struct strip_data
 	STRIP_PSG Pokey;
 	STRIP_OPX QSound;
 	STRIP_PCM ICS2115;
+	STRIP_PSG Mikey;
 	bool Unknown;
 } STRIP_DATA;
 
@@ -128,3 +129,4 @@ bool rf5c164_mem_write(UINT16 Offset, UINT8 Data);
 bool c140_write(UINT8 Port, UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
+bool mikey_write(UINT8 Register, UINT8 Data);

--- a/chiptext.c
+++ b/chiptext.c
@@ -56,6 +56,7 @@ typedef struct chip_count
 	UINT32 K005289;
 	UINT32 ICS2115;
 	UINT32 OKIM5205;
+	UINT32 OKIM5232;
 } CHIP_CNT;
 
 
@@ -545,6 +546,10 @@ INLINE UINT32 GetChipName(UINT8 ChipType, const char** RetName)
 	case 0x2C:
 		ChipName = (ChpCnt.OKIM5205 & 0x80000000) ? "OKIM6585" : "OKIM5205";
 		ChipCnt = ChpCnt.OKIM5205;
+		break;
+	case 0x2D:
+		ChipName = "OKIM5232";
+		ChipCnt = ChpCnt.OKIM5232;
 		break;
 	case 0x2F:
 		ChipName = "ICS2115";
@@ -4557,4 +4562,98 @@ void mikey_write(char* TempStr, UINT8 offset, UINT8 data)
 
 	// Final output string
 	sprintf(TempStr, "Mikey: %s", WriteStr);
+}
+
+void okim5232_write(char* TempStr, UINT8 Register, UINT8 Data)
+{
+	UINT8 CurChn;
+
+	WriteChipID(0x2D);
+
+	if (Register < 0x08)
+	{
+		CurChn = Register & 0x7;
+		sprintf(RedirectStr, "Pitch: 0x%02X, GF: %u", Data & 0x7F, (Data >> 7) & 0x01);
+		sprintf(WriteStr, "Ch %u %s", CurChn, RedirectStr);
+	}
+	else
+	{
+		switch(Register)
+		{
+		case 0x08:
+		case 0x09:
+			CurChn = Register & 0x1;
+			sprintf(WriteStr, "Group %u: Attack rate 0x%01X", CurChn, Data & 0x07);
+			break;
+		case 0x0A:
+		case 0x0B:
+			CurChn = Register & 0x1;
+			sprintf(WriteStr, "Group %u: Decay rate 0x%01X", CurChn, Data & 0x0F);
+			break;
+		case 0x0C:
+		case 0x0D:
+			CurChn = Register & 0x1;
+			sprintf(WriteStr, "Group %u: EG Arm=%s, Output: 16=%s, 8=%s, 4=%s, 2=%s",
+				CurChn,
+				OnOff((Data >> 4) & 0x01),
+				OnOff((Data >> 0) & 0x01),
+				OnOff((Data >> 1) & 0x01),
+				OnOff((Data >> 2) & 0x01),
+				OnOff((Data >> 3) & 0x01));
+			break;
+		case 0x10:
+		case 0x14:
+			CurChn = (Register >> 2) & 0x1;
+			sprintf(WriteStr, "Group %u: Output volume 2 0x%02X", CurChn, Data);
+			break;
+		case 0x11:
+		case 0x15:
+			CurChn = (Register >> 2) & 0x1;
+			sprintf(WriteStr, "Group %u: Output volume 4 0x%02X", CurChn, Data);
+			break;
+		case 0x12:
+		case 0x16:
+			CurChn = (Register >> 2) & 0x1;
+			sprintf(WriteStr, "Group %u: Output volume 8 0x%02X", CurChn, Data);
+			break;
+		case 0x13:
+		case 0x17:
+			CurChn = (Register >> 2) & 0x1;
+			sprintf(WriteStr, "Group %u: Output volume 16 0x%02X", CurChn, Data);
+			break;
+		case 0x18:
+			sprintf(WriteStr, "Group 1: Solo output volume 8 0x%02X", Data);
+			break;
+		case 0x19:
+			sprintf(WriteStr, "Group 1: Solo output volume 16 0x%02X", Data);
+			break;
+		case 0x1A:
+			sprintf(WriteStr, "Noise output volume 0x%02X", Data);
+			break;
+		case 0x1E:
+		case 0x1F:
+			CurChn = Register & 0x1;
+			sprintf(WriteStr, "Group %u: External volume 0x%02X", CurChn, Data);
+			break;
+		case 0x20:
+			sprintf(WriteStr, "Set Master Clock: xxxxxx%02X", Data);
+			break;
+		case 0x21:
+			sprintf(WriteStr, "Set Master Clock: xxxx%02Xxx", Data);
+			break;
+		case 0x22:
+			sprintf(WriteStr, "Set Master Clock: xx%02Xxxxx", Data);
+			break;
+		case 0x23:
+			sprintf(WriteStr, "Set Master Clock: %02Xxxxxxx", Data);
+			break;
+		default:
+			sprintf(WriteStr, "Unknown Register 0x%02X: data 0x%02X", Register, Data);
+			break;
+		}
+	}
+
+	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
+
+	return;
 }

--- a/chiptext.c
+++ b/chiptext.c
@@ -55,6 +55,7 @@ typedef struct chip_count
 	UINT32 K007232;
 	UINT32 K005289;
 	UINT32 ICS2115;
+	UINT32 OKIM5205;
 } CHIP_CNT;
 
 
@@ -191,6 +192,12 @@ static const int dpcm_clocks[16] = {428, 380, 340, 320, 286, 254, 226, 214,
 #define SKCTL_C		0x0F
 
 static const int okim6258_dividers[4] = {1024, 768, 512, 512};
+
+static const int okim5205_dividers[2][4] = 
+{
+	{96, 64, 48, 1}, // MSM5205
+	{160, 80, 40, 20} // MSM6585
+};
 
 static const UINT8 okim6295_voltbl[0x10] =
 {	0x20, 0x16, 0x10, 0x0B, 0x08, 0x06, 0x04, 0x03,
@@ -534,6 +541,10 @@ INLINE UINT32 GetChipName(UINT8 ChipType, const char** RetName)
 	case 0x2B:
 		ChipName = "K005289";
 		ChipCnt = ChpCnt.K005289;
+		break;
+	case 0x2C:
+		ChipName = (ChpCnt.OKIM5205 & 0x80000000) ? "OKIM6585" : "OKIM5205";
+		ChipCnt = ChpCnt.OKIM5205;
 		break;
 	case 0x2F:
 		ChipName = "ICS2115";
@@ -3297,6 +3308,38 @@ void okim6258_write(char* TempStr, UINT8 Port, UINT8 Data)
 		break;
 	default:
 		sprintf(WriteStr, "Port %02X: 0x%02X", Port, Data);
+		break;
+	}
+
+	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
+
+	return;
+}
+
+void okim5205_write(char* TempStr, UINT8 Port, UINT8 Data)
+{
+	WriteChipID(0x2C);
+
+	Data &= 0x0F;
+	switch(Port & 0x07)
+	{
+	case 0x00:
+		sprintf(WriteStr, "Reset write: %s", OnOff(Data & 0x01));
+		break;
+	case 0x01:
+		sprintf(WriteStr, "Data Write: 0x%01X", Data);
+		break;
+	case 0x02:
+		sprintf(WriteStr, "VCLK write: %s", OnOff(Data & 0x01));
+		break;
+	case 0x04:
+		sprintf(WriteStr, "Set prescaler to %u", okim5205_dividers[(ChpCnt.OKIM5205 & 0x80000000) >> 31][Data & 0x03]);
+		break;
+	case 0x05:
+		sprintf(WriteStr, "Set ADPCM bit width: %u", Data ? 4 : 3);
+		break;
+	default:
+		sprintf(WriteStr, "Unknown write %01X: 0x%01X", Port & 7, Data);
 		break;
 	}
 

--- a/chiptext.c
+++ b/chiptext.c
@@ -236,14 +236,14 @@ static const char* K054539_SAMPLE_MODES[0x04] = {"8-bit PCM", "16-bit PCM", "4-b
 #define BSMT2000_MAX_VOICES   (BSMT2000_CHANNELS + 1)  /* 12 PCM + 1 ADPCM/compressed */
 
 static const UINT8 bsmt2000_regmap[8][7] = {
-    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
-    { 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
-    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
-    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
-    { 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
-    { 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
+	{ 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
+	{ 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
+	{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
+	{ 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
+	{ 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
+	{ 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
 
 typedef struct ymf278b_chip
 {
@@ -4270,82 +4270,82 @@ void k007232_write(char* TempStr, UINT8 offset, UINT8 data)
 {
 	WriteChipID(0x2A);
 	
-    if (offset < 0x0C)
-    {
+	if (offset < 0x0C)
+	{
 		UINT8 ch = (offset >= 6 && offset < 0x0C) ? 1 : 0; // Channel 0 or 1
 		UINT8 reg = offset % 6; // offset offset within the channel
 
-        // offsets for pitch, start address, and key on/off
-        switch (reg)
-        {
-        case 0: // Pitch LSB
-            sprintf(RedirectStr, "Pitch LSB: 0x%02X", data);
-            break;
-        case 1: // Pitch MSB + frequency mode
-        {
-            static const char* freq_modes[4] = { "12-bit", "8-bit", "4-bit", "reserved" };
-            int freq_mode = (data >> 4) & 3;
-            sprintf(RedirectStr, "Pitch MSB: 0x%01X, Freq Mode: %s",
-                data & 0x0F, freq_modes[freq_mode]);
-            break;
-        }
-        case 2: // Start address LSB
-            sprintf(RedirectStr, "Start Address LSB: 0x%02X", data);
-            break;
-        case 3: // Start address MID
-            sprintf(RedirectStr, "Start Address MID: 0x%02X", data);
-            break;
-        case 4: // Start address MSB (bit 0 only)
-            sprintf(RedirectStr, "Start Address MSB (bit 0): %u", data & 0x01);
-            break;
-        case 5: // Key on/off trigger
-            sprintf(RedirectStr, "Key On/Off Trigger: %s", (data & 1) ? "Start" : "Stop");
-            break;
-        }
-        sprintf(WriteStr, "Ch%u: %s", ch, RedirectStr);
-    }
-    else
-    {
-        // offsets for external control, loop enable, and bankswitching
-        switch (offset)
-        {
-        case 0x0C: // External port write (volume/pan control, typically)
-            sprintf(WriteStr, "External Port Write: 0x%02X", data);
-            break;
-        case 0x0D: // Loop enable for channels
-            sprintf(WriteStr, "Loop Enable: Ch0: %s, Ch1: %s",
-                (data & 0x01) ? "On" : "Off",
-                (data & 0x02) ? "On" : "Off");
-            break;
-        case 0x10: // Left volume for Channel 0
-            sprintf(WriteStr, "Left Volume (Ch0): 0x%02X", data);
-            break;
-        case 0x11: // Right volume for Channel 0
-            sprintf(WriteStr, "Right Volume (Ch0): 0x%02X", data);
-            break;
-        case 0x12: // Left volume for Channel 1
-            sprintf(WriteStr, "Left Volume (Ch1): 0x%02X", data);
-            break;
-        case 0x13: // Right volume for Channel 1
-            sprintf(WriteStr, "Right Volume (Ch1): 0x%02X", data);
-            break;
-        case 0x14: // Bankswitch for Channel 0
-            sprintf(WriteStr, "Bankswitch (Ch0): 0x%02X", data);
-            break;
-        case 0x15: // Bankswitch for Channel 1
-            sprintf(WriteStr, "Bankswitch (Ch1): 0x%02X", data);
-            break;
+		// offsets for pitch, start address, and key on/off
+		switch (reg)
+		{
+		case 0: // Pitch LSB
+			sprintf(RedirectStr, "Pitch LSB: 0x%02X", data);
+			break;
+		case 1: // Pitch MSB + frequency mode
+		{
+			static const char* freq_modes[4] = { "12-bit", "8-bit", "4-bit", "reserved" };
+			int freq_mode = (data >> 4) & 3;
+			sprintf(RedirectStr, "Pitch MSB: 0x%01X, Freq Mode: %s",
+				data & 0x0F, freq_modes[freq_mode]);
+			break;
+		}
+		case 2: // Start address LSB
+			sprintf(RedirectStr, "Start Address LSB: 0x%02X", data);
+			break;
+		case 3: // Start address MID
+			sprintf(RedirectStr, "Start Address MID: 0x%02X", data);
+			break;
+		case 4: // Start address MSB (bit 0 only)
+			sprintf(RedirectStr, "Start Address MSB (bit 0): %u", data & 0x01);
+			break;
+		case 5: // Key on/off trigger
+			sprintf(RedirectStr, "Key On/Off Trigger: %s", (data & 1) ? "Start" : "Stop");
+			break;
+		}
+		sprintf(WriteStr, "Ch%u: %s", ch, RedirectStr);
+	}
+	else
+	{
+		// offsets for external control, loop enable, and bankswitching
+		switch (offset)
+		{
+		case 0x0C: // External port write (volume/pan control, typically)
+			sprintf(WriteStr, "External Port Write: 0x%02X", data);
+			break;
+		case 0x0D: // Loop enable for channels
+			sprintf(WriteStr, "Loop Enable: Ch0: %s, Ch1: %s",
+				(data & 0x01) ? "On" : "Off",
+				(data & 0x02) ? "On" : "Off");
+			break;
+		case 0x10: // Left volume for Channel 0
+			sprintf(WriteStr, "Left Volume (Ch0): 0x%02X", data);
+			break;
+		case 0x11: // Right volume for Channel 0
+			sprintf(WriteStr, "Right Volume (Ch0): 0x%02X", data);
+			break;
+		case 0x12: // Left volume for Channel 1
+			sprintf(WriteStr, "Left Volume (Ch1): 0x%02X", data);
+			break;
+		case 0x13: // Right volume for Channel 1
+			sprintf(WriteStr, "Right Volume (Ch1): 0x%02X", data);
+			break;
+		case 0x14: // Bankswitch for Channel 0
+			sprintf(WriteStr, "Bankswitch (Ch0): 0x%02X", data);
+			break;
+		case 0x15: // Bankswitch for Channel 1
+			sprintf(WriteStr, "Bankswitch (Ch1): 0x%02X", data);
+			break;
 		case 0x1F: // Special command for k007232 read
 			sprintf(WriteStr, "Read register 0x%02X", data);
 			break;
-        default:
-            sprintf(WriteStr, "Unknown Register 0x%02X: data 0x%02X", offset, data);
-            break;
-        }
-    }
+		default:
+			sprintf(WriteStr, "Unknown Register 0x%02X: data 0x%02X", offset, data);
+			break;
+		}
+	}
 
-    // Final output string
-    sprintf(TempStr, "K007232: %s", WriteStr);
+	// Final output string
+	sprintf(TempStr, "K007232: %s", WriteStr);
 }
 
 void k005289_write(char* TempStr, UINT8 offset, UINT16 data)
@@ -4373,12 +4373,12 @@ void k005289_write(char* TempStr, UINT8 offset, UINT16 data)
 		case 0x05:
 			sprintf(RedirectStr, "Frequency update trigger set 0x%04X", data);
 			break;
-    }
+	}
 
 	sprintf(WriteStr, "Ch%u: %s", ch, RedirectStr);
 
-    // Final output string
-    sprintf(TempStr, "K005289: %s", WriteStr);
+	// Final output string
+	sprintf(TempStr, "K005289: %s", WriteStr);
 }
 
 
@@ -4491,10 +4491,10 @@ void ics2115_write(char* TempStr, UINT8 offset, UINT8 data)
 		case 0x03:
 			sprintf(WriteStr, "Write register MSB 0x%02X", data);
 			break;
-    }
+	}
 
-    // Final output string
-    sprintf(TempStr, "ICS2115: %s", WriteStr);
+	// Final output string
+	sprintf(TempStr, "ICS2115: %s", WriteStr);
 }
 
 void mikey_write(char* TempStr, UINT8 offset, UINT8 data)
@@ -4715,36 +4715,36 @@ void bsmt2000_write(char* TempStr, UINT8 Offset, UINT16 Value)
 	{
 		switch (Value & 0xFF)
 		{
-        /* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
-        case 0:
-            TempBSMT->Voices = 12;
-            TempBSMT->ADPCM = 1;
-            TempBSMT->Mode = 0;
-            break;
-        /* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
-        case 1:
-            TempBSMT->Voices = 11;
-            TempBSMT->ADPCM = 1;
-            TempBSMT->Mode = 1;
-            break;
-        /* mode 5: 24kHz, 12 channel PCM, stereo */
-        case 5:
-            TempBSMT->Voices = 12;
-            TempBSMT->ADPCM = 0;
-            TempBSMT->Mode = 5;
-            break;
-        /* mode 6: 34kHz, 8 channel PCM, stereo */
-        case 6:
-            TempBSMT->Voices = 8;
-            TempBSMT->ADPCM = 0;
-            TempBSMT->Mode = 6;
-            break;
-        /* mode 7: 32kHz, 9 channel PCM, stereo */
-        case 7:
-            TempBSMT->Voices = 9;
-            TempBSMT->ADPCM = 0;
-            TempBSMT->Mode = 7;
-            break;
+		/* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
+		case 0:
+			TempBSMT->Voices = 12;
+			TempBSMT->ADPCM = 1;
+			TempBSMT->Mode = 0;
+			break;
+		/* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
+		case 1:
+			TempBSMT->Voices = 11;
+			TempBSMT->ADPCM = 1;
+			TempBSMT->Mode = 1;
+			break;
+		/* mode 5: 24kHz, 12 channel PCM, stereo */
+		case 5:
+			TempBSMT->Voices = 12;
+			TempBSMT->ADPCM = 0;
+			TempBSMT->Mode = 5;
+			break;
+		/* mode 6: 34kHz, 8 channel PCM, stereo */
+		case 6:
+			TempBSMT->Voices = 8;
+			TempBSMT->ADPCM = 0;
+			TempBSMT->Mode = 6;
+			break;
+		/* mode 7: 32kHz, 9 channel PCM, stereo */
+		case 7:
+			TempBSMT->Voices = 9;
+			TempBSMT->ADPCM = 0;
+			TempBSMT->Mode = 7;
+			break;
 		default:
 			sprintf(WriteStr, "Unknown Chip Mode: 0x%04X", Value);
 			sprintf(TempStr, "%s%s", ChipStr, WriteStr);
@@ -4758,48 +4758,48 @@ void bsmt2000_write(char* TempStr, UINT8 Offset, UINT16 Value)
 		return;
 	}
 
-    // Standard voices (interleaved register layout)
-    if (Offset < 0x6d)
+	// Standard voices (interleaved register layout)
+	if (Offset < 0x6d)
 	{
-        int voice_index;
-        int regindex = BSMT2000_REG_TOTAL - 1;
-        while (Offset < bsmt2000_regmap[TempBSMT->Mode][regindex])
-            --regindex;
+		int voice_index;
+		int regindex = BSMT2000_REG_TOTAL - 1;
+		while (Offset < bsmt2000_regmap[TempBSMT->Mode][regindex])
+			--regindex;
 
-        voice_index = Offset - bsmt2000_regmap[TempBSMT->Mode][regindex];
-        if (voice_index >= TempBSMT->Voices)
-            return;
+		voice_index = Offset - bsmt2000_regmap[TempBSMT->Mode][regindex];
+		if (voice_index >= TempBSMT->Voices)
+			return;
 
-        ch = voice_index;
+		ch = voice_index;
 		reg = regindex;
-    }
-    // Compressed/ADPCM channel (11-voice model only)
-    else if (TempBSMT->ADPCM != 0 && Offset >= 0x6d)
+	}
+	// Compressed/ADPCM channel (11-voice model only)
+	else if (TempBSMT->ADPCM != 0 && Offset >= 0x6d)
 	{
-        ch = BSMT2000_ADPCM_INDEX;
-        switch (Offset) {
-        case 0x6d:
-            reg = BSMT2000_REG_LOOPEND;
-            break;
-        case 0x6f:
-            reg = BSMT2000_REG_BANK;
-            break;
-        case 0x6e: // main right channel volume control, used when ADPCM is alreay playing
-        case 0x74:
-            reg = BSMT2000_REG_RIGHTVOL;
-            break;
-        case 0x75:
-            reg = BSMT2000_REG_CURRPOS;
-            break;
-        case 0x70: // main left channel volume control, used when ADPCM is alreay playing
-        case 0x78:
-            reg = BSMT2000_REG_LEFTVOL;
-            break;
+		ch = BSMT2000_ADPCM_INDEX;
+		switch (Offset) {
+		case 0x6d:
+			reg = BSMT2000_REG_LOOPEND;
+			break;
+		case 0x6f:
+			reg = BSMT2000_REG_BANK;
+			break;
+		case 0x6e: // main right channel volume control, used when ADPCM is alreay playing
+		case 0x74:
+			reg = BSMT2000_REG_RIGHTVOL;
+			break;
+		case 0x75:
+			reg = BSMT2000_REG_CURRPOS;
+			break;
+		case 0x70: // main left channel volume control, used when ADPCM is alreay playing
+		case 0x78:
+			reg = BSMT2000_REG_LEFTVOL;
+			break;
 		default:
 			sprintf(TempStr, "%sUnknown register write 0x%02X: 0x%04X", ChipStr, Offset, Value);
 			return;
-        }
-    }
+		}
+	}
 
 	switch (reg)
 	{

--- a/chiptext.c
+++ b/chiptext.c
@@ -4406,3 +4406,112 @@ void ics2115_write(char* TempStr, UINT8 offset, UINT8 data)
     // Final output string
     sprintf(TempStr, "ICS2115: %s", WriteStr);
 }
+
+void mikey_write(char* TempStr, UINT8 offset, UINT8 data)
+{
+	UINT8 ch, reg;
+	UINT32 StrPos;
+	UINT8 ChnEn;
+	WriteChipID(0x29);
+
+	if ((offset >= 0x20) && (offset < 0x40))
+	{
+		ch = (offset >> 3) & 3; // Channel 0 to 3
+		reg = offset & 7; // offset within the channel
+
+		switch (reg)
+		{
+		case 0: // Volume
+			sprintf(RedirectStr, "Volume: 0x%02X", data);
+			break;
+		case 1: // Feedback
+			sprintf(RedirectStr, "Feedback: 0x%02X (0x%03X)", data, (data & 0x3F) | ((data & 0xC0) << 4));
+			break;
+		case 2: // Direct output
+			sprintf(RedirectStr, "Direct output: 0x%02X", data);
+			break;
+		case 3: // Shifter LSB
+			sprintf(RedirectStr, "Shifter LSB: 0x%02X", data);
+			break;
+		case 4: // Backup
+			sprintf(RedirectStr, "Timer backup: 0x%02X", data);
+			break;
+		case 5: // Control
+			sprintf(RedirectStr, "Control: 0x%02X (Feedback bit 7: %u, Reset done flag: %u, Inegrate: %u, Reload: %u, Count: %u, Timer clock shift: %u)",
+					data,
+					(data >> 7) & 1,
+					(data >> 6) & 1,
+					(data >> 5) & 1,
+					(data >> 4) & 1,
+					(data >> 3) & 1,
+					data & 7);
+			break;
+		case 6: // Counter
+			sprintf(RedirectStr, "Timer counter: 0x%02X", data);
+			break;
+		case 7: // Shifter MSB, Timer done
+			sprintf(RedirectStr, "Other: 0x%02X (Shifter MSB: 0x%01X, Timer done: %u, Last clock: %u, Borrow in: %u, Borrow out: %u)",
+					data,
+					(data >> 4) & 0x0F,
+					(data >> 3) & 0x1,
+					(data >> 2) & 0x1,
+					(data >> 1) & 0x1,
+					data & 0x1);
+			break;
+		}
+		sprintf(WriteStr, "Ch%u: %s", ch, RedirectStr);
+	}
+	else
+	{
+		switch (offset)
+		{
+		case 0x40: // Attenuation
+		case 0x41:
+		case 0x42:
+		case 0x43:
+			ch = offset & 3; // Channel 0 to 3
+			sprintf(RedirectStr, "Attenuation: 0x%02X (Left: 0x%01X, Right: 0x%01X)",
+					data,
+					(data >> 4) & 0x0F,
+					data & 0x0F);
+			sprintf(WriteStr, "Ch%u: %s", ch, RedirectStr);
+			break;
+		case 0x44:
+			// Format:
+			//	Bit	76543210
+			//	L/R	LLLLRRRR (laoo core is treated to only used low nibble for both pan)
+			//	Ch	32103210
+			WriteChipID(0x00);
+			sprintf(WriteStr, "Attenuation enable: ");
+			StrPos = strlen(WriteStr);
+			for (ch = 0x00; ch < 0x04; ch ++)
+			{
+				ChnEn = data & (0x01 << (ch ^ 0x04));
+				WriteStr[StrPos] = ChnEn ? ('0' + (ch & 0x03)) : '-';
+				StrPos ++;
+			}
+			WriteStr[StrPos] = 0x00;
+		case 0x50:
+			// Format:
+			//	Bit	76543210
+			//	L/R	LLLLRRRR
+			//	Ch	32103210
+			WriteChipID(0x00);
+			sprintf(WriteStr, "Stereo: ");
+			StrPos = strlen(WriteStr);
+			for (ch = 0x00; ch < 0x08; ch ++)
+			{
+				ChnEn = data & (0x01 << (ch ^ 0x04));
+				WriteStr[StrPos] = ChnEn ? '-' : ('0' + (ch & 0x03));
+				StrPos ++;
+			}
+			WriteStr[StrPos] = 0x00;
+		default:
+			sprintf(WriteStr, "Unknown Register 0x%02X: data 0x%02X", offset, data);
+			break;
+		}
+	}
+
+	// Final output string
+	sprintf(TempStr, "Mikey: %s", WriteStr);
+}

--- a/chiptext.c
+++ b/chiptext.c
@@ -57,6 +57,7 @@ typedef struct chip_count
 	UINT32 ICS2115;
 	UINT32 OKIM5205;
 	UINT32 OKIM5232;
+	UINT32 BSMT2000;
 } CHIP_CNT;
 
 
@@ -221,6 +222,29 @@ static const char* ES5503_MODES[0x04] = {"Free-Run", "One-Shot", "Sync", "Swap"}
 
 static const char* K054539_SAMPLE_MODES[0x04] = {"8-bit PCM", "16-bit PCM", "4-bit DPCM", "unknown"};
 
+#define BSMT2000_CHANNELS     12          /* up to 12 PCM voices, plus ADPCM */
+#define BSMT2000_ADPCM_INDEX  12          /* 0..11 = PCM, 12 = ADPCM/compressed */
+#define BSMT2000_REG_CURRPOS  0
+#define BSMT2000_REG_RATE 1
+#define BSMT2000_REG_LOOPEND     2
+#define BSMT2000_REG_LOOPSTART  3
+#define BSMT2000_REG_BANK 4
+#define BSMT2000_REG_RIGHTVOL     5
+#define BSMT2000_REG_LEFTVOL 6
+#define BSMT2000_REG_TOTAL    7
+
+#define BSMT2000_MAX_VOICES   (BSMT2000_CHANNELS + 1)  /* 12 PCM + 1 ADPCM/compressed */
+
+static const UINT8 bsmt2000_regmap[8][7] = {
+    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x48, 0xff }, // last one (stereo/leftvol) unused, set to max for mapping
+    { 0x00, 0x16, 0x21, 0x2c, 0x37, 0x42, 0x4d },
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 2 only a testmode left channel
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 3 only a testmode right channel
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // mode 4 only a testmode left channel
+    { 0x00, 0x18, 0x24, 0x30, 0x3c, 0x54, 0x60 },
+    { 0x00, 0x10, 0x18, 0x20, 0x28, 0x38, 0x40 },
+    { 0x00, 0x12, 0x1b, 0x24, 0x2d, 0x3f, 0x48 } };
+
 typedef struct ymf278b_chip
 {
 	UINT8 smplH[24];	// high bit of the sample ID
@@ -260,6 +284,12 @@ typedef struct ics2115_chip
 	UINT8 Addr;	// Register address
 	UINT8 Ch; // Channel index
 } ICS2115_DATA;
+typedef struct bsmt2000_chip
+{
+	UINT8 Mode;
+	UINT8 ADPCM;
+	UINT8 Voices;
+} BSMT2000_DATA;
 
 
 static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
@@ -289,6 +319,7 @@ static UPD7759_DATA CacheUPD7759[0x02];
 static ES5506_DATA CacheES5506[0x02];
 static WSWAN_DATA CacheWSwan[0x02];
 static ICS2115_DATA CacheICS2115[0x02];
+static BSMT2000_DATA CacheBSMT2000[0x02];
 
 void InitChips(UINT32 ChipCntSize, UINT32* ChipCounts)
 {
@@ -302,12 +333,19 @@ void InitChips(UINT32 ChipCntSize, UINT32* ChipCounts)
 	memset(CacheES5506, 0x00, sizeof(ES5506_DATA) * 0x02);
 	memset(CacheWSwan, 0x00, sizeof(WSWAN_DATA) * 0x02);
 	memset(CacheICS2115, 0x00, sizeof(ICS2115_DATA) * 0x02);
+	memset(CacheBSMT2000, 0x00, sizeof(BSMT2000_DATA) * 0x02);
 	CacheOKI6295[0].Command = 0xFF;
 	CacheOKI6295[1].Command = 0xFF;
 	CacheICS2115[0].Addr = 0;
 	CacheICS2115[0].Ch = 0;
 	CacheICS2115[1].Addr = 0;
 	CacheICS2115[1].Ch = 0;
+	CacheBSMT2000[0].ADPCM = 1;
+	CacheBSMT2000[0].Voices = 12;
+	CacheBSMT2000[0].Mode = 1;
+	CacheBSMT2000[1].ADPCM = 1;
+	CacheBSMT2000[1].Voices = 12;
+	CacheBSMT2000[1].Mode = 1;
 	ChpCur = 0x00;
 	ChipStr = RedirectStr + 0xF0;
 
@@ -550,6 +588,10 @@ INLINE UINT32 GetChipName(UINT8 ChipType, const char** RetName)
 	case 0x2D:
 		ChipName = "OKIM5232";
 		ChipCnt = ChpCnt.OKIM5232;
+		break;
+	case 0x2E:
+		ChipName = "BSMT2000";
+		ChipCnt = ChpCnt.BSMT2000;
 		break;
 	case 0x2F:
 		ChipName = "ICS2115";
@@ -4654,6 +4696,145 @@ void okim5232_write(char* TempStr, UINT8 Register, UINT8 Data)
 	}
 
 	sprintf(TempStr, "%s%s", ChipStr, WriteStr);
+
+	return;
+}
+
+void bsmt2000_write(char* TempStr, UINT8 Offset, UINT16 Value)
+{
+	UINT8 ch;
+	UINT8 reg;
+	INT8 TempByt;
+	BSMT2000_DATA* TempBSMT;
+
+	WriteChipID(0x2E);
+
+	TempBSMT = &CacheBSMT2000[ChpCur];
+
+	if (Offset == 0x7F)
+	{
+		switch (Value & 0xFF)
+		{
+        /* mode 0: 24kHz, 12 channel PCM, 1 channel ADPCM, mono; from PinMAME */
+        case 0:
+            TempBSMT->Voices = 12;
+            TempBSMT->ADPCM = 1;
+            TempBSMT->Mode = 0;
+            break;
+        /* mode 1: 24kHz, 11 channel PCM, 1 channel ADPCM, stereo */
+        case 1:
+            TempBSMT->Voices = 11;
+            TempBSMT->ADPCM = 1;
+            TempBSMT->Mode = 1;
+            break;
+        /* mode 5: 24kHz, 12 channel PCM, stereo */
+        case 5:
+            TempBSMT->Voices = 12;
+            TempBSMT->ADPCM = 0;
+            TempBSMT->Mode = 5;
+            break;
+        /* mode 6: 34kHz, 8 channel PCM, stereo */
+        case 6:
+            TempBSMT->Voices = 8;
+            TempBSMT->ADPCM = 0;
+            TempBSMT->Mode = 6;
+            break;
+        /* mode 7: 32kHz, 9 channel PCM, stereo */
+        case 7:
+            TempBSMT->Voices = 9;
+            TempBSMT->ADPCM = 0;
+            TempBSMT->Mode = 7;
+            break;
+		default:
+			sprintf(WriteStr, "Unknown Chip Mode: 0x%04X", Value);
+			sprintf(TempStr, "%s%s", ChipStr, WriteStr);
+			return;
+		}
+		sprintf(WriteStr, "Set Chip Mode: 0x%04X (%u = ADPCM: %s, Voices: %u)", Value,
+				TempBSMT->Mode,
+				Enable(TempBSMT->ADPCM),
+				TempBSMT->Voices);
+		sprintf(TempStr, "%s%s", ChipStr, WriteStr);
+		return;
+	}
+
+    // Standard voices (interleaved register layout)
+    if (Offset < 0x6d)
+	{
+        int voice_index;
+        int regindex = BSMT2000_REG_TOTAL - 1;
+        while (Offset < bsmt2000_regmap[TempBSMT->Mode][regindex])
+            --regindex;
+
+        voice_index = Offset - bsmt2000_regmap[TempBSMT->Mode][regindex];
+        if (voice_index >= TempBSMT->Voices)
+            return;
+
+        ch = voice_index;
+		reg = regindex;
+    }
+    // Compressed/ADPCM channel (11-voice model only)
+    else if (TempBSMT->ADPCM != 0 && Offset >= 0x6d)
+	{
+        ch = BSMT2000_ADPCM_INDEX;
+        switch (Offset) {
+        case 0x6d:
+            reg = BSMT2000_REG_LOOPEND;
+            break;
+        case 0x6f:
+            reg = BSMT2000_REG_BANK;
+            break;
+        case 0x6e: // main right channel volume control, used when ADPCM is alreay playing
+        case 0x74:
+            reg = BSMT2000_REG_RIGHTVOL;
+            break;
+        case 0x75:
+            reg = BSMT2000_REG_CURRPOS;
+            break;
+        case 0x70: // main left channel volume control, used when ADPCM is alreay playing
+        case 0x78:
+            reg = BSMT2000_REG_LEFTVOL;
+            break;
+		default:
+			sprintf(TempStr, "%sUnknown register write 0x%02X: 0x%04X", ChipStr, Offset, Value);
+			return;
+        }
+    }
+
+	switch (reg)
+	{
+	case BSMT2000_REG_CURRPOS: // current address
+		sprintf(WriteStr, "Set Current Address: 0x%04X", Value);
+		break;
+	case BSMT2000_REG_RATE: // pitch
+		sprintf(WriteStr, "Set Pitch: 0x%04X", Value);
+		if (! Value)
+			sprintf(WriteStr, "%s (Key Off)", WriteStr);
+		break;
+	case BSMT2000_REG_LOOPEND: // loop end address
+		sprintf(WriteStr, "Set Loop End Address: 0x%04X", Value);
+		break;
+	case BSMT2000_REG_LOOPSTART: // loop start address
+		sprintf(WriteStr, "Set Loop Start Address: 0x%04X", Value);
+		break;
+	case BSMT2000_REG_BANK: // Bank
+		sprintf(WriteStr, "Set Bank: %04X (base 0x%08X)", Value,
+				Value << 16);
+		break;
+	case BSMT2000_REG_RIGHTVOL: // right volume
+		sprintf(WriteStr, "Set Right Volume: 0x%04X", Value);
+		break;
+	case BSMT2000_REG_LEFTVOL: // left volume
+		sprintf(WriteStr, "Set Left Volume: 0x%04X", Value);
+		break;
+	default:
+		sprintf(WriteStr, "Register %u: 0x%04X", reg, Value);
+		break;
+	}
+	if (ch < BSMT2000_ADPCM_INDEX)
+		sprintf(TempStr, "%sCh %u: %s", ChipStr, ch, WriteStr);
+	else if (ch == BSMT2000_ADPCM_INDEX)
+		sprintf(TempStr, "%sADPCM: %s", ChipStr, WriteStr);
 
 	return;
 }

--- a/chiptext.c
+++ b/chiptext.c
@@ -53,6 +53,8 @@ typedef struct chip_count
 	UINT32 GA20;
 	UINT32 Mikey;
 	UINT32 K007232;
+	UINT32 K005289;
+	UINT32 ICS2115;
 } CHIP_CNT;
 
 
@@ -245,6 +247,11 @@ typedef struct wswan_chip
 {
 	bool pcmEnable;
 } WSWAN_DATA;
+typedef struct ics2115_chip
+{
+	UINT8 Addr;	// Register address
+	UINT8 Ch; // Channel index
+} ICS2115_DATA;
 
 
 static void opn_write(char* TempStr, UINT8 Mode, UINT8 Port, UINT8 Register,
@@ -273,6 +280,7 @@ static MULTIPCM_DATA CacheMultiPCM[0x02];
 static UPD7759_DATA CacheUPD7759[0x02];
 static ES5506_DATA CacheES5506[0x02];
 static WSWAN_DATA CacheWSwan[0x02];
+static ICS2115_DATA CacheICS2115[0x02];
 
 void InitChips(UINT32 ChipCntSize, UINT32* ChipCounts)
 {
@@ -285,8 +293,13 @@ void InitChips(UINT32 ChipCntSize, UINT32* ChipCounts)
 	memset(CacheUPD7759, 0x00, sizeof(UPD7759_DATA) * 0x02);
 	memset(CacheES5506, 0x00, sizeof(ES5506_DATA) * 0x02);
 	memset(CacheWSwan, 0x00, sizeof(WSWAN_DATA) * 0x02);
+	memset(CacheICS2115, 0x00, sizeof(ICS2115_DATA) * 0x02);
 	CacheOKI6295[0].Command = 0xFF;
 	CacheOKI6295[1].Command = 0xFF;
+	CacheICS2115[0].Addr = 0;
+	CacheICS2115[0].Ch = 0;
+	CacheICS2115[1].Addr = 0;
+	CacheICS2115[1].Ch = 0;
 	ChpCur = 0x00;
 	ChipStr = RedirectStr + 0xF0;
 
@@ -517,6 +530,14 @@ INLINE UINT32 GetChipName(UINT8 ChipType, const char** RetName)
 	case 0x2A:
 		ChipName = "K007232";
 		ChipCnt = ChpCnt.K007232;
+		break;
+	case 0x2B:
+		ChipName = "K005289";
+		ChipCnt = ChpCnt.K005289;
+		break;
+	case 0x2F:
+		ChipName = "ICS2115";
+		ChipCnt = ChpCnt.ICS2115;
 		break;
 	default:
 		ChipName = "Unknown";
@@ -3756,7 +3777,7 @@ void x1_010_write(char* TempStr, UINT16 Offset, UINT8 val)
 			sprintf(WriteStr, "Waveform %u, position %02x: %02X", chan, pos, val);
 		}
 		else
-			sprintf(WriteStr, "Offset 0x%04X, Data 0x%2X", Offset, val);
+			sprintf(WriteStr, "Offset 0x%04X, Data 0x%02X", Offset, val);
 
 
 	}
@@ -4225,7 +4246,7 @@ void k007232_write(char* TempStr, UINT8 offset, UINT8 data)
             sprintf(WriteStr, "Bankswitch (Ch1): 0x%02X", data);
             break;
 		case 0x1F: // Special command for k007232 read
-			sprintf(WriteStr, "Read register 0x%2X", data);
+			sprintf(WriteStr, "Read register 0x%02X", data);
 			break;
         default:
             sprintf(WriteStr, "Unknown Register 0x%02X: data 0x%02X", offset, data);
@@ -4242,7 +4263,8 @@ void k005289_write(char* TempStr, UINT8 offset, UINT16 data)
 	WriteChipID(0x2B);
 	
 	UINT8 ch = offset & 1; // Channel 0 or 1
-	switch (offset) {
+	switch (offset)
+	{
 		// Control A (Channel 1)
 		case 0x00:
 		// Control B (Channel 2)
@@ -4267,4 +4289,120 @@ void k005289_write(char* TempStr, UINT8 offset, UINT16 data)
 
     // Final output string
     sprintf(TempStr, "K005289: %s", WriteStr);
+}
+
+
+INLINE const char* ics2115_reg_str(UINT32 Value)
+{
+	switch (Value)
+	{
+		case 0x00:
+			return "Oscillator config";
+		case 0x01:
+			return "Sample frequency";
+		case 0x02:
+			return "Loop start high";
+		case 0x03:
+			return "Loop start low";
+		case 0x04:
+			return "Loop end high";
+		case 0x05:
+			return "Loop end low";
+		case 0x06:
+			return "Volume increment";
+		case 0x07:
+			return "Volume start";
+		case 0x08:
+			return "Volume end";
+		case 0x09:
+			return "Volume accumulator";
+		case 0x0a:
+			return "Sample address high";
+		case 0x0b:
+			return "Sample address low";
+		case 0x0c:
+			return "Pan";
+		case 0x0d:
+			return "Volume envelope control";
+		case 0x0e:
+			return "Active voices";
+		case 0x0f:
+			return "Interrupt source/oscillator";
+		case 0x10:
+			return "Oscillator control";
+		case 0x11:
+			return "Sample bank";
+		case 0x40:
+			return "Timer 1 preset";
+		case 0x41:
+			return "Timer 2 preset";
+		case 0x42:
+			return "Timer 1 prescale";
+		case 0x43:
+			return "Timer 2 prescale/Timer status";
+		case 0x44:
+			return "DMA start address bit 4-11";
+		case 0x45:
+			return "DMA start address bit 12-19";
+		case 0x46:
+			return "DMA start address bit 20-21";
+		case 0x47:
+			return "DMA control";
+		case 0x48:
+			return "Accumulator monitor status";
+		case 0x49:
+			return "Accumulator monitor data";
+		case 0x4a:
+			return "IRQ enable/pending";
+		case 0x4b:
+			return "Address of interrupting voice";
+		case 0x4c:
+			return "Memory config/Revision";
+		case 0x4d:
+			return "System control";
+		case 0x4f:
+			return "Voice select";
+		case 0x50:
+			return "MIDI data";
+		case 0x51:
+			return "MIDI control/status";
+		case 0x52:
+			return "Host data";
+		case 0x53:
+			return "Host control/status";
+		case 0x54:
+			return "MIDI emulation interrupt control";
+		case 0x55:
+			return "Host emulation interrupt control";
+		case 0x56:
+			return "MIDI/Host emulation interrupt status";
+		case 0x57:
+			return "Emulation mode";
+		default:
+			return "Unknown";
+	}
+}
+
+void ics2115_write(char* TempStr, UINT8 offset, UINT8 data)
+{
+	ICS2115_DATA* TempICS;
+	WriteChipID(0x2F);
+
+	TempICS = &CacheICS2115[ChpCur];
+	switch (offset & 3)
+	{
+		case 0x01:
+			TempICS->Addr = data;
+			sprintf(WriteStr, "Write address 0x%02X (%s)", data, ics2115_reg_str(data));
+			break;
+		case 0x02:
+			sprintf(WriteStr, "Write register LSB 0x%02X", data);
+			break;
+		case 0x03:
+			sprintf(WriteStr, "Write register MSB 0x%02X", data);
+			break;
+    }
+
+    // Final output string
+    sprintf(TempStr, "ICS2115: %s", WriteStr);
 }

--- a/chiptext.h
+++ b/chiptext.h
@@ -58,5 +58,6 @@ void k005289_write(char* TempStr, UINT8 offset, UINT16 data);
 void ics2115_write(char* TempStr, UINT8 offset, UINT8 data);
 void mikey_write(char* TempStr, UINT8 offset, UINT8 data);
 void okim5205_write(char* TempStr, UINT8 Port, UINT8 Data);
+void okim5232_write(char* TempStr, UINT8 Register, UINT8 Data);
 
 #endif	// __CHIPTEXT_H__

--- a/chiptext.h
+++ b/chiptext.h
@@ -57,5 +57,6 @@ void k007232_write(char* TempStr, UINT8 offset, UINT8 data);
 void k005289_write(char* TempStr, UINT8 offset, UINT16 data);
 void ics2115_write(char* TempStr, UINT8 offset, UINT8 data);
 void mikey_write(char* TempStr, UINT8 offset, UINT8 data);
+void okim5205_write(char* TempStr, UINT8 Port, UINT8 Data);
 
 #endif	// __CHIPTEXT_H__

--- a/chiptext.h
+++ b/chiptext.h
@@ -56,5 +56,6 @@ void ws_mem_write(char* TempStr, UINT16 Offset, UINT8 Data);
 void k007232_write(char* TempStr, UINT8 offset, UINT8 data);
 void k005289_write(char* TempStr, UINT8 offset, UINT16 data);
 void ics2115_write(char* TempStr, UINT8 offset, UINT8 data);
+void mikey_write(char* TempStr, UINT8 offset, UINT8 data);
 
 #endif	// __CHIPTEXT_H__

--- a/chiptext.h
+++ b/chiptext.h
@@ -55,5 +55,6 @@ void wswan_write(char* TempStr, UINT8 Register, UINT8 Data);
 void ws_mem_write(char* TempStr, UINT16 Offset, UINT8 Data);
 void k007232_write(char* TempStr, UINT8 offset, UINT8 data);
 void k005289_write(char* TempStr, UINT8 offset, UINT16 data);
+void ics2115_write(char* TempStr, UINT8 offset, UINT8 data);
 
 #endif	// __CHIPTEXT_H__

--- a/chiptext.h
+++ b/chiptext.h
@@ -59,5 +59,6 @@ void ics2115_write(char* TempStr, UINT8 offset, UINT8 data);
 void mikey_write(char* TempStr, UINT8 offset, UINT8 data);
 void okim5205_write(char* TempStr, UINT8 Port, UINT8 Data);
 void okim5232_write(char* TempStr, UINT8 Register, UINT8 Data);
+void bsmt2000_write(char* TempStr, UINT8 Offset, UINT16 Value);
 
 #endif	// __CHIPTEXT_H__

--- a/vgm2txt.c
+++ b/vgm2txt.c
@@ -1515,6 +1515,14 @@ static void WriteVGMData2Txt(FILE* hFile)
 				}
 				CmdLen = 0x02;
 				break;
+			case 0x43:	// OKIM5232 write
+				if (WriteEvents)
+				{
+					SetChip((VGMPnt[0x01] & 0x80) >> 7);
+					okim5232_write(TempStr, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				}
+				CmdLen = 0x03;
+				break;
 			case 0x44:	// ICS2115 write
 				if (WriteEvents)
 				{

--- a/vgm2txt.c
+++ b/vgm2txt.c
@@ -465,6 +465,7 @@ static void WriteVGM2Txt(const char* FileName)
 	
 	WriteClockText(TempStr, VGMHead.lngHzOKIM5205, "OKIM5205");
 	fprintf(hFile, "OKIM5205 Clock:\t\t%s\n", TempStr);
+	fprintf(hFile, "OKIM5205 Flags:\t\t0x%02X\n", VGMHead.bytOKI5205Flags);
 	
 	WriteClockText(TempStr, VGMHead.lngHzOKIM5232, "OKIM5232");
 	fprintf(hFile, "OKIM5232 Clock:\t\t%s\n", TempStr);
@@ -1505,6 +1506,14 @@ static void WriteVGMData2Txt(FILE* hFile)
 										(VGMPnt[0x02] << 0));
 				}
 				CmdLen = 0x03;
+				break;
+			case 0x32:	// OKIM5205 write
+				if (WriteEvents)
+				{
+					SetChip((VGMPnt[0x01] & 0x80) >> 7);
+					okim5205_write(TempStr, (VGMPnt[0x01] >> 4) & 0x7, VGMPnt[0x01] & 0xF);
+				}
+				CmdLen = 0x02;
 				break;
 			case 0x44:	// ICS2115 write
 				if (WriteEvents)

--- a/vgm2txt.c
+++ b/vgm2txt.c
@@ -1498,6 +1498,14 @@ static void WriteVGMData2Txt(FILE* hFile)
 				}
 				CmdLen = 0x03;
 				break;
+			case 0x44:	// ICS2115 write
+				if (WriteEvents)
+				{
+					SetChip((VGMPnt[0x01] & 0x80) >> 7);
+					ics2115_write(TempStr, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				}
+				CmdLen = 0x03;
+				break;
 			case 0x90:	// DAC Ctrl: Setup Chip
 				if (WriteEvents)
 				{

--- a/vgm2txt.c
+++ b/vgm2txt.c
@@ -1405,6 +1405,14 @@ static void WriteVGMData2Txt(FILE* hFile)
 				}
 				CmdLen = 0x04;
 				break;
+			case 0xC9:	// BSMT2000 write
+				if (WriteEvents)
+				{
+					SetChip((VGMPnt[0x01] & 0x80) >> 7);
+					bsmt2000_write(TempStr, VGMPnt[0x01] & 0x7F, (VGMPnt[0x02] << 8) | (VGMPnt[0x03] << 0));
+				}
+				CmdLen = 0x04;
+				break;
 			case 0xBC:	// WonderSwan write
 				if (WriteEvents)
 				{

--- a/vgm2txt.c
+++ b/vgm2txt.c
@@ -1480,6 +1480,14 @@ static void WriteVGMData2Txt(FILE* hFile)
 				}
 				CmdLen = 0x04;
 				break;
+			case 0x40:	// Mikey write
+				if (WriteEvents)
+				{
+					SetChip((VGMPnt[0x01] & 0x80) >> 7);
+					mikey_write(TempStr, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				}
+				CmdLen = 0x03;
+				break;
 			case 0x41:	// K007232 write
 				if (WriteEvents)
 				{

--- a/vgm_cmp.c
+++ b/vgm_cmp.c
@@ -65,6 +65,7 @@ bool k005289_write(UINT8 Register, UINT16 Data);
 bool k007232_write(UINT8 Register, UINT8 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
+bool okim5205_write(UINT8 Port, UINT8 Data);
 
 VGM_HEADER VGMHead;
 UINT32 VGMDataLen;
@@ -292,6 +293,7 @@ static void CompressVGMData(void)
 	UINT8 TempByt;
 	UINT16 TempSht;
 	UINT32 TempLng;
+	UINT32 TempFlag;
 	//UINT32 DataStart;
 	//UINT32 DataLen;
 #ifdef WIN32
@@ -346,6 +348,20 @@ static void CompressVGMData(void)
 			okim6295_write(0x8A, (TempLng >> 16) & 0xFF);
 			okim6295_write(0x8B, (TempLng >> 24) & 0xFF);
 			okim6295_write(0x8C, VGMHead.lngHzOKIM6295 >> 31);
+		}
+	}
+	if (VGMHead.lngHzOKIM5205)
+	{
+		TempFlag = VGMHead.bytOKI5205Flags & 0x07;
+
+		SetChipSet(0x00);
+		okim5205_write(0x04, (TempFlag) & 0x03);
+		okim5205_write(0x05, (TempFlag >> 2) & 0x01);
+		if (VGMHead.lngHzOKIM5205 & 0x40000000)
+		{
+			SetChipSet(0x01);
+			okim6295_write(0x04, (TempFlag) & 0x03);
+			okim6295_write(0x05, (TempFlag >> 2) & 0x01);
 		}
 	}
 	/*if (VGMHead.lngHzK054539)
@@ -605,6 +621,11 @@ static void CompressVGMData(void)
 				break;
 			case 0x4F:	// GG Stereo
 				WriteEvent = GGStereo(VGMPnt[0x01]);
+				CmdLen = 0x02;
+				break;
+			case 0x32:	// OKIM5205 write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				WriteEvent = okim5205_write((VGMPnt[0x01] >> 4) & 0x7, VGMPnt[0x01] & 0xF);
 				CmdLen = 0x02;
 				break;
 			case 0x54:	// YM2151 write

--- a/vgm_cmp.c
+++ b/vgm_cmp.c
@@ -66,6 +66,7 @@ bool k007232_write(UINT8 Register, UINT8 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
 bool okim5205_write(UINT8 Port, UINT8 Data);
+bool okim5232_write(UINT8 Register, UINT8 Data);
 
 VGM_HEADER VGMHead;
 UINT32 VGMDataLen;
@@ -612,6 +613,11 @@ static void CompressVGMData(void)
 				WriteEvent = k005289_write((VGMPnt[0x01] & 0x70) >> 4,
 										(VGMPnt[0x01] & 0x0F) << 8 |
 										(VGMPnt[0x02] << 0));
+				CmdLen = 0x03;
+				break;
+			case 0x43:	// OKIM5232 write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				WriteEvent = okim5232_write(VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
 				CmdLen = 0x03;
 				break;
 			case 0x44:	// ICS2115 write

--- a/vgm_cmp.c
+++ b/vgm_cmp.c
@@ -67,6 +67,7 @@ bool ics2115_write(UINT8 Register, UINT8 Data);
 bool mikey_write(UINT8 Register, UINT8 Data);
 bool okim5205_write(UINT8 Port, UINT8 Data);
 bool okim5232_write(UINT8 Register, UINT8 Data);
+bool bsmt2000_write(UINT8 Offset, UINT16 Value);
 
 VGM_HEADER VGMHead;
 UINT32 VGMDataLen;
@@ -837,6 +838,11 @@ static void CompressVGMData(void)
 				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
 				TempSht = ((VGMPnt[0x01] & 0x7F) << 8) | (VGMPnt[0x02] << 0);
 				WriteEvent = x1_010_write(TempSht, VGMPnt[0x03]);
+				CmdLen = 0x04;
+				break;
+			case 0xC9:	// BSMT2000 write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				WriteEvent = bsmt2000_write(VGMPnt[0x01] & 0x7F, (VGMPnt[0x02] << 8) | (VGMPnt[0x03] << 0));
 				CmdLen = 0x04;
 				break;
 			case 0xE1:	// C352 write

--- a/vgm_cmp.c
+++ b/vgm_cmp.c
@@ -63,6 +63,7 @@ bool vsu_write(UINT16 Register, UINT8 Data);
 bool wswan_write(UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
 bool k007232_write(UINT8 Register, UINT8 Data);
+bool ics2115_write(UINT8 Register, UINT8 Data);
 
 VGM_HEADER VGMHead;
 UINT32 VGMDataLen;
@@ -589,6 +590,11 @@ static void CompressVGMData(void)
 				WriteEvent = k005289_write((VGMPnt[0x01] & 0x70) >> 4,
 										(VGMPnt[0x01] & 0x0F) << 8 |
 										(VGMPnt[0x02] << 0));
+				CmdLen = 0x03;
+				break;
+			case 0x44:	// ICS2115 write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				WriteEvent = ics2115_write(VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
 				CmdLen = 0x03;
 				break;
 			case 0x4F:	// GG Stereo

--- a/vgm_cmp.c
+++ b/vgm_cmp.c
@@ -64,6 +64,7 @@ bool wswan_write(UINT8 Register, UINT8 Data);
 bool k005289_write(UINT8 Register, UINT16 Data);
 bool k007232_write(UINT8 Register, UINT8 Data);
 bool ics2115_write(UINT8 Register, UINT8 Data);
+bool mikey_write(UINT8 Register, UINT8 Data);
 
 VGM_HEADER VGMHead;
 UINT32 VGMDataLen;
@@ -579,6 +580,11 @@ static void CompressVGMData(void)
 			case 0xE0:	// Seek to PCM Data Bank Pos
 				memcpy(&TempLng, &VGMPnt[0x01], 0x04);
 				CmdLen = 0x05;
+				break;
+			case 0x40:	// Mikey write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				WriteEvent = mikey_write(VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				CmdLen = 0x03;
 				break;
 			case 0x41:	// K007232 write
 				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);

--- a/vgm_cnt.c
+++ b/vgm_cnt.c
@@ -17,6 +17,8 @@ typedef struct chip_count_state
 {
 	bool Used;
 	UINT8 ChnReg;
+	UINT8 ChnCnt;
+	UINT8 RegSel;
 	UINT32 CmdCount;
 	INT32 KeyOnCnt;
 	UINT32 KeyState;
@@ -196,6 +198,12 @@ static void CountVGMData()
 	memset(ChipState, 0x00, sizeof(ChipState));
 	ChipState[0x00][0][0x18].ChnReg = 0xFF;
 	ChipState[0x01][0][0x18].ChnReg = 0xFF;
+	ChipState[0x00][0][0x2F].RegSel = 0;
+	ChipState[0x00][0][0x2F].ChnReg = 0;
+	ChipState[0x00][0][0x2F].ChnCnt = 0x1F;
+	ChipState[0x01][0][0x2F].RegSel = 0;
+	ChipState[0x01][0][0x2F].ChnReg = 0;
+	ChipState[0x01][0][0x2F].ChnCnt = 0x1F;
 	for (CurChip = 0x00; CurChip < CHIP_COUNT; CurChip ++)
 	{
 		switch(CurChip)
@@ -303,7 +311,10 @@ static void CountVGMData()
 		case 0x2B:
 			TempLng = VGMHead.lngHzK005289;
 			break;
-		// TODO: 0x2C OKIM5205 .. 0x2F ICS2115
+		// TODO: 0x2C OKIM5205 .. 0x2E BSMT2000
+		case 0x2F:
+			TempLng = VGMHead.lngHzICS2115;
+			break;
 		default:
 			TempLng = 0x00;
 			break;
@@ -581,6 +592,9 @@ static void CountVGMData()
 					case 0x94:	// K007232 ROM Image
 						DoChipCommand(CurChip, 0x2A, 0xFFFF, TempByt);
 						break;
+					case 0x96:	// ICS2115 ROM Image
+						DoChipCommand(CurChip, 0x2F, 0xFFFF, TempByt);
+						break;
 					default:
 						break;
 					}
@@ -796,6 +810,11 @@ static void CountVGMData()
 				DoChipCommand(CurChip, 0x2B, (VGMPnt[0x01] & 0x70) >> 4,
 											((VGMPnt[0x01] & 0x0F) << 8) |
 											VGMPnt[0x02]);
+				CmdLen = 0x03;
+				break;
+			case 0x44:	// ICS2115 write
+				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
+				DoChipCommand(CurChip, 0x2F, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
 				CmdLen = 0x03;
 				break;
 			case 0x90:	// DAC Ctrl: Setup Chip
@@ -1185,10 +1204,39 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 		}
 		break;
 	case 0x2B:	// K005289
-		if ((Reg >> 1) == 0x02)
+		if ((Reg & 0x06) == 0x04)
 		{
-			for (CurChn = 0x00; CurChn < 0x02; CurChn ++)
-				DoKeyOnOff(TempChp, CurChn, ~Data & (1 << CurChn), 0x00);
+			UINT8 ch = Reg & 0x01;
+			DoKeyOnOff(TempChp, ch, 1, 0x00);
+		}
+		break;
+	// TODO: 0x2C OKIM5205 .. 0x2E BSMT2000
+	case 0x2F:	// ICS2115
+		switch (Reg & 0x03)
+		{
+		case 0x01:
+			TempChp->RegSel = Data;
+		case 0x02:
+			switch (TempChp->RegSel)
+			{
+			case 0x4F:
+				TempChp->ChnReg = (Data & 0xFF) % (TempChp->ChnCnt + 1);
+				break;
+			}
+		case 0x03:
+			switch (TempChp->RegSel)
+			{
+			case 0x0E:
+				TempChp->ChnCnt = Data & 0x1F;
+				break;
+			case 0x10:
+				if (TempChp->ChnReg <= TempChp->ChnCnt)
+				{
+					if (!Data)
+						DoKeyOnOff(TempChp, TempChp->ChnReg, 1, 0x00);
+				}
+				break;
+			}
 		}
 		break;
 	}

--- a/vgm_cnt.c
+++ b/vgm_cnt.c
@@ -305,6 +305,9 @@ static void CountVGMData()
 			TempLng = VGMHead.lngHzQSound;
 			break;
 		// TODO: 0x20 SCSP .. 0x29 Mikey
+		case 0x29:
+			TempLng = VGMHead.lngHzMikey;
+			break;
 		case 0x2A:
 			TempLng = VGMHead.lngHzK007232;
 			break;
@@ -800,6 +803,11 @@ static void CountVGMData()
 				DoChipCommand(0x00, 0x1F, VGMPnt[0x03], (VGMPnt[0x01] << 8) | (VGMPnt[0x02] << 0));
 				CmdLen = 0x04;
 				break;
+			case 0x40:	// Mikey write
+				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
+				DoChipCommand(CurChip, 0x29, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				CmdLen = 0x03;
+				break;
 			case 0x41:	// K007232 write
 				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
 				DoChipCommand(CurChip, 0x2A, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
@@ -1194,6 +1202,13 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 		}
 		break;
 	// TODO: 0x20 SCSP .. 0x29 Mikey
+	case 0x29:	// Mikey
+		if ((Reg >= 0x20) && (Reg < 0x40))
+		{
+			UINT8 ch = (Reg >> 3) & 0x03;
+			DoKeyOnOff(TempChp, ch, Data & 0x08, 0x00);
+		}
+		break;
 	case 0x2A:	// K007232
 		if (Reg == 0x1F)
 			Reg = Data;	// chip read - data value contains register ID

--- a/vgm_cnt.c
+++ b/vgm_cnt.c
@@ -320,7 +320,9 @@ static void CountVGMData()
 		case 0x2D:
 			TempLng = VGMHead.lngHzOKIM5232;
 			break;
-		// TODO: 0x2E BSMT2000
+		case 0x2E:
+			TempLng = VGMHead.lngHzBSMT2000;
+			break;
 		case 0x2F:
 			TempLng = VGMHead.lngHzICS2115;
 			break;
@@ -601,6 +603,9 @@ static void CountVGMData()
 					case 0x94:	// K007232 ROM Image
 						DoChipCommand(CurChip, 0x2A, 0xFFFF, TempByt);
 						break;
+					case 0x95:	// BSMT2000 ROM Image
+						DoChipCommand(CurChip, 0x2E, 0xFFFF, TempByt);
+						break;
 					case 0x96:	// ICS2115 ROM Image
 						DoChipCommand(CurChip, 0x2F, 0xFFFF, TempByt);
 						break;
@@ -835,6 +840,11 @@ static void CountVGMData()
 				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
 				DoChipCommand(CurChip, 0x2D, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
 				CmdLen = 0x03;
+				break;
+			case 0xC9:	// BSMT2000 write
+				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
+				DoChipCommand(CurChip, 0x2E, VGMPnt[0x01] & 0x7F, (VGMPnt[0x02] << 8) | VGMPnt[0x03]);
+				CmdLen = 0x04;
 				break;
 			case 0x44:	// ICS2115 write
 				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
@@ -1251,7 +1261,9 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 			DoKeyOnOff(TempChp, ch, (Data >> 7) & 1, 0x00);
 		}
 		break;
-	// TODO: 0x2E BSMT2000
+	case 0x2E:	// BSMT2000
+		TempChp->KeyOnCnt = -1;
+		break;
 	case 0x2F:	// ICS2115
 		switch (Reg & 0x03)
 		{

--- a/vgm_cnt.c
+++ b/vgm_cnt.c
@@ -314,6 +314,9 @@ static void CountVGMData()
 		case 0x2B:
 			TempLng = VGMHead.lngHzK005289;
 			break;
+		case 0x2C:
+			TempLng = VGMHead.lngHzOKIM5205;
+			break;
 		// TODO: 0x2C OKIM5205 .. 0x2E BSMT2000
 		case 0x2F:
 			TempLng = VGMHead.lngHzICS2115;
@@ -820,6 +823,11 @@ static void CountVGMData()
 											VGMPnt[0x02]);
 				CmdLen = 0x03;
 				break;
+			case 0x32:	// OKIM5205 write
+				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
+				DoChipCommand(CurChip, 0x2C, (VGMPnt[0x01] >> 4) & 0x7, VGMPnt[0x01] & 0xF);
+				CmdLen = 0x02;
+				break;
 			case 0x44:	// ICS2115 write
 				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
 				DoChipCommand(CurChip, 0x2F, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
@@ -1224,6 +1232,9 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 			UINT8 ch = Reg & 0x01;
 			DoKeyOnOff(TempChp, ch, 1, 0x00);
 		}
+		break;
+	case 0x2C:	// OKIM5205
+		TempChp->KeyOnCnt = -1;
 		break;
 	// TODO: 0x2C OKIM5205 .. 0x2E BSMT2000
 	case 0x2F:	// ICS2115

--- a/vgm_cnt.c
+++ b/vgm_cnt.c
@@ -304,7 +304,7 @@ static void CountVGMData()
 		case 0x1F:
 			TempLng = VGMHead.lngHzQSound;
 			break;
-		// TODO: 0x20 SCSP .. 0x29 Mikey
+		// TODO: 0x20 SCSP .. 0x28 GA20
 		case 0x29:
 			TempLng = VGMHead.lngHzMikey;
 			break;
@@ -317,7 +317,10 @@ static void CountVGMData()
 		case 0x2C:
 			TempLng = VGMHead.lngHzOKIM5205;
 			break;
-		// TODO: 0x2C OKIM5205 .. 0x2E BSMT2000
+		case 0x2D:
+			TempLng = VGMHead.lngHzOKIM5232;
+			break;
+		// TODO: 0x2E BSMT2000
 		case 0x2F:
 			TempLng = VGMHead.lngHzICS2115;
 			break;
@@ -828,6 +831,11 @@ static void CountVGMData()
 				DoChipCommand(CurChip, 0x2C, (VGMPnt[0x01] >> 4) & 0x7, VGMPnt[0x01] & 0xF);
 				CmdLen = 0x02;
 				break;
+			case 0x43:	// OKIM5232 write
+				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
+				DoChipCommand(CurChip, 0x2D, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				CmdLen = 0x03;
+				break;
 			case 0x44:	// ICS2115 write
 				CurChip = (VGMPnt[0x01] & 0x80) >> 7;
 				DoChipCommand(CurChip, 0x2F, VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
@@ -1209,7 +1217,7 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 			}
 		}
 		break;
-	// TODO: 0x20 SCSP .. 0x29 Mikey
+	// TODO: 0x20 SCSP .. 0x28 GA20
 	case 0x29:	// Mikey
 		if ((Reg >= 0x20) && (Reg < 0x40))
 		{
@@ -1236,7 +1244,14 @@ static void DoChipCommand(UINT8 ChipSet, UINT8 ChipID, UINT16 Reg, UINT16 Data)
 	case 0x2C:	// OKIM5205
 		TempChp->KeyOnCnt = -1;
 		break;
-	// TODO: 0x2C OKIM5205 .. 0x2E BSMT2000
+	case 0x2D:	// OKIM5232
+		if (Reg < 0x08)
+		{
+			UINT8 ch = Reg & 0x07;
+			DoKeyOnOff(TempChp, ch, (Data >> 7) & 1, 0x00);
+		}
+		break;
+	// TODO: 0x2E BSMT2000
 	case 0x2F:	// ICS2115
 		switch (Reg & 0x03)
 		{

--- a/vgm_ndlz.c
+++ b/vgm_ndlz.c
@@ -268,6 +268,9 @@ static void CopyHeader(VGM_HEADER* SrcHead, VGM_HEADER* DstHead, bool IsChip2)
 			case 0x1C:
 				DstHead->bytC140Type = 0x00;
 				break;
+			case 0x27:
+				DstHead->bytOKI5205Flags = 0x00;
+				break;
 			}
 		}
 

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -172,6 +172,7 @@ int main(int argc, char* argv[])
 		printf("    -SetHzK005289  Sets the K005289 chip clock\n");
 		printf("    -SetHzOKIM5205 Sets the OKIM5205 chip clock\n");
 		printf("    -SetOKIM5205Flags  Sets the OKIM5205 Flags\n");
+		printf("    -SetHzOKIM5232 Sets the OKIM5232 chip clock\n");
 		printf("    -SetHzICS2115  Sets the ICS2115 chip clock\n");
 		printf("\n");
 		printf("Setting a clock rate to 0 disables the chip.\n");
@@ -220,6 +221,7 @@ int main(int argc, char* argv[])
 		printf("    K007232       *0..1\n");
 		printf("    K005289       *0..1\n");
 		printf("    OKIM5205       -\n");
+		printf("    OKIM5232      *0..7\n");
 		printf("    ICS2115       *0..31\n");
 		printf("    DacCtrl        0..255\n");
 		printf("* strip whole chip only, no channel stripping\n");
@@ -873,6 +875,11 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			CurChip = 0x2C;
 			TempChip = (STRIP_GENERIC*)&StripVGM[0].OKIM5205;
 		}
+		else if (! stricmp(ChipPos, "OKIM5232"))
+		{
+			CurChip = 0x2D;
+			TempChip = (STRIP_GENERIC*)&StripVGM[0].OKIM5232;
+		}
 		else if (! stricmp(ChipPos, "ICS2115"))
 		{
 			CurChip = 0x2F;
@@ -1419,6 +1426,11 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 			else if (! stricmp(CmdStr, "OKIM5205"))
 			{
 				ChipHzPnt = &VGMHead.lngHzOKIM5205;
+				OldVal = 0x172;
+			}
+			else if (! stricmp(CmdStr, "OKIM5232"))
+			{
+				ChipHzPnt = &VGMHead.lngHzOKIM5232;
 				OldVal = 0x172;
 			}
 			else if (! stricmp(CmdStr, "ICS2115"))
@@ -2947,6 +2959,8 @@ static bool ChipCommandIsValid(UINT8 Command)
 		return true;
 	if (Command == 0x32 && VGMHead.lngHzOKIM5205)
 		return true;
+	if (Command == 0x43 && VGMHead.lngHzOKIM5232)
+		return true;
 	if (Command == 0x44 && VGMHead.lngHzICS2115)
 		return true;
 
@@ -3905,6 +3919,14 @@ static void StripVGMData(void)
 					VGMPnt[0x01] &= ~0x80;
 				CmdLen = 0x02;
 				break;
+			case 0x43:	// OKIM5232 write
+				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
+				SetChipSet(ChipID);
+				WriteEvent = okim5232_write(VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				if (WriteEvent && ChipID && StripVGM[0].OKIM5232.All)
+					VGMPnt[0x01] &= ~0x80;
+				CmdLen = 0x03;
+				break;
 			case 0x44:	// ICS2115 write
 				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
 				if (StripVGM[ChipID].ICS2115.All)
@@ -4185,6 +4207,7 @@ static void StripVGMData(void)
 	StripClock(&StripVGM[0].K005289.All, &VGMHead.lngHzK005289);
 	if (StripClock(&StripVGM[0].OKIM5205.All, &VGMHead.lngHzOKIM5205))
 		VGMHead.bytOKI5205Flags = 0x00;
+	StripClock(&StripVGM[0].OKIM5232.All, &VGMHead.lngHzOKIM5232);
 	StripClock(&StripVGM[0].ICS2115.All, &VGMHead.lngHzICS2115);
 	//StripClock(&StripVGM[0].SCSP.All, &VGMHead.lngHzSCSP);
 

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -170,6 +170,8 @@ int main(int argc, char* argv[])
 		printf("    -SetHzMikey    Sets the Mikey chip clock\n");
 		printf("    -SetHzK007232  Sets the K007232 chip clock\n");
 		printf("    -SetHzK005289  Sets the K005289 chip clock\n");
+		printf("    -SetHzOKIM5205 Sets the OKIM5205 chip clock\n");
+		printf("    -SetOKIM5205Flags  Sets the OKIM5205 Flags\n");
 		printf("    -SetHzICS2115  Sets the ICS2115 chip clock\n");
 		printf("\n");
 		printf("Setting a clock rate to 0 disables the chip.\n");
@@ -217,6 +219,7 @@ int main(int argc, char* argv[])
 		printf("    Mikey         *0..3\n");
 		printf("    K007232       *0..1\n");
 		printf("    K005289       *0..1\n");
+		printf("    OKIM5205       -\n");
 		printf("    ICS2115       *0..31\n");
 		printf("    DacCtrl        0..255\n");
 		printf("* strip whole chip only, no channel stripping\n");
@@ -865,6 +868,11 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			CurChip = 0x2B;
 			TempChip = (STRIP_GENERIC*)&StripVGM[0].K005289;
 		}
+		else if (! stricmp(ChipPos, "OKIM5205"))
+		{
+			CurChip = 0x2C;
+			TempChip = (STRIP_GENERIC*)&StripVGM[0].OKIM5205;
+		}
 		else if (! stricmp(ChipPos, "ICS2115"))
 		{
 			CurChip = 0x2F;
@@ -1408,6 +1416,11 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				ChipHzPnt = &VGMHead.lngHzK005289;
 				OldVal = 0x172;
 			}
+			else if (! stricmp(CmdStr, "OKIM5205"))
+			{
+				ChipHzPnt = &VGMHead.lngHzOKIM5205;
+				OldVal = 0x172;
+			}
 			else if (! stricmp(CmdStr, "ICS2115"))
 			{
 				ChipHzPnt = &VGMHead.lngHzICS2115;
@@ -1695,6 +1708,25 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 				if (TempByt != VGMHead.bytC140Type)
 				{
 					VGMHead.bytC140Type = TempByt;
+					RetVal |= 0x10;
+				}
+			}
+			else
+			{
+				printf("Warning! Command ignored - VGM version too low!\n");
+			}
+		}
+		else if (! stricmp(CmdStr, "SetOKIM5205Flags"))
+		{
+			if (CmdData == NULL)
+				goto IncompleteArg;
+
+			if (VGMHead.lngVersion >= 0x172)
+			{
+				TempByt = (UINT8)strtoul(CmdData, NULL, 0);
+				if (TempByt != VGMHead.bytOKI5205Flags)
+				{
+					VGMHead.bytOKI5205Flags = TempByt;
 					RetVal |= 0x10;
 				}
 			}
@@ -2913,6 +2945,8 @@ static bool ChipCommandIsValid(UINT8 Command)
 		return true;
 	if (Command == 0x42 && VGMHead.lngHzK005289)
 		return true;
+	if (Command == 0x32 && VGMHead.lngHzOKIM5205)
+		return true;
 	if (Command == 0x44 && VGMHead.lngHzICS2115)
 		return true;
 
@@ -3863,6 +3897,14 @@ static void StripVGMData(void)
 					VGMPnt[0x01] &= ~0x80;
 				CmdLen = 0x03;
 				break;
+			case 0x32:	// OKIM5205 write
+				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
+				if (StripVGM[ChipID].OKIM5205.All)
+					WriteEvent = false;
+				if (WriteEvent && ChipID && StripVGM[0].OKIM5205.All)
+					VGMPnt[0x01] &= ~0x80;
+				CmdLen = 0x02;
+				break;
 			case 0x44:	// ICS2115 write
 				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
 				if (StripVGM[ChipID].ICS2115.All)
@@ -4141,6 +4183,8 @@ static void StripVGMData(void)
 	StripClock(&StripVGM[0].Mikey.All, &VGMHead.lngHzMikey);
 	StripClock(&StripVGM[0].K007232.All, &VGMHead.lngHzK007232);
 	StripClock(&StripVGM[0].K005289.All, &VGMHead.lngHzK005289);
+	if (StripClock(&StripVGM[0].OKIM5205.All, &VGMHead.lngHzOKIM5205))
+		VGMHead.bytOKI5205Flags = 0x00;
 	StripClock(&StripVGM[0].ICS2115.All, &VGMHead.lngHzICS2115);
 	//StripClock(&StripVGM[0].SCSP.All, &VGMHead.lngHzSCSP);
 

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -169,6 +169,7 @@ int main(int argc, char* argv[])
 		printf("    -SetHzQSound   Sets the QSound chip clock\n");
 		printf("    -SetHzK007232  Sets the K007232 chip clock\n");
 		printf("    -SetHzK005289  Sets the K005289 chip clock\n");
+		printf("    -SetHzICS2115  Sets the ICS2115 chip clock\n");
 		printf("\n");
 		printf("Setting a clock rate to 0 disables the chip.\n");
 		goto EndProgram;
@@ -214,6 +215,7 @@ int main(int argc, char* argv[])
 		printf("    QSound        *0..15\n");
 		printf("    K007232       *0..1\n");
 		printf("    K005289       *0..1\n");
+		printf("    ICS2115       *0..31\n");
 		printf("    DacCtrl        0..255\n");
 		printf("* strip whole chip only, no channel stripping\n");
 		printf("\n");
@@ -856,6 +858,11 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			CurChip = 0x2B;
 			TempChip = (STRIP_GENERIC*)&StripVGM[0].K005289;
 		}
+		else if (! stricmp(ChipPos, "ICS2115"))
+		{
+			CurChip = 0x2F;
+			TempChip = (STRIP_GENERIC*)&StripVGM[0].ICS2115;
+		}
 		else if (! stricmp(ChipPos, "DacCtrl"))
 		{
 			CurChip = 0x7F;
@@ -1387,6 +1394,11 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 			else if (! stricmp(CmdStr, "K005289"))
 			{
 				ChipHzPnt = &VGMHead.lngHzK005289;
+				OldVal = 0x172;
+			}
+			else if (! stricmp(CmdStr, "ICS2115"))
+			{
+				ChipHzPnt = &VGMHead.lngHzICS2115;
 				OldVal = 0x172;
 			}
 			else
@@ -2887,6 +2899,8 @@ static bool ChipCommandIsValid(UINT8 Command)
 		return true;
 	if (Command == 0x42 && VGMHead.lngHzK005289)
 		return true;
+	if (Command == 0x44 && VGMHead.lngHzICS2115)
+		return true;
 
 	return false;
 }
@@ -3105,6 +3119,29 @@ static void StripVGMData(void)
 		{
 			SetChipSet(0x01);
 			c140_write(0xFF, 0x00, VGMHead.bytC140Type);
+		}
+	}
+	if (VGMHead.lngHzICS2115)
+	{
+		// initialize ICS2115
+		SetChipSet(0x00);
+		ics2115_write(0x01, 0x0E);
+		ics2115_write(0x02, 0x00);
+		ics2115_write(0x03, 0x1F);
+		ics2115_write(0x01, 0x4F);
+		ics2115_write(0x02, 0x00);
+		ics2115_write(0x03, 0x00);
+		ics2115_write(0x01, 0x00);
+		if (VGMHead.lngHzICS2115 & 0x40000000)
+		{
+			SetChipSet(0x01);
+			ics2115_write(0x01, 0x0E);
+			ics2115_write(0x02, 0x00);
+			ics2115_write(0x03, 0x1F);
+			ics2115_write(0x01, 0x4F);
+			ics2115_write(0x02, 0x00);
+			ics2115_write(0x03, 0x00);
+			ics2115_write(0x01, 0x00);
 		}
 	}
 
@@ -3453,6 +3490,12 @@ static void StripVGMData(void)
 						if (WriteEvent && ChipID && StripVGM[0].K007232.All)
 							VGMPnt[0x06] &= ~0x80;
 						break;
+					case 0x96:	// ICS2115 ROM Image
+						if (StripVGM[ChipID].ICS2115.All)
+							WriteEvent = false;
+						if (WriteEvent && ChipID && StripVGM[0].ICS2115.All)
+							VGMPnt[0x06] &= ~0x80;
+						break;
 					}
 					break;
 				case 0xC0:	// RAM Write
@@ -3798,6 +3841,14 @@ static void StripVGMData(void)
 					VGMPnt[0x01] &= ~0x80;
 				CmdLen = 0x03;
 				break;
+			case 0x44:	// ICS2115 write
+				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
+				if (StripVGM[ChipID].ICS2115.All)
+					WriteEvent = false;
+				if (WriteEvent && ChipID && StripVGM[0].ICS2115.All)
+					VGMPnt[0x01] &= ~0x80;
+				CmdLen = 0x03;
+				break;
 			case 0x90:	// DAC Ctrl: Setup Chip
 				if (StripVGM[0].DacCtrl.All ||
 					GetFromMask(StripVGM[0].DacCtrl.StrMsk, VGMPnt[0x01]))
@@ -4067,6 +4118,7 @@ static void StripVGMData(void)
 	StripClock(&StripVGM[0].QSound.All, &VGMHead.lngHzQSound);
 	StripClock(&StripVGM[0].K007232.All, &VGMHead.lngHzK007232);
 	StripClock(&StripVGM[0].K005289.All, &VGMHead.lngHzK005289);
+	StripClock(&StripVGM[0].ICS2115.All, &VGMHead.lngHzICS2115);
 	//StripClock(&StripVGM[0].SCSP.All, &VGMHead.lngHzSCSP);
 
 	// PatchVGM will rewrite the header later

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -173,6 +173,7 @@ int main(int argc, char* argv[])
 		printf("    -SetHzOKIM5205 Sets the OKIM5205 chip clock\n");
 		printf("    -SetOKIM5205Flags  Sets the OKIM5205 Flags\n");
 		printf("    -SetHzOKIM5232 Sets the OKIM5232 chip clock\n");
+		printf("    -SetHzBSMT2000 Sets the BSMT2000 chip clock\n");
 		printf("    -SetHzICS2115  Sets the ICS2115 chip clock\n");
 		printf("\n");
 		printf("Setting a clock rate to 0 disables the chip.\n");
@@ -216,12 +217,13 @@ int main(int argc, char* argv[])
 		printf("    C140           0..23, Other\n");
 		printf("    K053260       *\n");
 		printf("    Pokey         *\n");
-		printf("    QSound        *0..15\n");
+		printf("    QSound        *0..18\n");
 		printf("    Mikey         *0..3\n");
 		printf("    K007232       *0..1\n");
 		printf("    K005289       *0..1\n");
 		printf("    OKIM5205       -\n");
 		printf("    OKIM5232      *0..7\n");
+		printf("    BSMT2000      *0..13\n");
 		printf("    ICS2115       *0..31\n");
 		printf("    DacCtrl        0..255\n");
 		printf("* strip whole chip only, no channel stripping\n");
@@ -880,6 +882,11 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			CurChip = 0x2D;
 			TempChip = (STRIP_GENERIC*)&StripVGM[0].OKIM5232;
 		}
+		else if (! stricmp(ChipPos, "BSMT2000"))
+		{
+			CurChip = 0x2E;
+			TempChip = (STRIP_GENERIC*)&StripVGM[0].BSMT2000;
+		}
 		else if (! stricmp(ChipPos, "ICS2115"))
 		{
 			CurChip = 0x2F;
@@ -1431,6 +1438,11 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 			else if (! stricmp(CmdStr, "OKIM5232"))
 			{
 				ChipHzPnt = &VGMHead.lngHzOKIM5232;
+				OldVal = 0x172;
+			}
+			else if (! stricmp(CmdStr, "BSMT2000"))
+			{
+				ChipHzPnt = &VGMHead.lngHzBSMT2000;
 				OldVal = 0x172;
 			}
 			else if (! stricmp(CmdStr, "ICS2115"))
@@ -2961,6 +2973,8 @@ static bool ChipCommandIsValid(UINT8 Command)
 		return true;
 	if (Command == 0x43 && VGMHead.lngHzOKIM5232)
 		return true;
+	if (Command == 0xC9 && VGMHead.lngHzBSMT2000)
+		return true;
 	if (Command == 0x44 && VGMHead.lngHzICS2115)
 		return true;
 
@@ -3552,6 +3566,12 @@ static void StripVGMData(void)
 						if (WriteEvent && ChipID && StripVGM[0].K007232.All)
 							VGMPnt[0x06] &= ~0x80;
 						break;
+					case 0x95:	// BSMT2000 ROM Image
+						if (StripVGM[ChipID].BSMT2000.All)
+							WriteEvent = false;
+						if (WriteEvent && ChipID && StripVGM[0].BSMT2000.All)
+							VGMPnt[0x06] &= ~0x80;
+						break;
 					case 0x96:	// ICS2115 ROM Image
 						if (StripVGM[ChipID].ICS2115.All)
 							WriteEvent = false;
@@ -3887,6 +3907,14 @@ static void StripVGMData(void)
 					WriteEvent = false;
 				CmdLen = 0x04;
 				break;
+			case 0xC9:	// BSMT2000 write
+				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
+				if (StripVGM[ChipID].BSMT2000.All)
+					WriteEvent = false;
+				if (WriteEvent && ChipID && StripVGM[0].BSMT2000.All)
+					VGMPnt[0x01] &= ~0x80;
+				CmdLen = 0x04;
+				break;
 			case 0x40:	// Mikey write
 				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
 				SetChipSet(ChipID);
@@ -4208,6 +4236,7 @@ static void StripVGMData(void)
 	if (StripClock(&StripVGM[0].OKIM5205.All, &VGMHead.lngHzOKIM5205))
 		VGMHead.bytOKI5205Flags = 0x00;
 	StripClock(&StripVGM[0].OKIM5232.All, &VGMHead.lngHzOKIM5232);
+	StripClock(&StripVGM[0].BSMT2000.All, &VGMHead.lngHzBSMT2000);
 	StripClock(&StripVGM[0].ICS2115.All, &VGMHead.lngHzICS2115);
 	//StripClock(&StripVGM[0].SCSP.All, &VGMHead.lngHzSCSP);
 

--- a/vgm_ptch.c
+++ b/vgm_ptch.c
@@ -167,6 +167,7 @@ int main(int argc, char* argv[])
 		printf("    -SetHzK053260  Sets the K053260 chip clock\n");
 		printf("    -SetHzPokey    Sets the Pokey chip clock\n");
 		printf("    -SetHzQSound   Sets the QSound chip clock\n");
+		printf("    -SetHzMikey    Sets the Mikey chip clock\n");
 		printf("    -SetHzK007232  Sets the K007232 chip clock\n");
 		printf("    -SetHzK005289  Sets the K005289 chip clock\n");
 		printf("    -SetHzICS2115  Sets the ICS2115 chip clock\n");
@@ -213,6 +214,7 @@ int main(int argc, char* argv[])
 		printf("    K053260       *\n");
 		printf("    Pokey         *\n");
 		printf("    QSound        *0..15\n");
+		printf("    Mikey         *0..3\n");
 		printf("    K007232       *0..1\n");
 		printf("    K005289       *0..1\n");
 		printf("    ICS2115       *0..31\n");
@@ -848,6 +850,11 @@ static UINT8 ParseStripCommand(const char* StripCmd)
 			CurChip = 0x1F;
 			TempChip = (STRIP_GENERIC*)&StripVGM[0].QSound;
 		}
+		else if (! stricmp(ChipPos, "Mikey"))
+		{
+			CurChip = 0x29;
+			TempChip = (STRIP_GENERIC*)&StripVGM[0].Mikey;
+		}
 		else if (! stricmp(ChipPos, "K007232"))
 		{
 			CurChip = 0x2A;
@@ -1385,6 +1392,11 @@ static UINT8 PatchVGM(int ArgCount, char* ArgList[])
 			{
 				ChipHzPnt = &VGMHead.lngHzQSound;
 				OldVal = 0x161;
+			}
+			else if (! stricmp(CmdStr, "Mikey"))
+			{
+				ChipHzPnt = &VGMHead.lngHzMikey;
+				OldVal = 0x172;
 			}
 			else if (! stricmp(CmdStr, "K007232"))
 			{
@@ -2895,6 +2907,8 @@ static bool ChipCommandIsValid(UINT8 Command)
 	if (Command == 0xBF && VGMHead.lngHzGA20)
 		return true;
 	// VGM v1.72
+	if (Command == 0x40 && VGMHead.lngHzMikey)
+		return true;
 	if (Command == 0x41 && VGMHead.lngHzK007232)
 		return true;
 	if (Command == 0x42 && VGMHead.lngHzK005289)
@@ -3825,6 +3839,14 @@ static void StripVGMData(void)
 					WriteEvent = false;
 				CmdLen = 0x04;
 				break;
+			case 0x40:	// Mikey write
+				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
+				SetChipSet(ChipID);
+				WriteEvent = mikey_write(VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				if (WriteEvent && ChipID && StripVGM[0].Mikey.All)
+					VGMPnt[0x01] &= ~0x80;
+				CmdLen = 0x03;
+				break;
 			case 0x41:	// K007232 write
 				ChipID = (VGMPnt[0x01] & 0x80) >> 7;
 				if (StripVGM[ChipID].K007232.All)
@@ -4116,6 +4138,7 @@ static void StripVGMData(void)
 	StripClock(&StripVGM[0].K053260.All, &VGMHead.lngHzK053260);
 	StripClock(&StripVGM[0].Pokey.All, &VGMHead.lngHzPokey);
 	StripClock(&StripVGM[0].QSound.All, &VGMHead.lngHzQSound);
+	StripClock(&StripVGM[0].Mikey.All, &VGMHead.lngHzMikey);
 	StripClock(&StripVGM[0].K007232.All, &VGMHead.lngHzK007232);
 	StripClock(&StripVGM[0].K005289.All, &VGMHead.lngHzK005289);
 	StripClock(&StripVGM[0].ICS2115.All, &VGMHead.lngHzICS2115);

--- a/vgm_sro.c
+++ b/vgm_sro.c
@@ -50,6 +50,7 @@ void es550x_w16(UINT8 Offset, UINT16 Data);
 void k007232_write(UINT8 offset, UINT8 data);
 void k005289_write(UINT8 offset, UINT16 data);
 void ics2115_write(UINT8 offset, UINT8 data);
+void bsmt2000_write(UINT8 Offset, UINT16 Value);
 void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 DataLength,
 					const UINT8* ROMData);
 UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData);
@@ -69,11 +70,11 @@ typedef struct rom_region_list
 } ROM_RGN_LIST;
 
 
-#define ROM_TYPES	0x1B
+#define ROM_TYPES	0x1C
 const UINT8 ROM_LIST[ROM_TYPES] =
 {	0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
 	0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F,
-	0x90, 0x91, 0x92, 0x93, 0x94, 0x96, 
+	0x90, 0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 
 	0xC0, 0xC1, 0xC2, 0xC3, 0xE1};
 
 
@@ -153,7 +154,7 @@ int main(int argc, char* argv[])
 		! VGMHead.lngHzNESAPU && ! VGMHead.lngHzES5503 && ! VGMHead.lngHzES5506 &&
 		! VGMHead.lngHzGA20 && ! VGMHead.lngHzX1_010 && ! VGMHead.lngHzC352 &&
 		! VGMHead.lngHzYMF278B && ! VGMHead.lngHzK007232 && ! VGMHead.lngHzK005289 &&
-		! VGMHead.lngHzICS2115)
+		! VGMHead.lngHzICS2115 && ! VGMHead.lngHzBSMT2000)
 	{
 		printf("No chips with Sample-ROM used!\n");
 		ErrVal = 2;
@@ -615,6 +616,11 @@ static void FindUsedROMData(void)
 				qsound_write(VGMPnt[0x03], (VGMPnt[0x01] << 8) | (VGMPnt[0x02] << 0));
 				CmdLen = 0x04;
 				break;
+			case 0xC9:	// BSMT2000 write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				bsmt2000_write(VGMPnt[0x01] & 0x7F, (VGMPnt[0x02] << 8) | (VGMPnt[0x03] << 0));
+				CmdLen = 0x04;
+				break;
 			case 0xD5:	// ES5503 write
 				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
 				es5503_write(VGMPnt[0x02], VGMPnt[0x03]);
@@ -778,6 +784,9 @@ char* GetROMRegionText(UINT8 ROM_ID)
 		break;
 	case 0x94:	// K007232
 		RetStr = "K007232";
+		break;
+	case 0x95:	// BSMT2000
+		RetStr = "BSMT2000";
 		break;
 	case 0x96:	// ICS2115
 		RetStr = "ICS2115";

--- a/vgm_sro.c
+++ b/vgm_sro.c
@@ -49,6 +49,7 @@ void es550x_w(UINT8 Offset, UINT8 Data);
 void es550x_w16(UINT8 Offset, UINT16 Data);
 void k007232_write(UINT8 offset, UINT8 data);
 void k005289_write(UINT8 offset, UINT16 data);
+void ics2115_write(UINT8 offset, UINT8 data);
 void write_rom_data(UINT8 ROMType, UINT32 ROMSize, UINT32 DataStart, UINT32 DataLength,
 					const UINT8* ROMData);
 UINT32 GetROMMask(UINT8 ROMType, UINT8** MaskData);
@@ -68,11 +69,11 @@ typedef struct rom_region_list
 } ROM_RGN_LIST;
 
 
-#define ROM_TYPES	0x1A
+#define ROM_TYPES	0x1B
 const UINT8 ROM_LIST[ROM_TYPES] =
 {	0x80, 0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87,
 	0x88, 0x89, 0x8A, 0x8B, 0x8C, 0x8D, 0x8E, 0x8F,
-	0x90, 0x91, 0x92, 0x93, 0x94, 
+	0x90, 0x91, 0x92, 0x93, 0x94, 0x96, 
 	0xC0, 0xC1, 0xC2, 0xC3, 0xE1};
 
 
@@ -151,7 +152,8 @@ int main(int argc, char* argv[])
 		! VGMHead.lngHzQSound && ! VGMHead.lngHzUPD7759 && ! VGMHead.lngHzMultiPCM &&
 		! VGMHead.lngHzNESAPU && ! VGMHead.lngHzES5503 && ! VGMHead.lngHzES5506 &&
 		! VGMHead.lngHzGA20 && ! VGMHead.lngHzX1_010 && ! VGMHead.lngHzC352 &&
-		! VGMHead.lngHzYMF278B && ! VGMHead.lngHzK007232 && ! VGMHead.lngHzK005289)
+		! VGMHead.lngHzYMF278B && ! VGMHead.lngHzK007232 && ! VGMHead.lngHzK005289 &&
+		! VGMHead.lngHzICS2115)
 	{
 		printf("No chips with Sample-ROM used!\n");
 		ErrVal = 2;
@@ -494,6 +496,10 @@ static void FindUsedROMData(void)
 								((VGMPnt[0x01] & 0x0F) << 8) |
 								VGMPnt[0x02]);
 				CmdLen = 0x03;
+			case 0x44:	// ICS2115 write
+				SetChipSet((VGMPnt[0x01] & 0x80) >> 7);
+				ics2115_write(VGMPnt[0x01] & 0x7F, VGMPnt[0x02]);
+				CmdLen = 0x03;
 				break;
 			case 0x4F:	// GG Stereo
 				CmdLen = 0x02;
@@ -772,6 +778,9 @@ char* GetROMRegionText(UINT8 ROM_ID)
 		break;
 	case 0x94:	// K007232
 		RetStr = "K007232";
+		break;
+	case 0x96:	// ICS2115
+		RetStr = "ICS2115";
 		break;
 	case 0xC0:	// RF5C68 RAM
 		RetStr = "RF5C68";

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -619,6 +619,14 @@ static void PrepareChipMemory(void)
 				TempRC->GA20.Chns.ChnCount = 0x04;
 			}
 		}
+		if (VGMHead.lngHzMikey)
+		{
+			if (! CurCSet || (VGMHead.lngHzMikey & 0x40000000))
+			{
+				TempRC->Mikey.Regs.RegCount = 0x51;
+				TempRC->Mikey.Chns.ChnCount = 0x04;
+			}
+		}
 		if (VGMHead.lngHzK007232)
 		{
 			if (! CurCSet || (VGMHead.lngHzK007232 & 0x40000000))
@@ -928,6 +936,18 @@ static void SetImportantCommands(void)
 			case 0x28:	// GA20
 				break;
 			case 0x29:	// Mikey
+				for (CurReg = 0x20; CurReg < 0x40; CurReg += 0x8)
+				{
+					TempReg->RegMask[CurReg + 0x00] |= 0x80; // Volume
+					TempReg->RegMask[CurReg + 0x04] |= 0x80; // Backup
+					TempReg->RegMask[CurReg + 0x05] |= 0x80; // Control
+					TempReg->RegMask[CurReg + 0x07] |= 0x80; // Other
+				}
+				for (CurReg = 0x40; CurReg <= 0x44; CurReg++)
+				{
+					TempReg->RegMask[CurReg] |= 0x80; // Volume
+				}
+				TempReg->RegMask[0x50] |= 0x80; // Master enable
 				break;
 			case 0x2A:	// K007232
 				break;
@@ -1766,8 +1786,10 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				ChipCmd = 0xBF;
 				CmdType = 0x12;
 				break;
-			//case 0x29:	// Mikey
-			//	break;
+			case 0x29:	// Mikey
+				ChipCmd = 0x40;
+				CmdType = 0x12;
+				break;
 			case 0x2A:	// K007232
 				ChipCmd = 0x41;
 				CmdType = 0x12;
@@ -2090,6 +2112,21 @@ static UINT32 ReadCommand(UINT8 Mask)
 	TempChp = NULL;
 	switch(Command)
 	{
+	case 0x40:	// Mikey write
+		TempChp = &RC[ChipID].Mikey;
+		TempReg = &TempChp->Regs;
+		if (TempReg->RegCount)
+		{
+			CmdReg = VGMData[VGMPos + 0x01] & 0x7F;
+			if (CmdReg < TempReg->RegCount)
+			{
+				TempReg->RegMask[CmdReg] |= Mask;
+				if (Mask == 0x01)
+					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
+			}
+		}
+		CmdLen = 0x03;
+		break;
 	case 0x41:	// K007232 write
 		TempChp = &RC[ChipID].K007232;
 		TempReg = &TempChp->Regs;
@@ -2934,6 +2971,18 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 	case 0xE1:	// C352 write
 		break;
 	case 0xBF:	// GA20 write
+		break;
+	case 0x40:	// Mikey write
+		if ((CmdReg >= 0x20) && (CmdReg < 0x40))
+		{
+			CurChn = (CmdReg >> 3) & 3;
+			if ((CmdReg & 0x07) == 0x05)
+			{
+				KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x08) >> 3;
+				TempChn->ChnMask &= ~(1 << CurChn);
+				TempChn->ChnMask |= (KeyOnOff << CurChn);
+			}
+		}
 		break;
 	case 0x41:	// K007232 write
 		if (CmdReg == 0x1F)

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -674,8 +674,8 @@ static void PrepareChipMemory(void)
 			if (! CurCSet || (VGMHead.lngHzICS2115 & 0x40000000))
 			{
 				// 0x20 pages with 0x80 registers with 2 bytes + register index
-				TempRC->ICS2115.Regs.Mode = 0x01;
-				TempRC->ICS2115.Regs.RegCount = (0x80 * 0x20) + 1;
+				TempRC->ICS2115.Regs.Mode = 0x00;
+				TempRC->ICS2115.Regs.RegCount = ((0x80 * 0x20) * 2) + 1;
 				TempRC->ICS2115.Chns.ChnCount = 0x20;
 			}
 		}
@@ -1009,6 +1009,22 @@ static void SetImportantCommands(void)
 				TempReg->RegMask[0x7F] |= 0x80;
 				break;
 			case 0x2F:	// ICS2115
+				for (CurReg = 0x00; CurReg < 0x20; CurReg++)
+				{
+					TempReg->RegMask[(((CurReg << 7) | 0x00) << 1) | 1] |= 0x80; // Oscillator Configuration
+					TempReg->RegMask[(((CurReg << 7) | 0x06) << 1) | 1] |= 0x80; // Volume Increment
+					TempReg->RegMask[(((CurReg << 7) | 0x07) << 1) | 0] |= 0x80; // Volume Start
+					TempReg->RegMask[(((CurReg << 7) | 0x08) << 1) | 0] |= 0x80; // Volume End
+					TempReg->RegMask[(((CurReg << 7) | 0x09) << 1) | 0] |= 0x80; // Volume accumulator
+					TempReg->RegMask[(((CurReg << 7) | 0x09) << 1) | 1] |= 0x80; // Volume accumulator
+					TempReg->RegMask[(((CurReg << 7) | 0x0C) << 1) | 1] |= 0x80; // Pan
+					TempReg->RegMask[(((CurReg << 7) | 0x0D) << 1) | 1] |= 0x80; // Volume Envelope Control
+					TempReg->RegMask[(((CurReg << 7) | 0x11) << 1) | 1] |= 0x80; // Wavesample static address 27-20
+					TempReg->RegMask[(((CurReg << 7) | 0x12) << 1) | 1] |= 0x80; // vmode
+				}
+				TempReg->RegMask[(0x4F << 1) | 0] |= 0x80; // Voice select
+				TempReg->RegMask[(0x0E << 1) | 1] |= 0x80; // Number of voices
+				TempReg->RegMask[(0x80 | (0x20 << 7)) << 1] |= 0x80; // Register select
 				break;
 			}
 		}
@@ -1942,7 +1958,107 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 				break;
 			case 0x2F:	// ICS2115
 				ChipCmd = 0x44;
-				CmdType = 0xFF;
+
+				TempSht = (TempReg->RegData.R08[(0x0E << 1) | 1] >> 8) & 0xFF;
+				if ((TempReg->RegMask[0x0E] & 0x7F) == 0x01)
+				{
+					DstData[DstPos + 0x00] = ChipCmd;
+					DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+					DstData[DstPos + 0x02] = 0x0E;
+					DstPos += 0x03;
+					DstData[DstPos + 0x00] = ChipCmd;
+					DstData[DstPos + 0x01] = (CurCSet << 7) | 0x03;
+					DstData[DstPos + 0x02] = TempSht;
+					DstPos += 0x03;
+				}
+
+				for (TempByt = 0x00; TempByt <= TempSht; TempByt ++)
+				{
+					CmdType = 0x00;
+					WrtReg = TempByt * 0x80;
+					for (CurReg = 0x00; CurReg < 0x12; CurReg ++)
+					{
+						if ((CurReg == 0x0E) || (CurReg == 0x0F))
+							continue;
+
+						// Register LSB
+						if ((TempReg->RegMask[((WrtReg + CurReg) << 1) | 0] & 0x7F) == 0x01)
+						{
+							if (! CmdType)
+							{
+								// write Channel Select
+								DstData[DstPos + 0x00] = ChipCmd;
+								DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+								DstData[DstPos + 0x02] = 0x4F;
+								DstPos += 0x03;
+								DstData[DstPos + 0x00] = ChipCmd;
+								DstData[DstPos + 0x01] = (CurCSet << 7) | 0x02;
+								DstData[DstPos + 0x02] = TempByt;
+								DstPos += 0x03;
+								CmdType = 0x01;
+							}
+
+							DstData[DstPos + 0x00] = ChipCmd;
+							DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+							DstData[DstPos + 0x02] = CurReg;
+							DstPos += 0x03;
+							DstData[DstPos + 0x00] = ChipCmd;
+							DstData[DstPos + 0x01] = (CurCSet << 7) | 0x02;
+							DstData[DstPos + 0x02] = TempReg->RegData.R08[((WrtReg + CurReg) << 1) | 0] & 0xFF;
+							DstPos += 0x03;
+						}
+						// Register MSB
+						if ((TempReg->RegMask[((WrtReg + CurReg) << 1) | 1] & 0x7F) == 0x01)
+						{
+							if (! CmdType)
+							{
+								// write Channel Select
+								DstData[DstPos + 0x00] = ChipCmd;
+								DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+								DstData[DstPos + 0x02] = 0x4F;
+								DstPos += 0x03;
+								DstData[DstPos + 0x00] = ChipCmd;
+								DstData[DstPos + 0x01] = (CurCSet << 7) | 0x02;
+								DstData[DstPos + 0x02] = TempByt;
+								DstPos += 0x03;
+								CmdType = 0x01;
+							}
+
+							DstData[DstPos + 0x00] = ChipCmd;
+							DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+							DstData[DstPos + 0x02] = CurReg;
+							DstPos += 0x03;
+							DstData[DstPos + 0x00] = ChipCmd;
+							DstData[DstPos + 0x01] = (CurCSet << 7) | 0x03;
+							DstData[DstPos + 0x02] = TempReg->RegData.R08[((WrtReg + CurReg) << 1) | 1] & 0xFF;
+							DstPos += 0x03;
+						}
+					}
+				}
+
+				CurReg = (0x4F << 1) | 0;
+				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
+				{
+					DstData[DstPos + 0x00] = ChipCmd;
+					DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+					DstData[DstPos + 0x02] = CurReg;
+					DstPos += 0x03;
+					DstData[DstPos + 0x00] = ChipCmd;
+					DstData[DstPos + 0x01] = (CurCSet << 7) | 0x02;
+					DstData[DstPos + 0x02] = TempReg->RegData.R08[CurReg] & 0xFF;
+					DstPos += 0x03;
+				}
+
+				CurReg = (0x80 | (0x20 << 7)) << 1;
+				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
+				{
+					DstData[DstPos + 0x00] = ChipCmd;
+					DstData[DstPos + 0x01] = (CurCSet << 7) | 0x01;
+					DstData[DstPos + 0x02] = TempReg->RegData.R08[CurReg] & 0xFF;
+					DstPos += 0x03;
+				}
+
+				CmdType = 0x00;
 				break;
 			default:
 				CmdType = 0xFF;
@@ -2227,7 +2343,7 @@ static UINT32 ReadCommand(UINT8 Mask)
 	UINT8 ChipID;
 	UINT8 Command;
 	//UINT8 TempByt;
-	//UINT16 TempSht;
+	UINT16 TempSht;
 	//UINT32 TempLng;
 	UINT16 CmdReg;
 	UINT16 ChnReg;
@@ -2845,7 +2961,42 @@ static UINT32 ReadCommand(UINT8 Mask)
 
 		CmdLen = 0x02;
 		break;
-	case 0x44:	// ICS2115 write (16-bit data)
+	case 0x44:	// ICS2115 write (8-bit data)
+		ChipID = VGMData[VGMPos + 0x01] >> 7;
+		TempChp = &RC[ChipID].ICS2115;
+		TempReg = &TempChp->Regs;
+		if (TempReg->RegCount)
+		{
+			// Bit 0 - Byte select (0 = LSB, 1 = MSB)
+			// Bit 1 to 7 - Register index
+			// Bit 8 to 12 - Channel index
+			// 0x2000 - Register select
+			CmdReg = VGMData[VGMPos + 0x01];
+			switch (CmdReg)
+			{
+			case 0x01:
+				CmdReg = (0x80 | (0x20 << 7)) << 1;
+				TempReg->RegMask[CmdReg] |= Mask;
+				if (Mask == 0x01)
+					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
+				break;
+			case 0x02:
+			case 0x03:
+				TempSht = CmdReg & 0x01;
+				CmdReg = TempReg->RegData.R08[(0x80 | (0x20 << 7)) << 1];
+				if ((CmdReg <= 0x12) && (CmdReg != 0x0E) && (CmdReg != 0x0F))
+				{
+					ChnReg = TempReg->RegData.R08[(0x4F << 1) | 0];
+					CmdReg |= ChnReg << 7;
+				}
+				CmdReg = (CmdReg << 1) | TempSht;
+				TempReg->RegMask[CmdReg] |= Mask;
+				if (Mask == 0x01)
+					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
+				break;
+			}
+		}
+
 		CmdLen = 0x03;
 		break;
 	}
@@ -2863,6 +3014,7 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 	UINT8 CurChn;
 	UINT8 KeyOnOff;
 	UINT16 TempSht;
+	UINT16 TempVal;
 
 	if (ChpData == NULL)
 		return;
@@ -3089,6 +3241,8 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		break;
 	case 0xC5:	// SCSP write
 		break;
+	case 0xC9:	// BSMT2000 write
+		break;
 	case 0xBC:	// WonderSwan write
 		if (CmdReg == 0x10)
 		{
@@ -3221,7 +3375,29 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}
 		break;
-	case 0x44:	// ICS2115 write (16-bit data)
+	case 0x44:	// ICS2115 write (8-bit data)
+		switch (CmdReg)
+		{
+		case 0x02:
+		case 0x03:
+			TempSht = CmdReg & 0x01;
+			CurChn = TempReg->RegData.R08[(0x4F << 1) | 0];
+			CmdReg = TempReg->RegData.R08[(0x80 | (0x20 << 7)) << 1];
+			TempVal = CmdReg;
+			if ((CmdReg <= 0x12) && (CmdReg != 0x0E) && (CmdReg != 0x0F))
+			{
+				TempVal |= CurChn << 7;
+			}
+			TempVal = (TempVal << 1) | TempSht;
+			if ((CmdReg == 0x10) && (TempSht == 1))
+			{
+				KeyOnOff = TempReg->RegData.R08[TempVal] == 0;
+
+				TempChn->ChnMask &= ~(1 << CurChn);
+				TempChn->ChnMask |= (KeyOnOff << CurChn);
+			}
+			break;
+		}
 		break;
 	}
 

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -643,6 +643,15 @@ static void PrepareChipMemory(void)
 				TempRC->K005289.Chns.ChnCount = 0x02;
 			}
 		}
+		if (VGMHead.lngHzOKIM5205)
+		{
+			if (! CurCSet || (VGMHead.lngHzOKIM5205 & 0x40000000))
+			{
+				// One reg for every port (Ctrl, Data, Pan) Clock-stuff
+				TempRC->OKIM5205.Regs.RegCount = 0x06;
+				TempRC->OKIM5205.Chns.ChnCount = 0x01;
+			}
+		}
 	}
 
 	return;
@@ -952,6 +961,12 @@ static void SetImportantCommands(void)
 			case 0x2A:	// K007232
 				break;
 			case 0x2B:	// K005289
+				break;
+			case 0x2C:	// OKIM5205
+				TempReg->RegData.R08[0x04] = (VGMHead.bytOKI5205Flags >>  0) & 0x3;
+				TempReg->RegData.R08[0x05] = (VGMHead.bytOKI5205Flags >>  2) & 0x1;
+				for (CurReg = 0x04; CurReg <= 0x05; CurReg ++)
+					TempReg->RegMask[CurReg] |= 0x80;
 				break;
 			}
 		}
@@ -1809,6 +1824,31 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 
 				CmdType = 0x00;
 				break;
+			case 0x2C:	// OKIM5205
+				ChipCmd = 0x32;
+				CmdType = 0xFF;
+				if ((TempReg->RegMask[0x04] & 0x7F) == 0x01)
+				{
+					VGMHead.bytOKI5205Flags &= ~0x03;
+					VGMHead.bytOKI5205Flags |= TempReg->RegData.R08[0x04] & 0x03;
+				}
+				if ((TempReg->RegMask[0x05] & 0x7F) == 0x01)
+				{
+					VGMHead.bytOKI5205Flags &= ~0x04;
+					VGMHead.bytOKI5205Flags |= (TempReg->RegData.R08[0x05] & 0x01) << 2;
+				}
+
+				for (CurReg = 0x00; CurReg < 0x03; CurReg ++)
+				{
+					WrtReg = (0x02 + CurReg) % 0x03;	// write in order 02, 00, 01
+					if ((TempReg->RegMask[WrtReg] & 0x7F) == 0x01)
+					{
+						DstData[DstPos + 0x00] = ChipCmd;
+						DstData[DstPos + 0x01] = (CurCSet << 7) | ((WrtReg & 7) << 4) | (TempReg->RegData.R08[WrtReg] & 0x0F);
+						DstPos += 0x02;
+					}
+				}
+				break;
 			default:
 				CmdType = 0xFF;
 				break;
@@ -2657,6 +2697,24 @@ static UINT32 ReadCommand(UINT8 Mask)
 		break;
 	case 0xD6:	// ES5506 write (16-bit data)
 		CmdLen = 0x04;
+		break;
+	case 0x32:	// OKIM5205 write
+		ChipID = VGMData[VGMPos + 0x01] >> 7;
+		TempChp = &RC[ChipID].OKIM5205;
+		TempReg = &TempChp->Regs;
+
+		if (TempReg->RegCount)
+		{
+			CmdReg = (VGMData[VGMPos + 0x01] >> 4) & 0x7;
+			if (CmdReg < TempReg->RegCount)
+			{
+				TempReg->RegMask[CmdReg] |= Mask;
+				if (Mask == 0x01)
+					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x01] & 0xF;
+			}
+		}
+
+		CmdLen = 0x02;
 		break;
 	}
 	CommandCheck(0x00, Command, TempChp, CmdReg);

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -537,7 +537,7 @@ static void PrepareChipMemory(void)
 			{
 				TempRC->QSound.Regs.Mode = 0x01;
 				TempRC->QSound.Regs.RegCount = 0x100;
-				TempRC->QSound.Chns.ChnCount = 0x10;
+				TempRC->QSound.Chns.ChnCount = 0x13;
 			}
 		}
 		if (VGMHead.lngHzSCSP)
@@ -658,6 +658,15 @@ static void PrepareChipMemory(void)
 			{
 				TempRC->OKIM5232.Regs.RegCount = 0x24;
 				TempRC->OKIM5232.Chns.ChnCount = 0x8;
+			}
+		}
+		if (VGMHead.lngHzBSMT2000)
+		{
+			if (! CurCSet || (VGMHead.lngHzBSMT2000 & 0x40000000))
+			{
+				TempRC->BSMT2000.Regs.Mode = 0x01;
+				TempRC->BSMT2000.Regs.RegCount = 0x80;
+				TempRC->BSMT2000.Chns.ChnCount = 0x0D;
 			}
 		}
 	}
@@ -985,6 +994,9 @@ static void SetImportantCommands(void)
 				// control registers
 				for (CurReg = 0xC; CurReg < 0xD; CurReg ++)
 					TempReg->RegMask[CurReg] |= 0x80;
+				break;
+			case 0x2E:	// BSMT2000
+				TempReg->RegMask[0x7F] |= 0x80;
 				break;
 			}
 		}
@@ -1888,6 +1900,24 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 						TempReg->RegMask[CurReg] = TempReg->RegMask[0x23];
 				}
 				break;
+			case 0x2E:	// BSMT2000
+				ChipCmd = 0xC9;
+
+				for (CurReg = 0x00; CurReg < TempReg->RegCount; CurReg ++)
+				{
+					if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
+					{
+						TempSht = TempReg->RegData.R16[CurReg];
+						DstData[DstPos + 0x00] = ChipCmd;
+						DstData[DstPos + 0x01] = (UINT8)CurReg;
+						DstData[DstPos + 0x02] = (TempSht & 0xFF00) >> 8;
+						DstData[DstPos + 0x03] = (TempSht & 0x00FF) >> 0;
+						DstPos += 0x04;
+					}
+				}
+
+				CmdType = 0xFF;
+				break;
 			default:
 				CmdType = 0xFF;
 				break;
@@ -2741,6 +2771,25 @@ static UINT32 ReadCommand(UINT8 Mask)
 				if (Mask == 0x01)
 					TempReg->RegData.R16[CmdReg] = (VGMData[VGMPos + 0x01] << 8) |
 													(VGMData[VGMPos + 0x02] << 0);
+			}
+		}
+
+		CmdLen = 0x04;
+		break;
+	case 0xC9:	// BSMT2000 write
+		ChipID = VGMData[VGMPos + 0x01] >> 7;
+		TempChp = &RC[ChipID].BSMT2000;
+		TempReg = &TempChp->Regs;
+
+		if (TempReg->RegCount)
+		{
+			CmdReg = VGMData[VGMPos + 0x01] & 0x7F;
+			if (CmdReg < TempReg->RegCount)
+			{
+				TempReg->RegMask[CmdReg] |= Mask;
+				if (Mask == 0x01)
+					TempReg->RegData.R16[CmdReg] = (VGMData[VGMPos + 0x02] << 8) |
+													(VGMData[VGMPos + 0x03] << 0);
 			}
 		}
 

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -652,6 +652,14 @@ static void PrepareChipMemory(void)
 				TempRC->OKIM5205.Chns.ChnCount = 0x01;
 			}
 		}
+		if (VGMHead.lngHzOKIM5232)
+		{
+			if (! CurCSet || (VGMHead.lngHzOKIM5232 & 0x40000000))
+			{
+				TempRC->OKIM5232.Regs.RegCount = 0x24;
+				TempRC->OKIM5232.Chns.ChnCount = 0x8;
+			}
+		}
 	}
 
 	return;
@@ -966,6 +974,16 @@ static void SetImportantCommands(void)
 				TempReg->RegData.R08[0x04] = (VGMHead.bytOKI5205Flags >>  0) & 0x3;
 				TempReg->RegData.R08[0x05] = (VGMHead.bytOKI5205Flags >>  2) & 0x1;
 				for (CurReg = 0x04; CurReg <= 0x05; CurReg ++)
+					TempReg->RegMask[CurReg] |= 0x80;
+				break;
+			case 0x2D:	// OKIM5232
+				// clock
+				TempReg->RegData.R08[0x20] = (VGMHead.lngHzOKIM5232 >>  0) & 0xFF;
+				TempReg->RegData.R08[0x21] = (VGMHead.lngHzOKIM5232 >>  8) & 0xFF;
+				TempReg->RegData.R08[0x22] = (VGMHead.lngHzOKIM5232 >> 16) & 0xFF;
+				TempReg->RegData.R08[0x23] = (VGMHead.lngHzOKIM5232 >> 24) & 0x3F;
+				// control registers
+				for (CurReg = 0xC; CurReg < 0xD; CurReg ++)
 					TempReg->RegMask[CurReg] |= 0x80;
 				break;
 			}
@@ -1849,6 +1867,27 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 					}
 				}
 				break;
+			case 0x2D:	// OKIM5232
+				ChipCmd = 0x43;
+				CmdType = 0x12;
+				if (! CurCSet &&	// only chip 1 can change the master clock
+					((TempReg->RegMask[0x23] & 0x7F) == 0x01))
+				{
+					TempLng = VGMHead.lngHzOKIM5232 & 0x40000000;
+					VGMHead.lngHzOKIM5232 =	(TempReg->RegData.R08[0x20] <<  0) |
+											(TempReg->RegData.R08[0x21] <<  8) |
+											(TempReg->RegData.R08[0x22] << 16) |
+											(TempReg->RegData.R08[0x23] << 24) |
+											TempLng;
+					for (CurReg = 0x20; CurReg <= 0x23; CurReg ++)
+						TempReg->RegMask[CurReg] = 0x00;
+				}
+				else if ((TempReg->RegMask[0x23] & 0x7F) == 0x01)
+				{
+					for (CurReg = 0x20; CurReg <= 0x23; CurReg ++)
+						TempReg->RegMask[CurReg] = TempReg->RegMask[0x23];
+				}
+				break;
 			default:
 				CmdType = 0xFF;
 				break;
@@ -2197,6 +2236,21 @@ static UINT32 ReadCommand(UINT8 Mask)
 			}
 		}
 
+		CmdLen = 0x03;
+		break;
+	case 0x43:	// OKIM5232 write
+		TempChp = &RC[ChipID].OKIM5232;
+		TempReg = &TempChp->Regs;
+		if (TempReg->RegCount)
+		{
+			CmdReg = VGMData[VGMPos + 0x01] & 0x7F;
+			if (CmdReg < TempReg->RegCount)
+			{
+				TempReg->RegMask[CmdReg] |= Mask;
+				if (Mask == 0x01)
+					TempReg->RegData.R08[CmdReg] = VGMData[VGMPos + 0x02];
+			}
+		}
 		CmdLen = 0x03;
 		break;
 	case 0x50:	// SN76496 write
@@ -3057,6 +3111,34 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 		{
 			CurChn = 1;
 			KeyOnOff = 1;
+			TempChn->ChnMask &= ~(1 << CurChn);
+			TempChn->ChnMask |= (KeyOnOff << CurChn);
+		}
+		break;
+	case 0x42:	// K005289 write
+		CurChn = CmdReg & 0x01;
+		KeyOnOff = 0x00;
+
+		// test Frequency
+		if ((CmdReg & 0x06) == 0x04)
+		{
+			TempSht = TempReg->RegData.R16[CmdReg | 0x02];
+			if (TempSht >= 0xFFF)
+				KeyOnOff |= 0x01;	// inaudible frequency - key off
+		}
+		// test volume
+		if ((TempReg->RegData.R16[CmdReg | 0x00] & 0x00) == 0x00)
+			KeyOnOff |= 0x01;	// volume 0 - key off
+
+		KeyOnOff = ! KeyOnOff;
+		TempChn->ChnMask &= ~(1 << CurChn);
+		TempChn->ChnMask |= (KeyOnOff << CurChn);
+		break;
+	case 0x43:	// OKIM5232 write
+		if (CmdReg < 0x8)
+		{
+			CurChn = CmdReg & 0x7;
+			KeyOnOff = (TempReg->RegData.R08[CmdReg] & 0x80) >> 7;
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -1915,13 +1915,23 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 			case 0x2E:	// BSMT2000
 				ChipCmd = 0xC9;
 
-				for (CurReg = 0x00; CurReg < TempReg->RegCount; CurReg ++)
+				CurReg = 0x7F;
+				if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
+				{
+					TempSht = TempReg->RegData.R16[CurReg];
+					DstData[DstPos + 0x00] = ChipCmd;
+					DstData[DstPos + 0x01] = (CurCSet << 7) | CurReg;
+					DstData[DstPos + 0x02] = (TempSht & 0xFF00) >> 8;
+					DstData[DstPos + 0x03] = (TempSht & 0x00FF) >> 0;
+					DstPos += 0x04;
+				}
+				for (CurReg = 0x00; CurReg < 0x7F; CurReg ++)
 				{
 					if ((TempReg->RegMask[CurReg] & 0x7F) == 0x01)
 					{
 						TempSht = TempReg->RegData.R16[CurReg];
 						DstData[DstPos + 0x00] = ChipCmd;
-						DstData[DstPos + 0x01] = (UINT8)CurReg;
+						DstData[DstPos + 0x01] = (CurCSet << 7) | CurReg;
 						DstData[DstPos + 0x02] = (TempSht & 0xFF00) >> 8;
 						DstData[DstPos + 0x03] = (TempSht & 0x00FF) >> 0;
 						DstPos += 0x04;

--- a/vgm_trml.c
+++ b/vgm_trml.c
@@ -669,6 +669,16 @@ static void PrepareChipMemory(void)
 				TempRC->BSMT2000.Chns.ChnCount = 0x0D;
 			}
 		}
+		if (VGMHead.lngHzICS2115)
+		{
+			if (! CurCSet || (VGMHead.lngHzICS2115 & 0x40000000))
+			{
+				// 0x20 pages with 0x80 registers with 2 bytes + register index
+				TempRC->ICS2115.Regs.Mode = 0x01;
+				TempRC->ICS2115.Regs.RegCount = (0x80 * 0x20) + 1;
+				TempRC->ICS2115.Chns.ChnCount = 0x20;
+			}
+		}
 	}
 
 	return;
@@ -997,6 +1007,8 @@ static void SetImportantCommands(void)
 				break;
 			case 0x2E:	// BSMT2000
 				TempReg->RegMask[0x7F] |= 0x80;
+				break;
+			case 0x2F:	// ICS2115
 				break;
 			}
 		}
@@ -1918,6 +1930,10 @@ static void InitializeVGM(UINT8** DstDataRef, UINT32* DstPosRef)
 
 				CmdType = 0xFF;
 				break;
+			case 0x2F:	// ICS2115
+				ChipCmd = 0x44;
+				CmdType = 0xFF;
+				break;
 			default:
 				CmdType = 0xFF;
 				break;
@@ -2819,6 +2835,9 @@ static UINT32 ReadCommand(UINT8 Mask)
 
 		CmdLen = 0x02;
 		break;
+	case 0x44:	// ICS2115 write (16-bit data)
+		CmdLen = 0x03;
+		break;
 	}
 	CommandCheck(0x00, Command, TempChp, CmdReg);
 
@@ -3191,6 +3210,8 @@ static void CommandCheck(UINT8 Mode, UINT8 Command, CHIP_DATA* ChpData, UINT16 C
 			TempChn->ChnMask &= ~(1 << CurChn);
 			TempChn->ChnMask |= (KeyOnOff << CurChn);
 		}
+		break;
+	case 0x44:	// ICS2115 write (16-bit data)
 		break;
 	}
 

--- a/vgmlpfnd.c
+++ b/vgmlpfnd.c
@@ -330,6 +330,9 @@ static void ReadVGMData(void)
 			case 0x95:	// DAC Ctrl: Play Block (small)
 				CmdLen = 0x05;
 				break;
+			case 0x40: // Mikey write
+				CmdLen = 0x03;
+				break;
 			case 0x41: // K007232 write
 				CmdLen = 0x03;
 				break;
@@ -564,6 +567,9 @@ static void ReadVGMData(void)
 				break;
 			case 0x95:	// DAC Ctrl: Play Block (small)
 				CmdLen = 0x05;
+				break;
+			case 0x40: // Mikey write
+				CmdLen = 0x03;
 				break;
 			case 0x41: // K007232 write
 				CmdLen = 0x03;

--- a/vgmlpfnd.c
+++ b/vgmlpfnd.c
@@ -339,6 +339,9 @@ static void ReadVGMData(void)
 			case 0x42: // K005289 write
 				CmdLen = 0x03;
 				break;
+			case 0x43: // OKIM5232 write
+				CmdLen = 0x03;
+				break;
 			case 0x44: // ICS2115 write
 				CmdLen = 0x03;
 				break;
@@ -575,6 +578,9 @@ static void ReadVGMData(void)
 				CmdLen = 0x03;
 				break;
 			case 0x42: // K005289 write
+				CmdLen = 0x03;
+				break;
+			case 0x43: // OKIM5232 write
 				CmdLen = 0x03;
 				break;
 			case 0x44: // ICS2115 write

--- a/vgmlpfnd.c
+++ b/vgmlpfnd.c
@@ -897,6 +897,8 @@ INLINE bool IgnoredCmd(const UINT8* VGMPnt)
 		return true;	// OKIM6258 ADPCM Data
 	if (Command == 0xB5 && RegData >= 0x01)
 		return true;	// MultiPCM "Set Slot"
+	if (Command == 0x32 && (((RegData >> 4) & 7) == 0x01))
+		return true;	// OKIM5205 ADPCM Data
 
 	/*if (Command == 0xBA)
 	{

--- a/vgmlpfnd.c
+++ b/vgmlpfnd.c
@@ -336,6 +336,9 @@ static void ReadVGMData(void)
 			case 0x42: // K005289 write
 				CmdLen = 0x03;
 				break;
+			case 0x44: // ICS2115 write
+				CmdLen = 0x03;
+				break;
 			default:
 				switch(Command & 0xF0)
 				{
@@ -566,6 +569,9 @@ static void ReadVGMData(void)
 				CmdLen = 0x03;
 				break;
 			case 0x42: // K005289 write
+				CmdLen = 0x03;
+				break;
+			case 0x44: // ICS2115 write
 				CmdLen = 0x03;
 				break;
 			default:


### PR DESCRIPTION
ICS2115: for chip_cmp, chip_srom, chip_strp, chiptext, vgm_cmp, vgm_cnt, vgm_ptch, vgm_sro, vgm_trml, vgm2txt, vgmlpfnd
Mikey: for chip_cmp, chip_strp, chiptext, vgm_cmp, vgm_cnt, vgm_ptch, vgm_trml, vgm2txt, vgmlpfnd
MSM5205: for chip_cmp, chip_strp, chiptext, vgm_cmp, vgm_cnt, vgm_ndlz, vgm_ptch, vgm_trml, vgm2txt, vgmlpfnd
MSM5232: for chip_cmp, chip_strp, chiptext, vgm_cmp, vgm_cnt, vgm_ptch, vgm_trml, vgm2txt, vgmlpfnd
BSMT2000: for chip_cmp, chip_srom, chip_strp, chiptext, vgm_cmp, vgm_cnt, vgm_ptch, vgm_sro, vgm_trml, vgm2txt